### PR TITLE
Port agents-md namespace to Codex-native skills

### DIFF
--- a/.codex/prompts/agents-md/help.md
+++ b/.codex/prompts/agents-md/help.md
@@ -1,0 +1,59 @@
+---
+description: Overview of AGENTS.md management commands
+---
+
+> Trigger parity entrypoint for `/agents-md:help`.
+> Backing skill: `agents-md-help` (`.codex/skills/agents-md-help/SKILL.md`).
+
+# AGENTS.md Commands
+
+Audit and manage your project's AGENTS.md governance directives.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/agents-md:lint` | Audit AGENTS.md for CI/CD, Docker, and troubleshooting directives |
+| `/agents-md:help` | This help page |
+
+## Why AGENTS.md Governance Matters
+
+AGENTS.md is the primary mechanism for directing Codex agent behavior. Without explicit CI/CD and troubleshooting directives, agents default to ad-hoc approaches that bypass your project's build pipeline.
+
+`/agents-md:lint` checks that your AGENTS.md includes:
+
+| Category | What It Checks |
+|----------|----------------|
+| CI/CD Protocol | Makefile targets referenced for build/test/deploy |
+| Troubleshooting Protocol | Directives to fix CI/CD alongside code |
+| Quality Gates | `make lint`, `make test`, `make verify` mentioned |
+| Docker Conventions | `make docker-*` targets (if Docker files exist) |
+| Deployment Protocol | `make deploy` or deployment workflow |
+| Available Commands | Makefile targets listed for reference |
+
+## Scoring
+
+| Score | Rating |
+|-------|--------|
+| 5-6 / 6 | HEALTHY |
+| 3-4 / 6 | NEEDS ATTENTION |
+| 0-2 / 6 | UNHEALTHY |
+
+## Quick Start
+
+```bash
+# Audit your AGENTS.md
+/agents-md:lint
+
+# Fix gaps in your Makefile first
+/cicd:check
+
+# Full project health: Makefile + AGENTS.md
+/cicd:check && /agents-md:lint
+```
+
+## Related
+
+- `/cicd:check` - Validate Makefile targets
+- `/cicd:init` - Generate Makefile from detected framework
+- `/project:init` - Full project scaffolding (generates AGENTS.md with directives)

--- a/.codex/prompts/agents-md/lint.md
+++ b/.codex/prompts/agents-md/lint.md
@@ -1,0 +1,264 @@
+---
+description: Lint AGENTS.md for missing CI/CD, Docker, and troubleshooting directives
+allowed-tools: Bash(cat:*), Bash(grep:*), Bash(test:*), Bash(ls:*), Bash(PYTHONPATH=*), Bash(python3:*), Read, Glob, Grep
+---
+
+> Trigger parity entrypoint for `/agents-md:lint`.
+> Backing skill: `agents-md-lint` (`.codex/skills/agents-md-lint/SKILL.md`).
+
+# /agents-md:lint - AGENTS.md Health Check
+
+Audit a project's AGENTS.md to ensure it includes essential directives for CI/CD protocols, Docker conventions, and troubleshooting workflows.
+
+## Why This Matters
+
+AGENTS.md governs agent behavior. Without explicit CI/CD directives, Codex agents will:
+- Run raw `docker compose` instead of `make docker-*` targets
+- Debug ad-hoc without following Makefile pipelines
+- Skip lint/test gates when troubleshooting
+- Make manual fixes that break CI/CD alignment
+
+---
+
+## Step 1: Detect Project Context
+
+```bash
+# Check for AGENTS.md
+if [ ! -f "AGENTS.md" ]; then
+    echo "NO AGENTS.md FOUND"
+    echo ""
+    echo "This project has no AGENTS.md. Create one with /project:init or manually."
+    exit 1
+fi
+
+# Detect framework
+HAS_MAKEFILE="no"
+HAS_DOCKER="no"
+HAS_CICD_YML="no"
+FRAMEWORK="unknown"
+
+[ -f "Makefile" ] && HAS_MAKEFILE="yes"
+[ -f "Dockerfile" ] || [ -f "docker-compose.yml" ] || [ -f "docker-compose.yaml" ] && HAS_DOCKER="yes"
+[ -f ".codex/cicd.yml" ] && HAS_CICD_YML="yes"
+
+# Detect framework from markers
+[ -f "pyproject.toml" ] || [ -f "setup.py" ] && FRAMEWORK="python"
+[ -f "package.json" ] && FRAMEWORK="node"
+[ -f "go.mod" ] && FRAMEWORK="go"
+[ -f "Cargo.toml" ] && FRAMEWORK="rust"
+```
+
+---
+
+## Step 2: Read and Audit AGENTS.md
+
+Read the project's AGENTS.md and check for the presence of each required directive category.
+
+### Required Sections
+
+Check for these directive categories (case-insensitive, flexible matching):
+
+| Category | Check For | Weight |
+|----------|-----------|--------|
+| **CI/CD Protocol** | Mentions Makefile targets for build/test/deploy | REQUIRED |
+| **Troubleshooting Protocol** | Mentions running lint/test before debugging, fixing CI/CD alongside code | REQUIRED |
+| **Quality Gates** | Mentions `make lint`, `make test`, `make verify`, or equivalent | REQUIRED |
+| **Docker Conventions** | Mentions `make docker-*` targets (only if Docker files exist) | CONDITIONAL |
+| **Deployment Protocol** | Mentions `make deploy` or deployment workflow | RECOMMENDED |
+| **Available Commands** | Lists Makefile targets or build commands | RECOMMENDED |
+
+### Detection Patterns
+
+For each category, search AGENTS.md for these patterns:
+
+**CI/CD Protocol** (any of):
+- `make lint`, `make test`, `make build`, `make deploy`
+- `Makefile target`
+- `CI/CD protocol` or `cicd`
+- `quality gate`
+
+**Troubleshooting Protocol** (any of):
+- `troubleshoot`
+- `before debugging`
+- `fix.*CI/CD` or `fix.*Makefile` or `fix.*pipeline`
+- `root cause`
+- `never bypass`
+
+**Quality Gates** (any of):
+- `make lint`
+- `make test`
+- `make verify`
+- `quality gate`
+- `/flow:finish`
+
+**Docker Conventions** (any of, only checked if Docker files exist):
+- `make docker`
+- `docker-build`, `docker-up`, `docker-down`
+- `not raw.*docker`
+
+**Deployment Protocol** (any of):
+- `make deploy`
+- `deployment`
+- `/flow:deploy`
+
+**Available Commands** (any of):
+- A table or list containing `make` targets
+- `## Commands` or `## Makefile` or `## Available`
+
+---
+
+## Step 3: Score and Report
+
+Present results as a health report:
+
+```markdown
+## AGENTS.md Lint Report
+
+**Project:** {project name from directory}
+**Framework:** {detected framework}
+**Makefile:** {yes/no}
+**Docker:** {yes/no}
+**cicd.yml:** {yes/no}
+
+### Directive Coverage
+
+| Category | Status | Details |
+|----------|--------|---------|
+| CI/CD Protocol | PASS/FAIL | {what was found or missing} |
+| Troubleshooting Protocol | PASS/FAIL | {what was found or missing} |
+| Quality Gates | PASS/FAIL | {what was found or missing} |
+| Docker Conventions | PASS/FAIL/SKIP | {what was found, or "No Docker files"} |
+| Deployment Protocol | PASS/WARN | {what was found or missing} |
+| Available Commands | PASS/WARN | {what was found or missing} |
+
+### Score: {N}/6 ({percentage}%)
+
+### {HEALTHY / NEEDS ATTENTION / UNHEALTHY}
+```
+
+**Scoring:**
+- PASS on REQUIRED = 1 point each (3 total)
+- PASS on CONDITIONAL (Docker) = 1 point if applicable, auto-PASS if no Docker
+- PASS on RECOMMENDED = 1 point each (2 total)
+- **HEALTHY:** 5-6 points
+- **NEEDS ATTENTION:** 3-4 points
+- **UNHEALTHY:** 0-2 points
+
+---
+
+## Step 4: Generate Fix Suggestions
+
+For each FAIL or WARN, provide the exact text block to add to AGENTS.md.
+
+### If CI/CD Protocol is FAIL:
+
+```markdown
+**Add to AGENTS.md:**
+
+## CI/CD Protocol
+
+- Use Makefile targets for all build, test, and deploy operations
+- Never run raw build commands - use `make lint`, `make test`, `make build`, `make deploy`
+- The Makefile is the single source of truth for project commands
+- If a Makefile target is missing for your operation, ADD the target rather than running raw commands
+```
+
+### If Troubleshooting Protocol is FAIL:
+
+```markdown
+**Add to AGENTS.md:**
+
+## Troubleshooting Protocol
+
+- Before debugging manually, run `make lint` and `make test` to surface known issues
+- When fixing errors, fix BOTH the application code AND the CI/CD process (Makefile, Dockerfile, docker-compose.yml)
+- After any fix, verify through the full pipeline: `make verify`
+- Never bypass quality gates - if `make lint` or `make test` fails, fix the root cause
+- Use `make troubleshoot` for a single-command diagnostic pass (clean + lint + test)
+```
+
+### If Quality Gates is FAIL:
+
+```markdown
+**Add to AGENTS.md:**
+
+## Quality Gates
+
+| Target | Purpose | When to Run |
+|--------|---------|-------------|
+| `make lint` | Run linter | Before every commit |
+| `make test` | Run tests | Before every commit |
+| `make verify` | Full check (lint + test + typecheck) | Before deployment |
+| `make troubleshoot` | Diagnostic pass (clean + lint + test) | When debugging issues |
+```
+
+### If Docker Conventions is FAIL (and Docker files exist):
+
+```markdown
+**Add to AGENTS.md:**
+
+## Docker Conventions
+
+- Build images: `make docker-build` (not raw `docker build`)
+- Start services: `make docker-up` (not raw `docker compose up`)
+- Stop services: `make docker-down`
+- View logs: `make docker-logs`
+- Check status: `make docker-ps`
+- If Docker errors occur, check Dockerfile and docker-compose.yml alongside application code
+```
+
+### If Deployment Protocol is WARN:
+
+```markdown
+**Add to AGENTS.md:**
+
+## Deployment
+
+- Deploy: `make deploy` (runs verify first)
+- The deploy target should be customized in the Makefile for your environment
+- Post-deploy: run `/cicd:health` to verify endpoints
+```
+
+### If Available Commands is WARN:
+
+```markdown
+**Add to AGENTS.md:**
+
+## Available Makefile Targets
+
+Run `make help` or see the Makefile for all targets. Key targets:
+
+| Target | Purpose |
+|--------|---------|
+| `make lint` | Run linter |
+| `make test` | Run tests |
+| `make verify` | Full quality gate |
+| `make deploy` | Deploy (after verify) |
+| `make clean` | Remove build artifacts |
+| `make troubleshoot` | Diagnostic pass |
+```
+
+---
+
+## Step 5: Offer to Apply Fixes
+
+After presenting the report, ask:
+
+1. **Apply all fixes** - Add all missing sections to AGENTS.md
+2. **Apply selectively** - Choose which sections to add
+3. **View only** - Just see the report, make changes manually
+
+If the user chooses to apply:
+- Read the current AGENTS.md
+- Append missing sections at an appropriate location (after existing conventions, before detailed/reference sections)
+- Show the diff of what was added
+
+---
+
+## Notes
+
+- This command is read-only by default - it only modifies AGENTS.md if the user opts in
+- Patterns are intentionally flexible - projects can phrase directives differently
+- Docker section is only checked if Dockerfile or docker-compose.yml exists
+- Run this after `/project:init` or `/cicd:init` to verify completeness
+- Pair with `/cicd:check` for full project health: `/cicd:check` validates the Makefile, `/agents-md:lint` validates the AGENTS.md

--- a/.codex/prompts/cicd/help.md
+++ b/.codex/prompts/cicd/help.md
@@ -156,7 +156,7 @@ infrastructure:
 
 ## Related
 
-- `/claude-md:lint` - Audit AGENTS.md for CI/CD and troubleshooting directives
+- `/agents-md:lint` - Audit AGENTS.md for CI/CD and troubleshooting directives
 - `/flow:doctor` - Reports Makefile target availability
 - `/flow:deploy` - Runs deploy target
 - `/self-improvement:deployment` - Analyze deploy failures and improve Makefile

--- a/.codex/skills/agents-md-help/SKILL.md
+++ b/.codex/skills/agents-md-help/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: agents-md-help
+description: Trigger `/agents-md:help` to show AGENTS.md governance command guidance.
+---
+
+# agents-md-help
+
+## Trigger
+- Primary: `/agents-md:help`
+- Text alias: `agents-md:help`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/agents-md/help.md`
+
+## Execution
+1. Use this skill when the user asks for AGENTS.md governance command help.
+2. Follow `.codex/prompts/agents-md/help.md` as the authoritative runbook.
+3. Keep guidance Codex-native and focused on `AGENTS.md` and `.codex/*` paths.

--- a/.codex/skills/agents-md-help/agents/openai.yaml
+++ b/.codex/skills/agents-md-help/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "agents-md:help"
+  short_description: "Trigger /agents-md:help"
+  default_prompt: "/agents-md:help"

--- a/.codex/skills/agents-md-lint/SKILL.md
+++ b/.codex/skills/agents-md-lint/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: agents-md-lint
+description: Trigger `/agents-md:lint` to audit AGENTS.md governance directives.
+---
+
+# agents-md-lint
+
+## Trigger
+- Primary: `/agents-md:lint`
+- Text alias: `agents-md:lint`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/agents-md/lint.md`
+
+## Execution
+1. Use this skill when the user asks to lint or audit `AGENTS.md`.
+2. Follow `.codex/prompts/agents-md/lint.md` as the authoritative runbook.
+3. Keep outputs actionable with clear PASS/FAIL/WARN criteria and concrete remediation blocks.
+4. Only modify `AGENTS.md` after explicit user confirmation.

--- a/.codex/skills/agents-md-lint/agents/openai.yaml
+++ b/.codex/skills/agents-md-lint/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "agents-md:lint"
+  short_description: "Trigger /agents-md:lint"
+  default_prompt: "/agents-md:lint"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,4 @@
 ## Notes
 
 - CI/CD slash trigger parity is mapped in `docs/skills/cicd-command-skill-map.md`.
+- AGENTS.md governance trigger parity is mapped in `docs/skills/agents-md-command-skill-map.md`.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ The `/cicd:*` namespace is available through:
 - `.codex/skills/cicd-*/` - backing Codex skill packages
 - `docs/skills/cicd-command-skill-map.md` - trigger-to-skill inventory
 
+## AGENTS.md Trigger Parity
+
+The `/agents-md:*` namespace is available through:
+
+- `.codex/prompts/agents-md/*.md` - slash-compatible entrypoints
+- `.codex/skills/agents-md-*/` - backing Codex skill packages
+- `docs/skills/agents-md-command-skill-map.md` - trigger-to-skill inventory
+
 ## Verification
 
 ```bash

--- a/docs/skills/agents-md-command-skill-map.md
+++ b/docs/skills/agents-md-command-skill-map.md
@@ -1,0 +1,10 @@
+# AGENTS.md Trigger to Skill Map
+
+This file maps AGENTS.md governance triggers to Codex prompts and skill packages.
+
+| Trigger | Prompt Entrypoint | Skill Package |
+|---|---|---|
+| `/agents-md:help` | `.codex/prompts/agents-md/help.md` | `.codex/skills/agents-md-help/SKILL.md` |
+| `/agents-md:lint` | `.codex/prompts/agents-md/lint.md` | `.codex/skills/agents-md-lint/SKILL.md` |
+
+Canonical inventory: `.codex/prompts/agents-md/*.md` and `.codex/skills/agents-md-*/`.

--- a/tests/test_agents_md_skill_trigger_parity.py
+++ b/tests/test_agents_md_skill_trigger_parity.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PROMPT_DIR = ROOT / ".codex" / "prompts" / "agents-md"
+SKILLS_DIR = ROOT / ".codex" / "skills"
+
+AGENTS_MD_COMMANDS = {"help", "lint"}
+
+
+def _target_prompts() -> set[str]:
+    return {path.stem for path in PROMPT_DIR.glob("*.md")}
+
+
+def test_agents_md_prompt_trigger_parity() -> None:
+    assert _target_prompts() == AGENTS_MD_COMMANDS
+
+
+def test_every_agents_md_prompt_has_backing_skill_package() -> None:
+    for command in sorted(AGENTS_MD_COMMANDS):
+        trigger = f"/agents-md:{command}"
+        skill_name = f"agents-md-{command}"
+
+        skill_md = SKILLS_DIR / skill_name / "SKILL.md"
+        agent_yaml = SKILLS_DIR / skill_name / "agents" / "openai.yaml"
+        prompt_md = PROMPT_DIR / f"{command}.md"
+
+        assert skill_md.exists(), f"Missing skill file for {trigger}: {skill_md}"
+        assert agent_yaml.exists(), f"Missing agents metadata for {trigger}: {agent_yaml}"
+
+        prompt_text = prompt_md.read_text()
+        skill_text = skill_md.read_text()
+
+        assert f"Backing skill: `{skill_name}`" in prompt_text
+        assert trigger in skill_text
+        assert f".codex/prompts/agents-md/{command}.md" in skill_text


### PR DESCRIPTION
## Summary
- add Codex-native `/agents-md:*` prompt entrypoints in `.codex/prompts/agents-md/`
- add backing skill packages in `.codex/skills/agents-md-*` with `SKILL.md` and `agents/openai.yaml`
- add trigger parity map and parity tests for the new namespace
- update discoverability docs and replace `/claude-md:lint` reference in CI/CD help with `/agents-md:lint`

## Validation
- `env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev pytest -q tests/test_agents_md_skill_trigger_parity.py`
- `env UV_CACHE_DIR=/tmp/uv-cache make verify`

Closes #3
