### PR TITLE
Port cicd namespace to Codex skills and trigger entrypoints

### DIFF
--- a/.codex/prompts/cicd/check.md
+++ b/.codex/prompts/cicd/check.md
@@ -1,0 +1,123 @@
+---
+description: Validate Makefile against CPP standards
+allowed-tools: Bash(python3:*), Bash(PYTHONPATH=*), Bash(ls:*), Bash(test:*), Bash(cat:*), Bash(grep:*), Read
+---
+
+> Trigger parity entrypoint for `/cicd:check`.
+> Backing skill: `cicd-check` (`.codex/skills/cicd-check/SKILL.md`).
+
+
+# /cicd:check - Makefile Validation
+
+Validate your project's Makefile against Codex Power Pack standards.
+
+---
+
+## Step 1: Locate CPP Source
+
+```bash
+CPP_DIR=""
+for dir in ~/Projects/codex-power-pack /opt/codex-power-pack ~/.codex-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/AGENTS.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+
+if [ -z "$CPP_DIR" ]; then
+  echo "ERROR: codex-power-pack not found"
+  exit 1
+fi
+```
+
+---
+
+## Step 2: Check for Makefile
+
+```bash
+if [ ! -f "Makefile" ]; then
+  echo "No Makefile found in $(pwd)"
+  echo ""
+  echo "Create one with:"
+  echo "  /cicd:init    - Auto-detect framework and generate"
+  echo "  cp $CPP_DIR/templates/Makefile.example Makefile  - Copy starter template"
+  exit 1
+fi
+```
+
+---
+
+## Step 3: Load Configuration
+
+If `.codex/cicd.yml` exists, it overrides default required/recommended targets:
+
+```bash
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd check
+```
+
+---
+
+## Step 4: Present Results
+
+The CLI outputs a markdown table. Present it to the user as-is.
+
+The report includes:
+- **Target table**: Each target's status (present, MISSING, missing) and notes
+- **.PHONY declarations**: How many targets have .PHONY declared
+- **Issues**: Any problems found (no Makefile, missing required targets, anti-patterns)
+- **Summary**: Overall health status and target coverage
+
+### Interpreting Results
+
+| Status | Meaning |
+|--------|---------|
+| `present` | Target exists in Makefile |
+| `MISSING` | Required target missing - `/flow` commands need this |
+| `missing` | Recommended target missing - nice to have |
+
+### Required Targets (used by /flow)
+
+| Target | Used By |
+|--------|---------|
+| `lint` | `/flow:finish` - runs before commit |
+| `test` | `/flow:finish` - runs before commit |
+
+### Recommended Targets
+
+| Target | Purpose |
+|--------|---------|
+| `format` | Code formatting |
+| `typecheck` | Type checking (mypy, tsc, etc.) |
+| `build` | Build artifacts |
+| `deploy` | Deployment (`/flow:deploy`) |
+| `clean` | Remove build artifacts |
+| `verify` | Pre-deploy gate (lint + test + typecheck) |
+| `troubleshoot` | Diagnostic pass (clean + lint + test) |
+
+---
+
+## Step 5: Suggest Fixes
+
+If there are missing required targets:
+
+```
+To fix missing targets, run:
+  /cicd:init    - Auto-detect and offer to append missing targets
+
+Or add them manually to your Makefile:
+
+  lint:
+  	{framework-appropriate lint command}
+
+  test:
+  	{framework-appropriate test command}
+```
+
+---
+
+## Notes
+
+- Required targets are what `/flow:finish` looks for
+- Recommended targets improve your workflow but aren't blocking
+- `.PHONY` declarations prevent conflicts with files named like targets
+- Run `/cicd:init` to auto-fix missing targets

--- a/.codex/prompts/cicd/container.md
+++ b/.codex/prompts/cicd/container.md
@@ -1,0 +1,73 @@
+---
+allowed-tools: Bash(python3:*), Bash(PYTHONPATH=*), Bash(cat:*), Bash(ls:*), Bash(test:*), Read, Write
+---
+
+> Trigger parity entrypoint for `/cicd:container`.
+> Backing skill: `cicd-container` (`.codex/skills/cicd-container/SKILL.md`).
+
+
+# CI/CD Container Generation
+
+Generate Dockerfile, docker-compose.yml, and .dockerignore for the current project.
+
+## Steps
+
+1. **Detect framework** using `lib/cicd`:
+
+```bash
+PYTHONPATH="$PWD/lib:$HOME/Projects/codex-power-pack/lib:$PYTHONPATH" python3 -m lib.cicd detect --quiet
+```
+
+2. **Generate container files** (dry run first):
+
+```bash
+PYTHONPATH="$PWD/lib:$HOME/Projects/codex-power-pack/lib:$PYTHONPATH" python3 -m lib.cicd container
+```
+
+3. **Review output** with the user. Show what will be generated.
+
+4. **Check for existing files** before writing:
+   - If `Dockerfile` exists, ask before overwriting
+   - If `docker-compose.yml` exists, ask before overwriting
+   - If `.dockerignore` exists, ask before overwriting
+
+5. **Write files** if approved:
+
+```bash
+PYTHONPATH="$PWD/lib:$HOME/Projects/codex-power-pack/lib:$PYTHONPATH" python3 -m lib.cicd container --write
+```
+
+6. **Report results**:
+
+```
+## Container Files Generated
+
+Framework: {framework} ({package_manager})
+
+Files created:
+  Dockerfile - Multi-stage build (builder -> runtime)
+  docker-compose.yml - (if compose_services configured)
+  .dockerignore - Standard patterns
+
+To build: docker build -t myapp .
+To run:    docker compose up -d
+```
+
+## Notes
+
+- Dockerfiles use multi-stage builds for smaller images
+- All containers run as non-root user
+- HEALTHCHECK instructions use endpoints from .codex/cicd.yml
+- Configure container settings in .codex/cicd.yml:
+  ```yaml
+  container:
+    enabled: true
+    base_image: auto        # auto-detected from framework
+    expose_ports: [8000]
+    compose_services:
+      - name: postgres
+        image: postgres:16-alpine
+        ports: ["5432:5432"]
+        environment:
+          POSTGRES_DB: app
+  ```

--- a/.codex/prompts/cicd/health.md
+++ b/.codex/prompts/cicd/health.md
@@ -1,0 +1,134 @@
+---
+description: Run health checks against configured endpoints and processes
+allowed-tools: Bash(python3:*), Bash(PYTHONPATH=*), Bash(curl:*), Bash(ss:*), Bash(lsof:*), Bash(ls:*), Bash(test:*), Bash(cat:*), Read
+---
+
+> Trigger parity entrypoint for `/cicd:health`.
+> Backing skill: `cicd-health` (`.codex/skills/cicd-health/SKILL.md`).
+
+
+# /cicd:health - Health Checks
+
+Run health checks against configured endpoints and processes.
+
+---
+
+## Step 1: Locate CPP Source
+
+```bash
+CPP_DIR=""
+for dir in ~/Projects/codex-power-pack /opt/codex-power-pack ~/.codex-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/AGENTS.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+
+if [ -z "$CPP_DIR" ]; then
+  echo "ERROR: codex-power-pack not found"
+  exit 1
+fi
+```
+
+---
+
+## Step 2: Check for Configuration
+
+```bash
+if [ ! -f ".codex/cicd.yml" ]; then
+  echo "No .codex/cicd.yml found in $(pwd)"
+  echo ""
+  echo "Create one with:"
+  echo "  /cicd:init    - Auto-detect framework and generate"
+  echo ""
+  echo "Or add health checks manually to .codex/cicd.yml:"
+  echo ""
+  echo "  health:"
+  echo "    endpoints:"
+  echo "      - url: http://localhost:8000/health"
+  echo "        name: API Server"
+  echo "    processes:"
+  echo "      - name: uvicorn"
+  echo "        port: 8000"
+  exit 1
+fi
+```
+
+If `.codex/cicd.yml` exists but has no `health:` section, the CLI will report "no checks configured" and show configuration guidance. This is handled gracefully - no error.
+
+---
+
+## Step 3: Run Health Checks
+
+```bash
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd health
+```
+
+---
+
+## Step 4: Present Results
+
+The CLI outputs a markdown table. Present it to the user as-is.
+
+The report includes:
+- **Check table**: Each check's name, type, status (PASS/FAIL), detail, and response time
+- **Summary**: Overall pass/fail count
+
+### Interpreting Results
+
+| Status | Meaning |
+|--------|---------|
+| `PASS` | Check succeeded - endpoint reachable or process running |
+| `FAIL` | Check failed - endpoint unreachable, wrong status, or process not found |
+
+### Check Types
+
+| Type | What It Checks |
+|------|---------------|
+| `endpoint` | HTTP request to URL - checks status code and optional response body |
+| `process` | Port listening - uses `ss` or `lsof` to verify process is bound to port |
+
+### No Checks Configured
+
+If the CLI reports "no checks configured", guide the user:
+
+```
+No health checks configured.
+
+Add checks to .codex/cicd.yml:
+
+  health:
+    endpoints:
+      - url: http://localhost:8000/health
+        name: API Server
+        expected_status: 200
+        timeout: 5
+    processes:
+      - name: uvicorn
+        port: 8000
+
+Then re-run: /cicd:health
+```
+
+---
+
+## Step 5: Interactive Fallback (No Config)
+
+If no `.codex/cicd.yml` exists, ask the user what to check:
+
+1. Use AskUserQuestion: "What endpoints should I check? (e.g., http://localhost:8000/health)"
+2. If the user provides URLs, run `curl -sf -o /dev/null -w "%{http_code}" <URL>` for each
+3. Report results in the same table format
+4. Offer to save the configuration to `.codex/cicd.yml`
+
+---
+
+## Notes
+
+- Health checks are designed for local development verification
+- Endpoint checks use `curl` with configurable timeouts (default 5s)
+- Process checks use `ss -tlnp` (preferred) or `lsof -i` as fallback
+- All checks run sequentially with timing for each
+- Use `--json` flag for machine-readable output
+- Use `--summary` flag for one-line pass/fail (useful in scripts)
+- Configure checks in `.codex/cicd.yml` under the `health:` section

--- a/.codex/prompts/cicd/help.md
+++ b/.codex/prompts/cicd/help.md
@@ -1,0 +1,162 @@
+> Trigger parity entrypoint for `/cicd:help`.
+> Backing skill: `cicd-help` (`.codex/skills/cicd-help/SKILL.md`).
+
+# CI/CD Commands
+
+Build, verify, and deploy automation for Codex projects.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/cicd:init` | Detect framework, generate Makefile and cicd.yml |
+| `/cicd:check` | Validate Makefile against CPP standards |
+| `/cicd:health` | Run health checks (endpoints + processes) |
+| `/cicd:smoke` | Run smoke tests from cicd.yml |
+| `/cicd:pipeline` | Generate GitHub Actions CI/CD workflows |
+| `/cicd:container` | Generate Dockerfile and docker-compose.yml |
+| `/cicd:infra-init` | Scaffold IaC directory with tiered structure (foundation/platform/app) |
+| `/cicd:infra-discover` | Generate cloud resource discovery script for IaC import |
+| `/cicd:infra-pipeline` | Generate CI/CD pipelines for infrastructure tiers with approval gates |
+| `/cicd:help` | This help page |
+
+## How It Works
+
+```
+/cicd:init      →  Detect framework  →  Generate Makefile  →  Generate .codex/cicd.yml
+                                              ↓
+/cicd:check     →  Validate targets  →  Report gaps  →  Suggest fixes
+                                              ↓
+/flow:finish    → make lint + make test       (quality gates)
+/flow:deploy    → make deploy                 (deployment)
+                                              ↓
+/cicd:health    →  Check endpoints  →  Check processes  →  Report status
+/cicd:smoke     →  Run smoke tests  →  Check results    →  Report pass/fail
+                                              ↓
+/cicd:pipeline  →  Read Makefile targets  →  Generate .github/workflows/ci.yml
+/cicd:container →  Detect framework       →  Generate Dockerfile + docker-compose.yml
+```
+
+## Supported Frameworks
+
+| Framework | Package Managers | Template |
+|-----------|-----------------|----------|
+| Python | uv, pip | `python-uv.mk`, `python-pip.mk` |
+| Node.js | npm, yarn | `node-npm.mk`, `node-yarn.mk` |
+| Go | go | `go.mk` |
+| Rust | cargo | `rust.mk` |
+| Multi-language | any | `multi.mk` |
+
+## Standard Makefile Targets
+
+| Target | Required | Used By |
+|--------|----------|---------|
+| `lint` | Yes | `/flow:finish` |
+| `test` | Yes | `/flow:finish` |
+| `format` | No | Manual / IDE |
+| `typecheck` | No | `/cicd:check` reports |
+| `build` | No | Build artifacts |
+| `deploy` | No | `/flow:deploy` |
+| `clean` | No | Cleanup |
+| `verify` | No | Pre-deploy gate (lint + test + typecheck) |
+| `troubleshoot` | No | Diagnostic pass (clean + lint + test) |
+
+## Configuration
+
+Optional `.codex/cicd.yml` overrides detection defaults:
+
+```yaml
+build:
+  required_targets: [lint, test]
+  recommended_targets: [format, typecheck, build, deploy, clean, verify]
+deploy:
+  default_target: deploy
+  targets:
+    deploy:
+      description: "Deploy to production"
+      requires_confirmation: true
+```
+
+### Health & Smoke Configuration
+
+```yaml
+health:
+  endpoints:
+    - url: http://localhost:8000/health
+      name: API Server
+      expected_status: 200
+      timeout: 5
+  processes:
+    - name: uvicorn
+      port: 8000
+  smoke_tests:
+    - name: API responds
+      command: "curl -sf http://localhost:8000/health"
+      expected_exit: 0
+    - name: CLI version
+      command: "python -m myapp --version"
+      expected_output: "v\\d+\\.\\d+"
+```
+
+See `templates/cicd.yml.example` for full documentation.
+
+## Quick Start
+
+```bash
+# Detect framework and generate Makefile
+/cicd:init
+
+# Validate your Makefile
+/cicd:check
+
+# Run health checks (after services are running)
+/cicd:health
+
+# Run smoke tests
+/cicd:smoke
+
+# Use with /flow
+/flow:finish    # Runs make lint + make test
+/flow:deploy    # Runs make deploy
+```
+
+## Infrastructure as Code
+
+Three-tier IaC model with separate pipelines and approval gates:
+
+```
+/cicd:infra-init      →  Scaffold infra/ directory  →  foundation/ + platform/ + app/
+                                    ↓
+/cicd:infra-discover  →  Audit cloud resources  →  Generate terraform import commands
+                                    ↓
+/cicd:infra-pipeline  →  Generate per-tier workflows  →  Approval gates for foundation
+```
+
+Supported IaC providers: Terraform (default), Pulumi, Bicep
+Supported clouds: AWS, Azure, GCP
+
+Configuration in `.codex/cicd.yml`:
+
+```yaml
+infrastructure:
+  provider: terraform
+  cloud: aws
+  state_backend:
+    type: s3
+    bucket: my-tf-state
+    lock: true
+  tiers:
+    foundation:
+      approval_required: true
+    platform:
+      approval_required: false
+    app:
+      approval_required: false
+```
+
+## Related
+
+- `/claude-md:lint` - Audit AGENTS.md for CI/CD and troubleshooting directives
+- `/flow:doctor` - Reports Makefile target availability
+- `/flow:deploy` - Runs deploy target
+- `/self-improvement:deployment` - Analyze deploy failures and improve Makefile

--- a/.codex/prompts/cicd/infra-discover.md
+++ b/.codex/prompts/cicd/infra-discover.md
@@ -1,0 +1,45 @@
+---
+description: Generate cloud resource discovery script for IaC import
+allowed-tools: Bash(PYTHONPATH=*), Bash(python3:*), Bash(bash:*), Bash(ls:*), Read, AskUserQuestion
+---
+
+> Trigger parity entrypoint for `/cicd:infra-discover`.
+> Backing skill: `cicd-infra-discover` (`.codex/skills/cicd-infra-discover/SKILL.md`).
+
+
+# /cicd:infra-discover - Cloud Resource Discovery
+
+Generate a discovery script that audits existing cloud resources and outputs them in a format suitable for IaC import (`terraform import`, etc.).
+
+## Instructions
+
+1. **Detect cloud provider** from `.codex/cicd.yml` or ask the user (aws/azure/gcp).
+
+2. **Generate the discovery script:**
+
+```bash
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd infra-discover --path "$(pwd)" --cloud aws --write
+```
+
+3. **Optionally run the script** if the user has CLI tools configured:
+
+```bash
+bash infra/scripts/discover-aws.sh
+```
+
+4. **Report findings** and suggest which resources to import first (most critical/fragile).
+
+## When to Use
+
+- Starting IaC from scratch ("no documentation exists yet")
+- Auditing what exists before codifying it
+- Building a manifest for `terraform import`
+
+## Key Principle
+
+Even if you only plan to run infrastructure changes once, codify them. The value is having an executable runbook, not a stale wiki page.
+
+## Related
+
+- `/cicd:infra-init` - Scaffold IaC directory structure
+- `/cicd:infra-pipeline` - Generate CI/CD pipelines with approval gates

--- a/.codex/prompts/cicd/infra-init.md
+++ b/.codex/prompts/cicd/infra-init.md
@@ -1,0 +1,73 @@
+---
+description: Scaffold IaC directory with tiered structure (foundation/platform/app)
+allowed-tools: Bash(PYTHONPATH=*), Bash(python3:*), Bash(ls:*), Bash(cat:*), Read, AskUserQuestion
+---
+
+> Trigger parity entrypoint for `/cicd:infra-init`.
+> Backing skill: `cicd-infra-init` (`.codex/skills/cicd-infra-init/SKILL.md`).
+
+
+# /cicd:infra-init - Scaffold Infrastructure as Code
+
+Generate a tiered IaC directory structure for your project.
+
+## Instructions
+
+1. **Check for existing IaC** by running detection:
+
+```bash
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd infra-init --path "$(pwd)" --json
+```
+
+2. **If no `.codex/cicd.yml` exists**, ask the user for:
+   - IaC provider: terraform (default), pulumi, or bicep
+   - Cloud provider: aws (default), azure, or gcp
+   - Remote state backend type (s3, azure-storage, gcs)
+   - Tagging conventions (managed-by, repo, owner)
+
+3. **If `.codex/cicd.yml` exists** with an `infrastructure` section, use those settings.
+
+4. **Generate the scaffold:**
+
+```bash
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd infra-init --path "$(pwd)" --write
+```
+
+5. **Report what was created** and suggest next steps.
+
+## Three-Tier Model
+
+- **foundation/** - Run once, touch rarely. DNS zones, resource groups, networking, identity. Manual approval gates.
+- **platform/** - Shared services. Container registries, key vaults, shared databases. Less frequent deploys.
+- **app/** - Application-specific infrastructure. Deployed with application CI/CD.
+
+## Configuration
+
+Add to `.codex/cicd.yml`:
+
+```yaml
+infrastructure:
+  provider: terraform
+  cloud: aws
+  state_backend:
+    type: s3
+    bucket: my-tf-state
+    lock: true
+  tagging:
+    managed-by: terraform
+    repo: my-project
+    owner: platform-team
+  tiers:
+    foundation:
+      approval_required: true
+      separate_credentials: true
+    platform:
+      approval_required: false
+    app:
+      approval_required: false
+```
+
+## Related
+
+- `/cicd:infra-discover` - Audit existing cloud resources
+- `/cicd:infra-pipeline` - Generate CI/CD pipelines with approval gates

--- a/.codex/prompts/cicd/infra-pipeline.md
+++ b/.codex/prompts/cicd/infra-pipeline.md
@@ -1,0 +1,48 @@
+---
+description: Generate CI/CD pipelines for infrastructure tiers with approval gates
+allowed-tools: Bash(PYTHONPATH=*), Bash(python3:*), Bash(ls:*), Read, AskUserQuestion
+---
+
+> Trigger parity entrypoint for `/cicd:infra-pipeline`.
+> Backing skill: `cicd-infra-pipeline` (`.codex/skills/cicd-infra-pipeline/SKILL.md`).
+
+
+# /cicd:infra-pipeline - Infrastructure CI/CD Pipelines
+
+Generate separate CI/CD pipelines for each infrastructure tier with appropriate approval gates.
+
+## Instructions
+
+1. **Read configuration** from `.codex/cicd.yml` infrastructure section.
+
+2. **Generate pipelines:**
+
+```bash
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd infra-pipeline --path "$(pwd)" --write
+```
+
+3. **Report what was generated** and explain the approval model:
+   - Foundation: requires environment approval in GitHub (or manual in Woodpecker)
+   - Platform: auto-deploy on merge (configurable)
+   - App: auto-deploy on merge
+
+## Pipeline Model
+
+Each tier gets its own workflow file, triggered only by changes to that tier's directory:
+
+- `.github/workflows/infra-foundation.yml` - Manual approval required
+- `.github/workflows/infra-platform.yml` - Auto-deploy (configurable)
+- `.github/workflows/infra-app.yml` - Auto-deploy
+
+### Approval Gates
+
+Foundation tier uses GitHub Environments with required reviewers. Set up:
+1. Go to repo Settings > Environments
+2. Create `infra-foundation` environment
+3. Add required reviewers
+
+## Related
+
+- `/cicd:infra-init` - Scaffold IaC directory structure
+- `/cicd:infra-discover` - Audit existing cloud resources
+- `/cicd:pipeline` - Application-layer pipeline generation

--- a/.codex/prompts/cicd/init.md
+++ b/.codex/prompts/cicd/init.md
@@ -1,0 +1,142 @@
+---
+description: Detect framework and generate/validate Makefile for CI/CD integration
+allowed-tools: Bash(python3:*), Bash(PYTHONPATH=*), Bash(ls:*), Bash(test:*), Bash(cat:*), Bash(grep:*), Bash(cp:*), Read, Write
+---
+
+> Trigger parity entrypoint for `/cicd:init`.
+> Backing skill: `cicd-init` (`.codex/skills/cicd-init/SKILL.md`).
+
+
+# /cicd:init - Framework Detection & Makefile Setup
+
+Detect your project's framework and package manager, then generate or validate a Makefile for CPP `/flow` integration.
+
+---
+
+## Step 1: Locate CPP Source
+
+```bash
+CPP_DIR=""
+for dir in ~/Projects/codex-power-pack /opt/codex-power-pack ~/.codex-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/AGENTS.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+
+if [ -z "$CPP_DIR" ]; then
+  echo "ERROR: codex-power-pack not found"
+  exit 1
+fi
+echo "CPP source: $CPP_DIR"
+```
+
+---
+
+## Step 2: Detect Framework
+
+Run the framework detector:
+
+```bash
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd detect
+```
+
+Report the detection results to the user:
+- Framework detected (Python, Node, Go, Rust, Multi, Unknown)
+- Package manager detected (uv, pip, npm, yarn, cargo, go, etc.)
+- Detected indicator files
+- Recommended Makefile targets for this stack
+
+If framework is "Unknown", ask the user which framework to use via AskUserQuestion with options matching the available templates.
+
+---
+
+## Step 3: Check Existing Makefile
+
+```bash
+if [ -f "Makefile" ]; then
+  echo "Existing Makefile found - running validation..."
+  PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd check
+else
+  echo "No Makefile found - will generate one."
+fi
+```
+
+### If Makefile exists:
+1. Run `python3 -m lib.cicd check` to validate against CPP standards
+2. Report the validation results (target coverage, missing targets, issues)
+3. If targets are missing, offer to append them:
+   - Show what targets would be added
+   - Ask user to confirm via AskUserQuestion
+   - If confirmed, read the current Makefile, append missing target stubs, write back
+
+### If no Makefile:
+1. Select the correct template based on detected framework + package manager:
+
+   | Detection | Template |
+   |-----------|----------|
+   | Python + uv | `templates/makefiles/python-uv.mk` |
+   | Python + pip | `templates/makefiles/python-pip.mk` |
+   | Node + npm | `templates/makefiles/node-npm.mk` |
+   | Node + yarn | `templates/makefiles/node-yarn.mk` |
+   | Go | `templates/makefiles/go.mk` |
+   | Rust | `templates/makefiles/rust.mk` |
+   | Multi / Unknown | `templates/makefiles/multi.mk` |
+
+2. Copy the template to the project root:
+   ```bash
+   cp "$CPP_DIR/templates/makefiles/{template}.mk" Makefile
+   ```
+
+3. Report what was generated and suggest customization.
+
+---
+
+## Step 4: Generate cicd.yml (if not exists)
+
+If `.codex/cicd.yml` does not exist, generate it from detected defaults:
+
+```bash
+if [ ! -f ".codex/cicd.yml" ]; then
+  # Get detection result as JSON
+  DETECT_JSON=$(PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd detect --json)
+fi
+```
+
+Generate `.codex/cicd.yml` with:
+- Detected framework and package manager (commented out - auto-detection is preferred)
+- Build section with required and recommended targets
+- Deploy section with placeholder target metadata
+
+Use the `templates/cicd.yml.example` as reference but generate a minimal version with only the relevant sections for the detected framework.
+
+If `.codex/cicd.yml` already exists, skip this step and report "cicd.yml already configured".
+
+---
+
+## Step 5: Report Results
+
+```
+=== CI/CD Init Complete ===
+
+Framework:       {detected}
+Package Manager: {detected}
+
+Makefile:        {Generated from template | Validated (N/M targets)}
+Config:          {.codex/cicd.yml generated | Already exists}
+
+Next Steps:
+  1. Review and customize your Makefile targets
+  2. Run /cicd:check to validate
+  3. /flow:finish will now use `make lint` and `make test`
+  4. /flow:deploy will use `make deploy`
+```
+
+---
+
+## Notes
+
+- This command is idempotent - safe to run multiple times
+- Existing files are never overwritten without user confirmation
+- Templates are copied, not symlinked (so you can customize freely)
+- Run `/cicd:check` anytime to re-validate your Makefile

--- a/.codex/prompts/cicd/pipeline.md
+++ b/.codex/prompts/cicd/pipeline.md
@@ -1,0 +1,86 @@
+---
+description: Generate GitHub Actions CI/CD workflows
+allowed-tools: Bash(python3:*), Bash(PYTHONPATH=*), Bash(cat:*), Bash(ls:*), Bash(test:*), Bash(mkdir:*), Read, Write
+---
+
+> Trigger parity entrypoint for `/cicd:pipeline`.
+> Backing skill: `cicd-pipeline` (`.codex/skills/cicd-pipeline/SKILL.md`).
+
+
+# CI/CD Pipeline Generation
+
+Generate GitHub Actions CI/CD workflows from your Makefile targets.
+
+## Steps
+
+1. **Check for task manifest** - if `.codex/cicd_tasks.yml` exists, use it to inform pipeline generation:
+
+```bash
+if [ -f ".codex/cicd_tasks.yml" ]; then
+    echo "Found cicd_tasks.yml manifest - pipeline will use manifest-defined steps"
+    # The manifest defines plan steps (lint, test, deploy, etc.) with exact commands.
+    # Pipeline generation should use these commands instead of defaults.
+fi
+```
+
+When a manifest is present, the generated pipeline YAML should:
+- Use the exact commands from the manifest's step definitions
+- Include timeout values from the manifest
+- Respect skip_if conditions as conditional steps
+- Fall back to `make <target>` for steps not in the manifest
+
+2. **Detect framework** using `lib/cicd`:
+
+```bash
+PYTHONPATH="$PWD/lib:$HOME/Projects/codex-power-pack/lib:$PYTHONPATH" python3 -m lib.cicd detect --quiet
+```
+
+3. **Generate pipeline** (dry run first):
+
+```bash
+PYTHONPATH="$PWD/lib:$HOME/Projects/codex-power-pack/lib:$PYTHONPATH" python3 -m lib.cicd pipeline
+```
+
+4. **Review output** with the user. Show the generated workflow YAML.
+
+5. **Check for existing files** before writing:
+   - If `.github/workflows/ci.yml` exists, ask before overwriting
+
+6. **Write files** if approved:
+
+```bash
+PYTHONPATH="$PWD/lib:$HOME/Projects/codex-power-pack/lib:$PYTHONPATH" python3 -m lib.cicd pipeline --write
+```
+
+7. **Report results**:
+
+```
+## CI Pipeline Generated
+
+Framework: {framework} ({package_manager})
+
+Files created:
+  .github/workflows/ci.yml - CI pipeline with lint, test, build
+
+Triggers: push to main, pull requests
+Targets:  make lint, make test, make typecheck (if available)
+
+To view: cat .github/workflows/ci.yml
+```
+
+## Notes
+
+- Workflows use `make <target>` as steps (not direct tool commands)
+- This keeps CI in sync with local development commands
+- Caching is included for package managers (uv, npm, cargo, go)
+- Matrix builds are configured from `.codex/cicd.yml` if present
+- Configure pipeline settings in `.codex/cicd.yml`:
+  ```yaml
+  pipeline:
+    provider: github-actions
+    branches:
+      main: [lint, test, typecheck, build, deploy]
+      pr: [lint, test, typecheck]
+    matrix:
+      python: ["3.11", "3.12"]
+  ```

--- a/.codex/prompts/cicd/smoke.md
+++ b/.codex/prompts/cicd/smoke.md
@@ -1,0 +1,157 @@
+---
+description: Run smoke tests from cicd.yml configuration
+allowed-tools: Bash(python3:*), Bash(PYTHONPATH=*), Bash(curl:*), Bash(ls:*), Bash(test:*), Bash(cat:*), Read
+---
+
+> Trigger parity entrypoint for `/cicd:smoke`.
+> Backing skill: `cicd-smoke` (`.codex/skills/cicd-smoke/SKILL.md`).
+
+
+# /cicd:smoke - Smoke Tests
+
+Run smoke tests from `.codex/cicd.yml` configuration.
+
+---
+
+## Step 1: Locate CPP Source
+
+```bash
+CPP_DIR=""
+for dir in ~/Projects/codex-power-pack /opt/codex-power-pack ~/.codex-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/AGENTS.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+
+if [ -z "$CPP_DIR" ]; then
+  echo "ERROR: codex-power-pack not found"
+  exit 1
+fi
+```
+
+---
+
+## Step 2: Check for Configuration
+
+```bash
+if [ ! -f ".codex/cicd.yml" ]; then
+  echo "No .codex/cicd.yml found in $(pwd)"
+  echo ""
+  echo "Create one with:"
+  echo "  /cicd:init    - Auto-detect framework and generate"
+  echo ""
+  echo "Or add smoke tests manually to .codex/cicd.yml:"
+  echo ""
+  echo "  health:"
+  echo "    smoke_tests:"
+  echo "      - name: API responds"
+  echo "        command: \"curl -sf http://localhost:8000/health\""
+  echo "        expected_exit: 0"
+  echo "      - name: CLI version"
+  echo "        command: \"python -m myapp --version\""
+  echo "        expected_output: \"v\\\\d+\\\\.\\\\d+\""
+  exit 1
+fi
+```
+
+If `.codex/cicd.yml` exists but has no `smoke_tests:` section, the CLI will report "no tests configured" and show configuration guidance.
+
+---
+
+## Step 3: Run Smoke Tests
+
+```bash
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd smoke
+```
+
+---
+
+## Step 4: Present Results
+
+The CLI outputs a markdown table. Present it to the user as-is.
+
+The report includes:
+- **Test table**: Each test's name, status (PASS/FAIL), detail, and execution time
+- **Summary**: Overall pass/fail count
+
+### Interpreting Results
+
+| Status | Meaning |
+|--------|---------|
+| `PASS` | Command exited with expected code and output matched (if configured) |
+| `FAIL` | Command failed - wrong exit code, output mismatch, or timeout |
+
+### Test Configuration
+
+Each smoke test in `.codex/cicd.yml` supports:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Human-readable test name |
+| `command` | Yes | Shell command to execute |
+| `expected_exit` | No | Expected exit code (default: 0) |
+| `expected_output` | No | Regex pattern to match in stdout |
+| `timeout` | No | Timeout in seconds (default: 30) |
+
+### No Tests Configured
+
+If the CLI reports "no tests configured", guide the user:
+
+```
+No smoke tests configured.
+
+Add tests to .codex/cicd.yml:
+
+  health:
+    smoke_tests:
+      - name: API responds
+        command: "curl -sf http://localhost:8000/health"
+        expected_exit: 0
+      - name: CLI version
+        command: "python -m myapp --version"
+        expected_output: "v\\d+\\.\\d+"
+      - name: Database connection
+        command: "python -c 'import myapp.db; myapp.db.ping()'"
+        expected_exit: 0
+        timeout: 10
+
+Then re-run: /cicd:smoke
+```
+
+---
+
+## Step 5: Handle Failures
+
+When smoke tests fail, provide remediation guidance:
+
+1. **Exit code mismatch**: Show actual vs expected exit code and stderr output
+2. **Output mismatch**: Show the expected pattern and actual output
+3. **Timeout**: Suggest increasing timeout or checking if the service is running
+4. **Command not found**: Suggest installing the dependency or activating the venv
+
+Example failure guidance:
+
+```
+Test "API responds" FAILED:
+  Command: curl -sf http://localhost:8000/health
+  Expected exit: 0, Got: 7
+  Detail: Connection refused
+
+  Fix: Ensure the API server is running:
+    make run    (if available)
+    uvicorn myapp:app --host 0.0.0.0 --port 8000
+```
+
+---
+
+## Notes
+
+- Smoke tests verify that a deployed/running system works end-to-end
+- Run after `make deploy` or service startup to validate
+- Commands run in the project root directory
+- Each test is independent - failures don't stop subsequent tests
+- Use `--json` flag for machine-readable output
+- Use `--summary` flag for one-line pass/fail (useful in scripts)
+- Configure tests in `.codex/cicd.yml` under `health.smoke_tests`
+- Pair with `/cicd:health` for comprehensive verification

--- a/.codex/skills/cicd-check/SKILL.md
+++ b/.codex/skills/cicd-check/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: cicd-check
+description: Trigger `/cicd:check`. Validate Makefile against CPP standards
+---
+
+# cicd-check
+
+## Trigger
+- Primary: `/cicd:check`
+- Text alias: `cicd:check`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/cicd/check.md`
+
+## Execution
+1. Use this skill when the user invokes `/cicd:check` or explicitly asks for the `check` CI/CD workflow.
+2. Follow the workflow steps in `.codex/prompts/cicd/check.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/cicd-check/agents/openai.yaml
+++ b/.codex/skills/cicd-check/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cicd:check"
+  short_description: "Trigger /cicd:check"
+  default_prompt: "/cicd:check"

--- a/.codex/skills/cicd-container/SKILL.md
+++ b/.codex/skills/cicd-container/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: cicd-container
+description: Trigger `/cicd:container`. Run the /cicd:container workflow for Codex Power Pack CI/CD automation.
+---
+
+# cicd-container
+
+## Trigger
+- Primary: `/cicd:container`
+- Text alias: `cicd:container`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/cicd/container.md`
+
+## Execution
+1. Use this skill when the user invokes `/cicd:container` or explicitly asks for the `container` CI/CD workflow.
+2. Follow the workflow steps in `.codex/prompts/cicd/container.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/cicd-container/agents/openai.yaml
+++ b/.codex/skills/cicd-container/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cicd:container"
+  short_description: "Trigger /cicd:container"
+  default_prompt: "/cicd:container"

--- a/.codex/skills/cicd-health/SKILL.md
+++ b/.codex/skills/cicd-health/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: cicd-health
+description: Trigger `/cicd:health`. Run health checks against configured endpoints and processes
+---
+
+# cicd-health
+
+## Trigger
+- Primary: `/cicd:health`
+- Text alias: `cicd:health`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/cicd/health.md`
+
+## Execution
+1. Use this skill when the user invokes `/cicd:health` or explicitly asks for the `health` CI/CD workflow.
+2. Follow the workflow steps in `.codex/prompts/cicd/health.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/cicd-health/agents/openai.yaml
+++ b/.codex/skills/cicd-health/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cicd:health"
+  short_description: "Trigger /cicd:health"
+  default_prompt: "/cicd:health"

--- a/.codex/skills/cicd-help/SKILL.md
+++ b/.codex/skills/cicd-help/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: cicd-help
+description: Trigger `/cicd:help`. Run the /cicd:help workflow for Codex Power Pack CI/CD automation.
+---
+
+# cicd-help
+
+## Trigger
+- Primary: `/cicd:help`
+- Text alias: `cicd:help`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/cicd/help.md`
+
+## Execution
+1. Use this skill when the user invokes `/cicd:help` or explicitly asks for the `help` CI/CD workflow.
+2. Follow the workflow steps in `.codex/prompts/cicd/help.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/cicd-help/agents/openai.yaml
+++ b/.codex/skills/cicd-help/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cicd:help"
+  short_description: "Trigger /cicd:help"
+  default_prompt: "/cicd:help"

--- a/.codex/skills/cicd-infra-discover/SKILL.md
+++ b/.codex/skills/cicd-infra-discover/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: cicd-infra-discover
+description: Trigger `/cicd:infra-discover`. Generate cloud resource discovery script for IaC import
+---
+
+# cicd-infra-discover
+
+## Trigger
+- Primary: `/cicd:infra-discover`
+- Text alias: `cicd:infra-discover`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/cicd/infra-discover.md`
+
+## Execution
+1. Use this skill when the user invokes `/cicd:infra-discover` or explicitly asks for the `infra-discover` CI/CD workflow.
+2. Follow the workflow steps in `.codex/prompts/cicd/infra-discover.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/cicd-infra-discover/agents/openai.yaml
+++ b/.codex/skills/cicd-infra-discover/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cicd:infra-discover"
+  short_description: "Trigger /cicd:infra-discover"
+  default_prompt: "/cicd:infra-discover"

--- a/.codex/skills/cicd-infra-init/SKILL.md
+++ b/.codex/skills/cicd-infra-init/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: cicd-infra-init
+description: Trigger `/cicd:infra-init`. Scaffold IaC directory with tiered structure (foundation/platform/app)
+---
+
+# cicd-infra-init
+
+## Trigger
+- Primary: `/cicd:infra-init`
+- Text alias: `cicd:infra-init`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/cicd/infra-init.md`
+
+## Execution
+1. Use this skill when the user invokes `/cicd:infra-init` or explicitly asks for the `infra-init` CI/CD workflow.
+2. Follow the workflow steps in `.codex/prompts/cicd/infra-init.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/cicd-infra-init/agents/openai.yaml
+++ b/.codex/skills/cicd-infra-init/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cicd:infra-init"
+  short_description: "Trigger /cicd:infra-init"
+  default_prompt: "/cicd:infra-init"

--- a/.codex/skills/cicd-infra-pipeline/SKILL.md
+++ b/.codex/skills/cicd-infra-pipeline/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: cicd-infra-pipeline
+description: Trigger `/cicd:infra-pipeline`. Generate CI/CD pipelines for infrastructure tiers with approval gates
+---
+
+# cicd-infra-pipeline
+
+## Trigger
+- Primary: `/cicd:infra-pipeline`
+- Text alias: `cicd:infra-pipeline`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/cicd/infra-pipeline.md`
+
+## Execution
+1. Use this skill when the user invokes `/cicd:infra-pipeline` or explicitly asks for the `infra-pipeline` CI/CD workflow.
+2. Follow the workflow steps in `.codex/prompts/cicd/infra-pipeline.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/cicd-infra-pipeline/agents/openai.yaml
+++ b/.codex/skills/cicd-infra-pipeline/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cicd:infra-pipeline"
+  short_description: "Trigger /cicd:infra-pipeline"
+  default_prompt: "/cicd:infra-pipeline"

--- a/.codex/skills/cicd-init/SKILL.md
+++ b/.codex/skills/cicd-init/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: cicd-init
+description: Trigger `/cicd:init`. Detect framework and generate/validate Makefile for CI/CD integration
+---
+
+# cicd-init
+
+## Trigger
+- Primary: `/cicd:init`
+- Text alias: `cicd:init`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/cicd/init.md`
+
+## Execution
+1. Use this skill when the user invokes `/cicd:init` or explicitly asks for the `init` CI/CD workflow.
+2. Follow the workflow steps in `.codex/prompts/cicd/init.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/cicd-init/agents/openai.yaml
+++ b/.codex/skills/cicd-init/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cicd:init"
+  short_description: "Trigger /cicd:init"
+  default_prompt: "/cicd:init"

--- a/.codex/skills/cicd-pipeline/SKILL.md
+++ b/.codex/skills/cicd-pipeline/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: cicd-pipeline
+description: Trigger `/cicd:pipeline`. Generate GitHub Actions CI/CD workflows
+---
+
+# cicd-pipeline
+
+## Trigger
+- Primary: `/cicd:pipeline`
+- Text alias: `cicd:pipeline`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/cicd/pipeline.md`
+
+## Execution
+1. Use this skill when the user invokes `/cicd:pipeline` or explicitly asks for the `pipeline` CI/CD workflow.
+2. Follow the workflow steps in `.codex/prompts/cicd/pipeline.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/cicd-pipeline/agents/openai.yaml
+++ b/.codex/skills/cicd-pipeline/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cicd:pipeline"
+  short_description: "Trigger /cicd:pipeline"
+  default_prompt: "/cicd:pipeline"

--- a/.codex/skills/cicd-smoke/SKILL.md
+++ b/.codex/skills/cicd-smoke/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: cicd-smoke
+description: Trigger `/cicd:smoke`. Run smoke tests from cicd.yml configuration
+---
+
+# cicd-smoke
+
+## Trigger
+- Primary: `/cicd:smoke`
+- Text alias: `cicd:smoke`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/cicd/smoke.md`
+
+## Execution
+1. Use this skill when the user invokes `/cicd:smoke` or explicitly asks for the `smoke` CI/CD workflow.
+2. Follow the workflow steps in `.codex/prompts/cicd/smoke.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/cicd-smoke/agents/openai.yaml
+++ b/.codex/skills/cicd-smoke/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "cicd:smoke"
+  short_description: "Trigger /cicd:smoke"
+  default_prompt: "/cicd:smoke"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 - Never print secrets, tokens, passwords, connection strings, or raw `.env` contents.
 - Use `make` targets as the canonical interface for lint, test, verify, deploy, and Docker operations.
-- Prefer `.codex/` assets over legacy `.claude/` assets.
+- Use `.codex/` assets as the canonical workflow surface.
 - Read topic-specific docs from `docs/skills/` only when they are relevant.
 - After code changes, run `make verify` unless the environment blocks it.
 
@@ -12,6 +12,7 @@
 
 - `AGENTS.md` - canonical Codex instructions
 - `.codex/prompts/` - Codex prompt entrypoints ported from the source repo
+- `.codex/skills/` - Codex skill packages backing slash-style command workflows
 - `.codex/cicd.yml` - CI/CD config
 - `.codex/cicd_tasks.yml` - deterministic CI/CD task manifest
 - `mcp-second-opinion/` - external review server
@@ -33,5 +34,4 @@
 
 ## Notes
 
-- `CLAUDE.md` is retained only as a migrated source artifact.
-- If both `.codex/` and `.claude/` variants exist, treat `.codex/` as authoritative.
+- CI/CD slash trigger parity is mapped in `docs/skills/cicd-command-skill-map.md`.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Codex Power Pack
 
-Codex Power Pack is a Codex-oriented port of `cooneycw/claude-power-pack`.
+Codex Power Pack is a Codex-first automation toolkit.
 It preserves the reusable MCP servers, CI/CD helpers, security tooling, secrets
-management, templates, and tests, while switching the agent-facing surface from
-Claude conventions to Codex conventions.
+management, templates, and tests for Codex-centric workflows.
 
 ## What Is Included
 
 - `.codex/prompts/` - Codex prompt files ported from the original slash-command set
+- `.codex/skills/` - Codex skill packages that back slash-style trigger workflows
 - `.codex/cicd.yml` and `.codex/cicd_tasks.yml` - Codex-local CI/CD manifests
 - `AGENTS.md` - the canonical repo instructions for Codex
 - `mcp-second-opinion/` - external LLM code review server
@@ -38,19 +38,21 @@ Add the browser profile for Playwright:
 make docker-up PROFILE="core browser"
 ```
 
-## Codex Adaptation
-
-The port makes these opinionated changes:
+## Codex Architecture
 
 - Codex instructions live in `AGENTS.md`
-- Codex prompt files live in `.codex/prompts/`
-- runtime config now targets `.codex/` paths
-- secrets storage uses `~/.config/codex-power-pack/`
-- package and repo naming use `codex-power-pack`
+- Prompt entrypoints live in `.codex/prompts/`
+- Skill packages live in `.codex/skills/`
+- Runtime config targets `.codex/` paths
+- Secrets storage uses `~/.config/codex-power-pack/`
 
-Some imported materials still mention Claude-specific workflows or command names.
-Those are source-derived reference artifacts and can be cleaned up incrementally
-without affecting the core libraries or tests.
+## CI/CD Trigger Parity
+
+The `/cicd:*` namespace is available through:
+
+- `.codex/prompts/cicd/*.md` - slash-compatible entrypoints
+- `.codex/skills/cicd-*/` - backing Codex skill packages
+- `docs/skills/cicd-command-skill-map.md` - trigger-to-skill inventory
 
 ## Verification
 

--- a/docs/skills/cicd-command-skill-map.md
+++ b/docs/skills/cicd-command-skill-map.md
@@ -1,0 +1,18 @@
+# CI/CD Trigger to Skill Map
+
+This file maps slash-style CI/CD triggers to Codex prompts and skill packages.
+
+| Trigger | Prompt Entrypoint | Skill Package |
+|---|---|---|
+| `/cicd:check` | `.codex/prompts/cicd/check.md` | `.codex/skills/cicd-check/SKILL.md` |
+| `/cicd:container` | `.codex/prompts/cicd/container.md` | `.codex/skills/cicd-container/SKILL.md` |
+| `/cicd:health` | `.codex/prompts/cicd/health.md` | `.codex/skills/cicd-health/SKILL.md` |
+| `/cicd:help` | `.codex/prompts/cicd/help.md` | `.codex/skills/cicd-help/SKILL.md` |
+| `/cicd:infra-discover` | `.codex/prompts/cicd/infra-discover.md` | `.codex/skills/cicd-infra-discover/SKILL.md` |
+| `/cicd:infra-init` | `.codex/prompts/cicd/infra-init.md` | `.codex/skills/cicd-infra-init/SKILL.md` |
+| `/cicd:infra-pipeline` | `.codex/prompts/cicd/infra-pipeline.md` | `.codex/skills/cicd-infra-pipeline/SKILL.md` |
+| `/cicd:init` | `.codex/prompts/cicd/init.md` | `.codex/skills/cicd-init/SKILL.md` |
+| `/cicd:pipeline` | `.codex/prompts/cicd/pipeline.md` | `.codex/skills/cicd-pipeline/SKILL.md` |
+| `/cicd:smoke` | `.codex/prompts/cicd/smoke.md` | `.codex/skills/cicd-smoke/SKILL.md` |
+
+Canonical inventory: `.codex/prompts/cicd/*.md` and `.codex/skills/cicd-*/`.

--- a/tests/test_cicd_skill_trigger_parity.py
+++ b/tests/test_cicd_skill_trigger_parity.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PROMPT_DIR = ROOT / ".codex" / "prompts" / "cicd"
+SKILLS_DIR = ROOT / ".codex" / "skills"
+
+CICD_COMMANDS = {
+    "check",
+    "container",
+    "health",
+    "help",
+    "infra-discover",
+    "infra-init",
+    "infra-pipeline",
+    "init",
+    "pipeline",
+    "smoke",
+}
+
+def _target_prompts() -> set[str]:
+    return {path.stem for path in PROMPT_DIR.glob("*.md")}
+
+
+def test_cicd_prompt_trigger_parity_with_source_commands() -> None:
+    assert _target_prompts() == CICD_COMMANDS
+
+
+def test_every_cicd_prompt_has_backing_skill_package() -> None:
+    for command in sorted(CICD_COMMANDS):
+        trigger = f"/cicd:{command}"
+        skill_name = f"cicd-{command}"
+
+        skill_md = SKILLS_DIR / skill_name / "SKILL.md"
+        agent_yaml = SKILLS_DIR / skill_name / "agents" / "openai.yaml"
+        prompt_md = PROMPT_DIR / f"{command}.md"
+
+        assert skill_md.exists(), f"Missing skill file for {trigger}: {skill_md}"
+        assert agent_yaml.exists(), f"Missing agents metadata for {trigger}: {agent_yaml}"
+
+        prompt_text = prompt_md.read_text()
+        skill_text = skill_md.read_text()
+
+        assert f"Backing skill: `{skill_name}`" in prompt_text
+        assert trigger in skill_text
+        assert f".codex/prompts/cicd/{command}.md" in skill_text


### PR DESCRIPTION
## Summary
- add Codex-native `/cicd:*` trigger entrypoints under `.codex/prompts/cicd/`
- add backing skill packages under `.codex/skills/cicd-*` with `SKILL.md` and `agents/openai.yaml`
- add CI/CD trigger-to-skill inventory doc and parity tests
- update AGENTS/README for Codex-only CI/CD trigger discoverability

## Validation
- `env UV_CACHE_DIR=/tmp/uv-cache make verify`
- `env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev pytest -q tests/test_cicd_skill_trigger_parity.py`

Closes #2
