### PR TITLE
feat(flow): port flow namespace to codex skills (Closes #7)

### DIFF
--- a/.codex/prompts/flow/auto.md
+++ b/.codex/prompts/flow/auto.md
@@ -1,0 +1,483 @@
+> Trigger parity entrypoint for `/flow:auto`.
+> Backing skill: `flow-auto` (`.codex/skills/flow-auto/SKILL.md`).
+
+# Flow: Auto - Full Issue Lifecycle in One Shot
+
+Complete end-to-end workflow: start worktree → analyze issue → implement → finish (PR) → merge → deploy.
+
+## Arguments
+
+- `ISSUE` (required): GitHub issue number (e.g., `42`)
+
+## Instructions
+
+When the user invokes `/flow:auto <ISSUE>`, perform these steps sequentially. Stop immediately if any step fails.
+
+Report at the start:
+
+```
+Flow Auto: Issue #42 - Full Lifecycle
+
+Step 1/8: Start (create worktree and branch)
+Step 2/8: Analyze (understand issue and codebase)
+Step 3/8: Implement (write the code)
+Step 4/8: Update Docs (regenerate C4 diagrams, review AGENTS.md/README.md)
+Step 5/8: Finish (lint, test, commit, push, create PR)
+Step 6/8: Merge (squash-merge PR, clean up worktree)
+Step 7/8: Verify CI (confirm pipeline passes on main)
+Step 8/8: Deploy (make deploy, if target exists)
+
+Proceeding...
+```
+
+---
+
+### Step 1: Start - Create Worktree
+
+**CRITICAL: You MUST create or enter a worktree before proceeding. NEVER implement changes directly on main/master. This step is NOT optional - if worktree creation fails, STOP immediately.**
+
+Create a worktree and branch for the issue. If one already exists, `cd` into it.
+
+```bash
+ISSUE_NUM="$1"
+REPO=$(basename "$(git rev-parse --show-toplevel)")
+
+# Fetch issue details
+gh issue view "$ISSUE_NUM" --json number,title,state,body
+```
+
+- If issue is not OPEN, warn the user and ask whether to proceed.
+- Extract the title for branch naming.
+
+```bash
+# Sanitize title for branch name
+SLUG=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-50)
+BRANCH="issue-${ISSUE_NUM}-${SLUG}"
+WORKTREE_DIR="../${REPO}-issue-${ISSUE_NUM}"
+```
+
+**Check for existing work:**
+
+```bash
+# Check if already on the issue's branch
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" =~ issue-${ISSUE_NUM}- ]]; then
+    # Already in the right worktree - skip creation
+fi
+
+# Check if worktree already exists
+git worktree list | grep "issue-${ISSUE_NUM}"
+
+# Check if remote branch exists
+git fetch origin
+git branch -r | grep "issue-${ISSUE_NUM}-"
+```
+
+- **Already on issue branch:** Verify you are NOT on main/master. Use current directory.
+- **Worktree exists:** `cd` into the existing worktree directory.
+- **Remote branch exists:** Create worktree tracking the remote branch, then `cd` into it:
+  ```bash
+  git worktree add -b "$LOCAL_BRANCH" "$WORKTREE_DIR" "$REMOTE_BRANCH"
+  cd "$WORKTREE_DIR"
+  ```
+- **Neither exists:** Create fresh from `origin/main`, then `cd` into it:
+  ```bash
+  git fetch origin main
+  git worktree add -b "$BRANCH" "$WORKTREE_DIR" origin/main
+  cd "$WORKTREE_DIR"
+  ```
+
+#### Verification Gate (MANDATORY - do NOT skip)
+
+Before proceeding to Step 2, verify you are in the correct working directory:
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "master" ]]; then
+    echo "ERROR: Still on main/master after Step 1. Worktree creation failed or cd was skipped."
+    echo "STOP: Cannot proceed. You MUST be on an issue branch, not main."
+    exit 1
+fi
+echo "Verified: on branch '$CURRENT_BRANCH' in $(pwd)"
+```
+
+**If this verification fails, STOP immediately. Report the failure using the error template at the bottom of this file. Do NOT proceed to Step 2.**
+
+Report: `Step 1/8: Start complete - worktree at {path}, verified on branch {branch}`
+
+---
+
+### Step 2: Analyze - Understand the Issue
+
+Working from the worktree, analyze the issue and codebase to form an implementation plan.
+
+1. **Parse the issue body:**
+   - Extract acceptance criteria (checkbox items `- [ ]`)
+   - Identify referenced files, components, or areas
+   - Note any dependencies or constraints mentioned
+
+2. **Explore the codebase:**
+   - Read files referenced in the issue
+   - Understand existing patterns and conventions
+   - Identify all files that need to be created or modified
+
+3. **Form an implementation plan:**
+   - List the specific changes needed
+   - Note any edge cases or risks
+
+4. **Report the plan to the user:**
+
+```
+Step 2/8: Analysis Complete
+
+Issue #42: "Fix login redirect loop"
+
+Acceptance Criteria:
+  - [ ] Login redirects to dashboard after auth
+  - [ ] Invalid sessions redirect to /login
+  - [ ] Tests pass
+
+Implementation Plan:
+  1. Modify src/auth/login.py - fix redirect logic in handle_login()
+  2. Update tests/test_auth.py - add redirect test cases
+  3. Update config/routes.py - add dashboard route
+
+Files to modify: 3
+Estimated scope: Small
+
+Proceeding to implementation...
+```
+
+Report: `Step 2/8: Analyze complete - {N} files to modify`
+
+---
+
+### Step 3: Implement - Write the Code
+
+Execute the implementation plan from Step 2:
+
+1. **Make all code changes** in the worktree.
+2. **Follow existing conventions** - match the code style, patterns, and structure of the project.
+3. **Run tests locally** if a quick feedback loop is available (e.g., `make test` or the project's test command).
+4. **Verify the changes** address all acceptance criteria from the issue.
+
+If implementation hits a blocker that cannot be resolved:
+- **STOP** and report the blocker.
+- Suggest manual intervention.
+
+Report: `Step 3/8: Implement complete - {summary of changes}`
+
+---
+
+### Step 4: Update Docs - Regenerate C4 Diagrams and Review Docs
+
+If the Makefile has an `update_docs` target:
+
+```bash
+if [[ -f "Makefile" ]] && grep -q "^update_docs:" Makefile; then
+    echo "Running: make update_docs"
+    make update_docs
+fi
+```
+
+Then perform these documentation tasks:
+
+1. **Regenerate C4 diagrams** - If `docs/architecture/` exists or significant code changes were made, run the `/documentation:c4` workflow:
+   - Analyze the project architecture
+   - Generate L1-L4 C4 diagrams to `docs/architecture/`
+   - Screenshot via Playwright if available
+
+2. **Review AGENTS.md** - Check that repository structure, command references, and component descriptions match the current state. Fix any stale references.
+
+3. **Review README.md** - Check that the project description, setup instructions, and feature list reflect the changes just implemented. Fix any inaccuracies.
+
+4. **Stage doc changes** - `git add` any modified documentation files.
+
+If no `update_docs` target exists in the Makefile, skip this step.
+
+Report: `Step 4/8: Update Docs complete - {N} files updated` or `Step 4/8: Update Docs skipped (no Makefile target)`
+
+---
+
+### Step 5: Finish - Quality Gates, Commit, Push, PR
+
+```bash
+BRANCH=$(git branch --show-current)
+ISSUE_NUM=$(echo "$BRANCH" | grep -oP 'issue-\K[0-9]+' || echo "")
+```
+
+1. **Quality gates** - use the deterministic runner as primary path:
+
+   **Primary path:** Call the CI/CD runner for reproducible quality gates:
+   ```bash
+   CPP_DIR=""
+   for dir in ~/Projects/codex-power-pack /opt/codex-power-pack ~/.codex-power-pack; do
+     if [ -d "$dir" ] && [ -f "$dir/AGENTS.md" ]; then
+       CPP_DIR="$dir"
+       break
+     fi
+   done
+
+   if [ -n "$CPP_DIR" ]; then
+       PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd run --plan finish
+       RUNNER_EXIT=$?
+   fi
+   ```
+
+   - If runner succeeds (exit 0): quality gates passed, proceed to commit.
+   - If runner fails: parse JSON output, report the failed step, **STOP**.
+
+   **Fallback** (only if runner unavailable): Run `make lint` and `make test` directly.
+   - If either fails: **STOP**. Report the failure and exit.
+
+2. **Commit** - if there are uncommitted changes:
+   - Use conventional commit format: `type(scope): Description (Closes #N)`
+   - Include a `Co-Authored-By` trailer when required by team policy.
+
+3. **Push** the branch:
+   ```bash
+   git push -u origin "$BRANCH"
+   ```
+
+4. **Create PR** - if no PR exists:
+   ```bash
+   gh pr create --title "type(scope): Description (Closes #ISSUE_NUM)" --body "..."
+   ```
+   - If PR already exists, report its URL and continue.
+   - PR body: Summary of changes + test plan + `Closes #N`
+   - Analyze all commits on the branch to draft the summary.
+
+Report: `Step 5/8: Finish complete - PR #XX created`
+
+---
+
+### Step 6: Merge - Squash-Merge and Clean Up
+
+1. **Merge the PR:**
+   ```bash
+   PR_NUMBER=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number')
+   gh pr merge "$PR_NUMBER" --squash --delete-branch
+   ```
+   - If merge fails (conflicts, checks): **STOP**. Report and exit.
+
+2. **Update local main:**
+   ```bash
+   if [[ -f ".git" ]]; then
+       MAIN_REPO=$(cat .git | sed 's/gitdir: //' | sed 's|/.git/worktrees/.*||')
+   else
+       MAIN_REPO=$(pwd)
+   fi
+   git -C "$MAIN_REPO" checkout main 2>/dev/null || true
+   git -C "$MAIN_REPO" pull origin main
+   ```
+
+3. **Clean up worktree and branch:**
+
+   **CRITICAL: You MUST `cd` to the main repo BEFORE removing the worktree. NEVER remove a worktree while your working directory is inside it - this kills all subsequent bash commands. Execute these as SEPARATE Bash calls, not in a single script.**
+
+   **Step 6a - Exit the worktree (separate Bash call):**
+   ```bash
+   cd "$MAIN_REPO"
+   pwd  # Verify you are in the main repo
+   ```
+
+   **Step 6b - Remove the worktree (separate Bash call, AFTER confirming cd succeeded):**
+   ```bash
+   if [[ -f ~/.codex/scripts/worktree-remove.sh ]]; then
+       ~/.codex/scripts/worktree-remove.sh "$WORKTREE_PATH" --force --delete-branch
+   else
+       git worktree remove "$WORKTREE_PATH" --force
+       git branch -D "$BRANCH" 2>/dev/null || true
+   fi
+   ```
+
+   **Step 6c - Verify working directory is valid:**
+   ```bash
+   pwd  # MUST show main repo path, NOT the deleted worktree
+   git status  # MUST succeed - if this fails, your CWD was deleted
+   ```
+
+   If you are NOT in a worktree (just on a feature branch in main repo):
+   ```bash
+   git branch -D "$BRANCH" 2>/dev/null || true
+   ```
+
+4. **Close issue** (if still open):
+   ```bash
+   if [[ -n "$ISSUE_NUM" ]]; then
+       ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null)
+       if [[ "$ISSUE_STATE" == "OPEN" ]]; then
+           gh issue close "$ISSUE_NUM" --comment "Closed via /flow:auto - PR #${PR_NUMBER} merged."
+       fi
+   fi
+   ```
+
+Report: `Step 6/8: Merge complete - worktree cleaned up`
+
+---
+
+### Step 7: Verify CI (after merge)
+
+After merging to main, verify that the CI pipeline passes before deploying.
+
+1. **Detect CI system and poll for results:**
+
+```bash
+cd "$MAIN_REPO"
+COMMIT_SHA=$(git rev-parse HEAD)
+SHORT_SHA=$(git rev-parse --short HEAD)
+REPO_FULL=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
+```
+
+2. **Check Woodpecker CI** (if `WOODPECKER_API_TOKEN` is set):
+
+```bash
+if [[ -n "$WOODPECKER_API_TOKEN" ]]; then
+    WOODPECKER_SERVER="${WOODPECKER_SERVER:-https://woodpecker.essent-ai.com}"
+    echo "Polling Woodpecker CI for commit $SHORT_SHA..."
+
+    # Woodpecker v3 API requires numeric repo ID, not owner/name
+    # First resolve repo ID via lookup endpoint
+    REPO_ID=$(curl -s -H "Authorization: Bearer $WOODPECKER_API_TOKEN" \
+        -H "Accept: application/json" \
+        "$WOODPECKER_SERVER/api/repos/lookup/$REPO_FULL" | jq -r '.id' 2>/dev/null)
+
+    if [[ -z "$REPO_ID" || "$REPO_ID" == "null" ]]; then
+        echo "WARNING: Could not resolve Woodpecker repo ID for $REPO_FULL. Skipping CI verification."
+    else
+        # Poll up to 10 minutes (60 attempts, 10s apart)
+        for i in $(seq 1 60); do
+            PIPELINE_JSON=$(curl -s -H "Authorization: Bearer $WOODPECKER_API_TOKEN" \
+                -H "Accept: application/json" \
+                "$WOODPECKER_SERVER/api/repos/$REPO_ID/pipelines?per_page=5" | \
+                jq --arg sha "$COMMIT_SHA" '[.[] | select(.commit == $sha)] | .[0]' 2>/dev/null)
+
+            if [[ -n "$PIPELINE_JSON" && "$PIPELINE_JSON" != "null" ]]; then
+                STATUS=$(echo "$PIPELINE_JSON" | jq -r '.status')
+                PIPELINE_NUM=$(echo "$PIPELINE_JSON" | jq -r '.number')
+
+                case "$STATUS" in
+                    success)
+                        echo "Woodpecker pipeline #$PIPELINE_NUM passed."
+                        break
+                        ;;
+                    failure|error|killed)
+                        echo "Woodpecker pipeline #$PIPELINE_NUM FAILED (status: $STATUS)."
+                        echo "View: $WOODPECKER_SERVER/repos/$REPO_FULL/pipeline/$PIPELINE_NUM"
+                        # STOP - do not deploy
+                        exit 1
+                        ;;
+                    *)
+                        echo "Pipeline #$PIPELINE_NUM status: $STATUS (attempt $i/60)..."
+                        sleep 10
+                        ;;
+                esac
+            else
+                if [[ $i -ge 60 ]]; then
+                    echo "WARNING: No Woodpecker pipeline found for $SHORT_SHA after 10 minutes."
+                    break
+                fi
+                sleep 10
+            fi
+        done
+    fi
+fi
+```
+
+3. **No CI detected:**
+
+If `WOODPECKER_API_TOKEN` is not set, skip with a warning:
+
+```
+WARNING: No CI system detected. Skipping verification.
+```
+
+- If CI **passes**: proceed to Step 8.
+- If CI **fails**: **STOP**. Report the failure and exit. Do not deploy broken code.
+- If CI **not found** after timeout: warn and proceed (non-blocking).
+
+Report: `Step 7/8: Verify CI complete - pipeline #{N} passed` or `Step 7/8: Verify CI skipped (no CI detected)`
+
+---
+
+### Step 8: Deploy (optional)
+
+Only if a Makefile with a `deploy` target exists in the main repo:
+
+```bash
+cd "$MAIN_REPO"
+if [[ -f "Makefile" ]] && grep -q "^deploy:" Makefile; then
+    echo "Running: make deploy"
+    make deploy
+
+    mkdir -p .codex
+    echo "$(date -Iseconds) | deploy | $(git rev-parse --short HEAD) | main | $?" >> .codex/deploy.log
+else
+    echo "No deploy target in Makefile - skipping deployment."
+fi
+```
+
+Report: `Step 8/8: Deploy complete` or `Step 8/8: Deploy skipped (no Makefile target)`
+
+---
+
+### Final Summary
+
+```
+Flow Auto Complete
+
+  Issue:    #42 - Fix login bug
+  Changes:  Modified 3 files (src/auth/login.py, tests/test_auth.py, config/routes.py)
+  PR:       #78 (squash-merged)
+  Branch:   issue-42-fix-login (deleted)
+  Worktree: ../my-project-issue-42 (removed)
+  CI:       Woodpecker pipeline #5 passed | skipped
+  Deploy:   make deploy (success) | skipped
+  Location: /home/user/Projects/my-project (main)
+```
+
+---
+
+## Error Handling
+
+At each step, if something fails:
+
+```
+Flow Auto stopped at Step N/8: {Step Name}
+
+  Failed: [description of what failed]
+  Fix:    [actionable suggestion]
+
+  To resume manually:
+    /flow:start N    (if step 1 failed)
+    [investigate]    (if step 2 failed)
+    [implement]      (if step 3 failed)
+    /documentation:c4 (if step 4 failed)
+    /flow:finish     (if step 5 failed)
+    /flow:merge      (if step 6 failed)
+    [check CI dashboard] (if step 7 failed)
+    /flow:deploy     (if step 8 failed)
+```
+
+Key failure scenarios:
+- **Issue not found:** Stop at step 1
+- **Issue closed:** Warn at step 1, ask to proceed
+- **Analysis unclear:** Stop at step 2, ask user for clarification
+- **Implementation blocker:** Stop at step 3, report what's blocking
+- **Doc update fails:** Non-blocking at step 4, warn and continue
+- **Lint/test fails:** Stop at step 5, show test output
+- **Push fails:** Stop at step 5, suggest `git pull --rebase`
+- **PR merge conflicts:** Stop at step 6, suggest manual resolution
+- **CI pipeline fails:** Stop at step 7, link to pipeline/run for investigation
+- **CI not detected:** Non-blocking at step 7, warn and continue to deploy
+- **Deploy fails:** Report but don't roll back (deploy is best-effort)
+- **Inside worktree being removed:** `worktree-remove.sh` handles this safely
+
+## Notes
+
+- This is the "one command to ship" - takes an issue number and delivers it end-to-end
+- The analyze step ensures the agent understands the issue before writing code
+- Each step builds on the previous one; there's no skipping
+- The deploy step is always optional - it only runs if a deploy target exists
+- After completion, the user is in the main repo on the main branch
+- For step-by-step control, use individual commands: `/flow:start`, `/flow:finish`, `/flow:merge`, `/flow:deploy`

--- a/.codex/prompts/flow/check.md
+++ b/.codex/prompts/flow/check.md
@@ -1,0 +1,155 @@
+---
+description: Run quality checks (lint + security) without committing
+allowed-tools: Bash(make:*), Bash(grep:*), Bash(test:*), Bash(python3:*), Bash(PYTHONPATH=*), Bash(git:*), Read
+---
+
+> Trigger parity entrypoint for `/flow:check`.
+> Backing skill: `flow-check` (`.codex/skills/flow-check/SKILL.md`).
+
+
+# Flow: Check - Run Quality Gates Without Committing
+
+Run lint and security checks to verify code quality. Does not commit, push, or create a PR.
+
+Use this to validate your changes before running `/flow:finish`.
+
+## Instructions
+
+When the user invokes `/flow:check`, perform these steps:
+
+### Step 1: Detect Available Checks
+
+```bash
+CHECKS_RUN=0
+CHECKS_PASS=0
+CHECKS_WARN=0
+CHECKS_FAIL=0
+
+# Detect Makefile targets
+HAS_LINT=false
+HAS_TEST=false
+if [[ -f "Makefile" ]]; then
+    grep -q "^lint:" Makefile && HAS_LINT=true
+    grep -q "^test:" Makefile && HAS_TEST=true
+fi
+
+# Detect security scanner
+HAS_SECURITY=false
+CPP_DIR=""
+for dir in ~/Projects/codex-power-pack /opt/codex-power-pack ~/.codex-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/lib/security/__init__.py" ]; then
+    CPP_DIR="$dir"
+    HAS_SECURITY=true
+    break
+  fi
+done
+
+# Detect Makefile completeness checker
+HAS_CICD=false
+if [ -n "$CPP_DIR" ] && [ -f "$CPP_DIR/lib/cicd/__init__.py" ]; then
+    HAS_CICD=true
+fi
+```
+
+### Step 2: Run Lint
+
+```bash
+if [[ "$HAS_LINT" == "true" ]]; then
+    echo "Running: make lint"
+    make lint
+    LINT_EXIT=$?
+    CHECKS_RUN=$((CHECKS_RUN + 1))
+    if [[ $LINT_EXIT -eq 0 ]]; then
+        CHECKS_PASS=$((CHECKS_PASS + 1))
+    else
+        CHECKS_FAIL=$((CHECKS_FAIL + 1))
+    fi
+fi
+```
+
+### Step 3: Run Tests
+
+```bash
+if [[ "$HAS_TEST" == "true" ]]; then
+    echo "Running: make test"
+    make test
+    TEST_EXIT=$?
+    CHECKS_RUN=$((CHECKS_RUN + 1))
+    if [[ $TEST_EXIT -eq 0 ]]; then
+        CHECKS_PASS=$((CHECKS_PASS + 1))
+    else
+        CHECKS_FAIL=$((CHECKS_FAIL + 1))
+    fi
+fi
+```
+
+### Step 4: Run Security Quick Scan
+
+```bash
+if [[ "$HAS_SECURITY" == "true" ]]; then
+    echo "Running: security gate (flow_finish)"
+    PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.security gate flow_finish
+    SEC_EXIT=$?
+    CHECKS_RUN=$((CHECKS_RUN + 1))
+    if [[ $SEC_EXIT -eq 0 ]]; then
+        CHECKS_PASS=$((CHECKS_PASS + 1))
+    elif [[ $SEC_EXIT -eq 2 ]]; then
+        # Exit code 2 = warnings only (HIGH findings)
+        CHECKS_WARN=$((CHECKS_WARN + 1))
+    else
+        CHECKS_FAIL=$((CHECKS_FAIL + 1))
+    fi
+fi
+```
+
+### Step 5: Run Makefile Completeness Check (optional)
+
+```bash
+if [[ "$HAS_CICD" == "true" ]] && [[ -f "Makefile" ]]; then
+    PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd check --summary
+    CICD_EXIT=$?
+    CHECKS_RUN=$((CHECKS_RUN + 1))
+    if [[ $CICD_EXIT -eq 0 ]]; then
+        CHECKS_PASS=$((CHECKS_PASS + 1))
+    else
+        CHECKS_WARN=$((CHECKS_WARN + 1))  # Non-blocking
+    fi
+fi
+```
+
+### Step 6: Report Results
+
+Present a summary report:
+
+```markdown
+## Flow Check Results
+
+| Check | Status | Details |
+|-------|--------|---------|
+| Lint (`make lint`) | PASS/FAIL/SKIP | All checks passed / 3 errors / No Makefile |
+| Tests (`make test`) | PASS/FAIL/SKIP | 211 passed / 2 failed / No Makefile |
+| Security scan | PASS/WARN/FAIL/SKIP | Clean / 1 HIGH warning / 1 CRITICAL / lib/security not available |
+| Makefile completeness | PASS/WARN/SKIP | 6/6 targets / 1 missing / lib/cicd not available |
+
+**Summary: {CHECKS_PASS} passed, {CHECKS_WARN} warnings, {CHECKS_FAIL} failed ({CHECKS_RUN} checks run)**
+```
+
+Status symbols:
+- **PASS** - Check succeeded
+- **WARN** - Non-blocking issue found (proceed with caution)
+- **FAIL** - Blocking issue found (fix before `/flow:finish`)
+- **SKIP** - Check not available (no Makefile, lib not installed)
+
+### Final Message
+
+Based on results:
+- **All pass:** "Ready for `/flow:finish`."
+- **Warnings only:** "Warnings found but non-blocking. Review before `/flow:finish`."
+- **Failures:** "Failing checks must be fixed before `/flow:finish`."
+
+## Notes
+
+- This command is **read-only** - it never commits, pushes, or modifies files
+- It runs the same checks as `/flow:finish` Step 2, extracted for standalone use
+- Use it to validate changes before committing or as a pre-flight check
+- The security gate uses the same `.codex/security.yml` configuration as `/flow:finish`

--- a/.codex/prompts/flow/cleanup.md
+++ b/.codex/prompts/flow/cleanup.md
@@ -1,0 +1,138 @@
+---
+description: Clean up stale worktree references and merged branches
+allowed-tools: Bash(git:*), Bash(grep:*), Bash(wc:*), Bash(echo:*), Read
+---
+
+> Trigger parity entrypoint for `/flow:cleanup`.
+> Backing skill: `flow-cleanup` (`.codex/skills/flow-cleanup/SKILL.md`).
+
+
+# Flow: Cleanup - Prune Stale Worktrees and Branches
+
+Remove orphaned worktree references, delete local branches already merged to main, and prune stale remote tracking branches.
+
+## Arguments
+
+- No arguments required. Run from the main repo or any worktree.
+
+## Instructions
+
+When the user invokes `/flow:cleanup`, perform these steps:
+
+### Step 1: Detect Repository Root
+
+```bash
+# Find the main repo (works from worktree or main)
+if [[ -f ".git" ]]; then
+    MAIN_REPO=$(cat .git | sed 's/gitdir: //' | sed 's|/.git/worktrees/.*||')
+else
+    MAIN_REPO=$(git rev-parse --show-toplevel)
+fi
+REPO=$(basename "$MAIN_REPO")
+```
+
+### Step 2: Prune Stale Worktree References
+
+When worktree folders are deleted manually, git still tracks them. This cleans those references.
+
+```bash
+# Show stale worktree references before pruning
+STALE_WORKTREES=$(git -C "$MAIN_REPO" worktree list --porcelain | grep -B2 "prunable" | grep "worktree " | sed 's/worktree //' || true)
+
+# Prune them
+git -C "$MAIN_REPO" worktree prune
+```
+
+Report what was pruned (or "No stale worktree references found").
+
+### Step 3: Find and Delete Merged Local Branches
+
+Delete local `issue-*` branches that have been merged to main. Protect `main`, `master`, and any branch with an active worktree.
+
+```bash
+# Get list of branches with active worktrees (these are protected)
+WORKTREE_BRANCHES=$(git -C "$MAIN_REPO" worktree list --porcelain | grep "^branch " | sed 's|branch refs/heads/||')
+
+# Make sure main is up to date
+git -C "$MAIN_REPO" fetch origin main
+
+# Find merged branches (excluding main/master and worktree branches)
+MERGED_BRANCHES=$(git -C "$MAIN_REPO" branch --merged main | grep -v '^\*' | grep -v 'main$' | grep -v 'master$' | sed 's/^[ ]*//')
+```
+
+For each merged branch:
+1. Skip if it has an active worktree
+2. Delete it with `git -C "$MAIN_REPO" branch -d "$BRANCH"`
+
+**Important:** Some branches from squash-merged PRs won't show as `--merged`. Also check for branches whose remote counterpart has been deleted:
+
+```bash
+# Find local issue-* branches whose remote tracking branch is gone
+for branch in $(git -C "$MAIN_REPO" branch | grep 'issue-' | sed 's/^[ *]*//' ); do
+    # Skip if branch has an active worktree
+    echo "$WORKTREE_BRANCHES" | grep -q "^${branch}$" && continue
+
+    # Check if remote tracking branch exists
+    REMOTE=$(git -C "$MAIN_REPO" config "branch.${branch}.remote" 2>/dev/null || echo "")
+    MERGE_REF=$(git -C "$MAIN_REPO" config "branch.${branch}.merge" 2>/dev/null || echo "")
+
+    if [[ -n "$REMOTE" && -n "$MERGE_REF" ]]; then
+        REMOTE_REF="refs/remotes/${REMOTE}/$(echo "$MERGE_REF" | sed 's|refs/heads/||')"
+        if ! git -C "$MAIN_REPO" show-ref --verify --quiet "$REMOTE_REF" 2>/dev/null; then
+            # Remote branch is gone - safe to delete locally
+            # (The PR was merged and remote branch deleted)
+            echo "Remote deleted: $branch"
+        fi
+    fi
+done
+```
+
+For branches where the remote was deleted (PR merged + `--delete-branch`), use `git branch -D` since squash merges don't register as fully merged.
+
+Report each branch deleted and the reason (merged to main, or remote branch deleted).
+
+### Step 4: Prune Stale Remote Tracking Branches
+
+```bash
+git -C "$MAIN_REPO" fetch --prune
+```
+
+This removes `remotes/origin/issue-*` references for branches already deleted on the remote.
+
+Report how many remote tracking branches were pruned.
+
+### Step 5: Summary Output
+
+```markdown
+## Flow Cleanup - {repo}
+
+### Worktree References
+  {N} stale references pruned (or "None found")
+
+### Local Branches Deleted
+  {branch-1} (merged to main)
+  {branch-2} (remote branch deleted - squash-merged PR)
+  ... or "No stale branches found"
+
+### Remote Tracking Branches
+  {N} stale remote references pruned (or "Already clean")
+
+### Current State
+  {M} worktrees active
+  {N} local issue branches remaining
+```
+
+## Error Handling
+
+- **Not a git repo:** Report error and exit
+- **Uncommitted changes on a branch:** Never delete - skip and warn
+- **Protected branches:** Never delete `main` or `master`
+- **Active worktree branches:** Never delete branches with active worktrees
+
+## Notes
+
+- Safe to run multiple times (fully idempotent)
+- Only deletes `issue-*` pattern branches in the squash-merge detection path (other branches require `--merged` confirmation)
+- Use `git branch -d` (safe delete) for merged branches, `git branch -D` (force) only for branches whose remote was deleted
+- Run automatically after `/flow:merge` or manually anytime
+- Does not require network access except for `git fetch --prune`

--- a/.codex/prompts/flow/deploy.md
+++ b/.codex/prompts/flow/deploy.md
@@ -1,0 +1,223 @@
+> Trigger parity entrypoint for `/flow:deploy`.
+> Backing skill: `flow-deploy` (`.codex/skills/flow-deploy/SKILL.md`).
+
+# Flow: Deploy via Makefile
+
+Run deployment using the project's Makefile targets.
+
+## Arguments
+
+- `TARGET` (optional): Makefile target to run (default: `deploy`)
+
+## Instructions
+
+When the user invokes `/flow:deploy [TARGET]`, perform these steps:
+
+### Step 1: Verify on Main Branch
+
+```bash
+BRANCH=$(git branch --show-current)
+if [[ "$BRANCH" != "main" && "$BRANCH" != "master" ]]; then
+    echo "WARNING: Deploying from branch '$BRANCH' (not main)."
+    echo "Consider merging first with /flow:merge."
+    # Ask user to confirm or abort
+fi
+```
+
+### Step 2: Check Makefile Exists
+
+```bash
+if [[ ! -f "Makefile" ]]; then
+    echo "ERROR: No Makefile found in $(pwd)"
+    echo "Create a Makefile with a 'deploy' target, or run your deploy command directly."
+    exit 1
+fi
+```
+
+### Step 3: Verify Target Exists
+
+```bash
+TARGET="${1:-deploy}"
+
+if ! grep -q "^${TARGET}:" Makefile; then
+    echo "ERROR: No '${TARGET}' target in Makefile"
+    echo ""
+    echo "Available targets:"
+    grep -E "^[a-zA-Z_-]+:" Makefile | sed 's/:.*//' | sort
+    exit 1
+fi
+```
+
+### Step 4: Check Deploy Metadata (optional)
+
+If `.codex/deploy.yaml` exists, read it for confirmation requirements:
+
+```yaml
+# .codex/deploy.yaml (optional)
+targets:
+  deploy:
+    description: Deploy to production
+    requires_confirmation: true
+  deploy-staging:
+    description: Deploy to staging
+```
+
+- If `requires_confirmation: true`, ask the user to confirm before proceeding
+- If no deploy.yaml, proceed without extra confirmation
+
+### Step 4b: Run Deploy via Deterministic Runner (primary path)
+
+**Primary path:** Use the deterministic CI/CD runner for reproducible deploy with security gate:
+
+```bash
+# Locate CPP source for lib/cicd
+CPP_DIR=""
+for dir in ~/Projects/codex-power-pack /opt/codex-power-pack ~/.codex-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/AGENTS.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+
+if [ -n "$CPP_DIR" ]; then
+    PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd run --plan deploy
+    RUNNER_EXIT=$?
+fi
+```
+
+- If runner **succeeds** (exit 0): deploy completed (includes security scan + make deploy), skip to Step 6.
+- If runner **fails** (exit non-zero): parse JSON output, report the failed step, and **stop**.
+- If runner is **not available**: fall back to manual execution below.
+
+**Fallback path** (only if runner unavailable):
+
+Run security scan before deploying:
+
+```bash
+PYTHONPATH="${HOME}/Projects/codex-power-pack/lib" python3 -m lib.security gate flow_deploy
+```
+
+- If the gate **fails** (critical or high findings): **stop and report**. Show findings.
+- If the gate produces **warnings** (medium findings): display them but proceed.
+- If `lib/security` is not available, skip this step.
+
+### Step 5: Run Deploy (fallback only - runner includes this)
+
+**Skip this step if the deterministic runner was used above** (it already runs make deploy).
+
+Only run manually if the runner was unavailable:
+
+```bash
+echo "Running: make $TARGET"
+make "$TARGET"
+```
+
+### Step 6: Log Deployment
+
+Append to `.codex/deploy.log`:
+
+```bash
+mkdir -p .codex
+echo "$(date -Iseconds) | ${TARGET} | $(git rev-parse --short HEAD) | $(git branch --show-current) | $?" >> .codex/deploy.log
+```
+
+Format: `timestamp | target | commit | branch | exit_code`
+
+### Step 7: Output
+
+On success:
+```
+Deployment complete ✅
+
+  Target:  make deploy
+  Commit:  abc1234
+  Branch:  main
+  Time:    2026-02-16T14:30:00-05:00
+
+  Log: .codex/deploy.log
+```
+
+On failure:
+```
+Deployment failed ❌
+
+  Target:  make deploy
+  Exit:    1
+
+Review the output above for errors.
+```
+
+### Step 8: Post-Deploy Verification (optional)
+
+After a successful deployment, automatically run health checks and smoke tests if configured.
+
+**Condition:** Only run if `.codex/cicd.yml` exists AND contains `health.post_deploy: true`.
+
+```bash
+# Locate CPP source for lib/cicd
+CPP_DIR=""
+for dir in ~/Projects/codex-power-pack /opt/codex-power-pack ~/.codex-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/AGENTS.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+```
+
+If `CPP_DIR` is found and `.codex/cicd.yml` exists:
+
+1. **Check if post-deploy verification is enabled:**
+   ```bash
+   if grep -q "post_deploy:" .codex/cicd.yml 2>/dev/null; then
+       # Verification enabled
+   else
+       # Skip - not configured
+   fi
+   ```
+
+2. **Run health checks:**
+   ```bash
+   echo "Running post-deploy health checks..."
+   PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd health --summary
+   HEALTH_EXIT=$?
+   ```
+
+3. **Run smoke tests:**
+   ```bash
+   echo "Running post-deploy smoke tests..."
+   PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd smoke --summary
+   SMOKE_EXIT=$?
+   ```
+
+4. **Report results:**
+   - If all pass: `"Deploy verified ✅ - health checks and smoke tests passed"`
+   - If any fail: Report failures and suggest `/self-improvement:deployment`
+
+5. **Log verification results** (extends deploy.log format):
+   ```bash
+   HEALTH_PASS=$( [ "$HEALTH_EXIT" -eq 0 ] && echo "pass" || echo "fail" )
+   SMOKE_PASS=$( [ "$SMOKE_EXIT" -eq 0 ] && echo "pass" || echo "fail" )
+   echo "$(date -Iseconds) | ${TARGET} | $(git rev-parse --short HEAD) | $(git branch --show-current) | $DEPLOY_EXIT | health:${HEALTH_PASS} | smoke:${SMOKE_PASS}" >> .codex/deploy.log
+   ```
+
+   Extended log format: `timestamp | target | commit | branch | deploy_exit | health:pass/fail | smoke:pass/fail`
+
+**Skip conditions:**
+- No `.codex/cicd.yml` → skip silently
+- No `post_deploy:` in config → skip silently
+- `lib/cicd` not available (no CPP_DIR) → skip with warning
+- Verification failures do NOT roll back the deployment - they only report
+
+## Error Handling
+
+- **No Makefile:** Report error with guidance to create one
+- **Target not found:** List available targets
+- **Deploy fails:** Report exit code, show output
+- **Not on main:** Warn but allow (user may want staging deploy from branch)
+
+## Notes
+
+- Deployment always goes through `make` - the Makefile is the single source of truth
+- The `.codex/deploy.log` provides an audit trail of all deployments
+- The optional `.codex/deploy.yaml` adds metadata without changing the Makefile
+- This command works from any directory that has a Makefile

--- a/.codex/prompts/flow/doctor.md
+++ b/.codex/prompts/flow/doctor.md
@@ -1,0 +1,322 @@
+---
+description: Diagnose flow workflow setup and environment
+allowed-tools: Bash(git:*), Bash(gh:*), Bash(command:*), Bash(test:*), Bash(ls:*), Bash(readlink:*), Bash(grep:*), Bash(make:*), Bash(python3:*), Bash(PYTHONPATH=*), Read
+---
+
+> Trigger parity entrypoint for `/flow:doctor`.
+> Backing skill: `flow-doctor` (`.codex/skills/flow-doctor/SKILL.md`).
+
+
+# Flow: Doctor - Diagnose Workflow Environment
+
+Check that the environment is properly configured for the `/flow` workflow.
+
+## Instructions
+
+When the user invokes `/flow:doctor`, run all diagnostic checks and present a single report.
+
+### Step 1: Environment Prerequisites
+
+Check required tools:
+
+```bash
+# git
+git --version 2>/dev/null && echo "PASS" || echo "FAIL"
+
+# gh CLI
+gh --version 2>/dev/null && echo "PASS" || echo "FAIL"
+
+# gh authentication
+gh auth status 2>/dev/null && echo "PASS" || echo "FAIL"
+
+# uv (optional but recommended)
+uv --version 2>/dev/null || echo "NOT_FOUND"
+```
+
+### Step 2: Git Repository State
+
+```bash
+# In a git repository?
+git rev-parse --show-toplevel 2>/dev/null || echo "NOT_A_REPO"
+
+# Remote origin configured?
+git remote get-url origin 2>/dev/null || echo "NO_REMOTE"
+
+# Default branch
+git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||'
+
+# User identity
+git config user.name 2>/dev/null || echo "NOT_SET"
+git config user.email 2>/dev/null || echo "NOT_SET"
+```
+
+### Step 3: Makefile Targets
+
+```bash
+# Makefile exists?
+if [ -f "Makefile" ]; then
+  # List standard targets (lint, test, deploy, format, etc.)
+  grep -E '^[a-zA-Z_-]+:' Makefile | sed 's/:.*//' | sort
+else
+  echo "NO_MAKEFILE"
+fi
+```
+
+Report which of these standard targets exist: `lint`, `test`, `format`, `deploy`.
+
+**If no Makefile found:** Detect the framework and suggest the matching template:
+
+```bash
+# Only if CPP lib is available
+CPP_DIR=""
+for dir in ~/Projects/codex-power-pack /opt/codex-power-pack ~/.codex-power-pack; do
+  if [ -d "$dir/lib/cicd" ]; then CPP_DIR="$dir"; break; fi
+done
+
+if [ -n "$CPP_DIR" ] && [ ! -f "Makefile" ]; then
+  DETECTED=$(PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -c "
+from lib.cicd.detector import detect_framework
+info = detect_framework('.')
+print(f'{info.framework.value}:{info.package_manager.value}')
+" 2>/dev/null)
+  echo "Detected: $DETECTED"
+fi
+```
+
+Use the detection result to suggest the specific template file in the Actions Needed section (e.g., `django-uv.mk` for Django projects, `python-uv.mk` for Python+uv).
+
+### Step 4: Hooks Configuration
+
+```bash
+# hooks.json exists?
+if [ -f ".codex/hooks.json" ]; then
+  # Check for expected hooks
+  grep -l "SessionStart\|PreToolUse\|PostToolUse" .codex/hooks.json
+fi
+```
+
+Check for the three expected hook types:
+- **SessionStart**: Upstream change detection
+- **PreToolUse (Bash)**: Dangerous command blocking via `hook-validate-command.sh`
+- **PostToolUse (Bash/Read)**: Secret masking via `hook-mask-output.sh`
+
+### Step 5: Scripts Availability
+
+Check that core scripts exist in `~/.codex/scripts/`:
+
+```bash
+for script in prompt-context.sh worktree-remove.sh hook-mask-output.sh hook-validate-command.sh secrets-mask.sh; do
+  if [ -x "$HOME/.codex/scripts/$script" ]; then
+    echo "PASS $script"
+  elif [ -f "$HOME/.codex/scripts/$script" ]; then
+    echo "WARN $script (not executable)"
+  else
+    echo "FAIL $script"
+  fi
+done
+```
+
+### Step 6: Active Worktrees
+
+```bash
+git worktree list
+```
+
+For each worktree (skip main), check:
+- Branch name and linked issue number
+- Uncommitted changes (`git -C <path> status --porcelain | wc -l`)
+- Unpushed commits (`git -C <path> rev-list --count origin/main..HEAD 2>/dev/null`)
+
+### Step 7: GitHub Integration
+
+```bash
+# Can list issues?
+gh issue list --limit 1 --json number 2>/dev/null && echo "PASS" || echo "FAIL"
+
+# Can list PRs?
+gh pr list --limit 1 --json number 2>/dev/null && echo "PASS" || echo "FAIL"
+```
+
+### Step 7b: CI/CD Readiness
+
+Check CI/CD configuration and tooling. This section is **optional** - skip entirely if `lib/cicd` is not available.
+
+```bash
+# Locate CPP source for lib/cicd
+CPP_DIR=""
+for dir in ~/Projects/codex-power-pack /opt/codex-power-pack ~/.codex-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/AGENTS.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+```
+
+If `CPP_DIR` is found, run these checks:
+
+```bash
+# 1. cicd.yml config file
+[ -f ".codex/cicd.yml" ] && echo "PASS cicd.yml" || echo "MISSING cicd.yml"
+
+# 2. Framework detection
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd detect --quiet 2>/dev/null
+
+# 3. Makefile completeness (uses lib/cicd check)
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd check --summary 2>/dev/null
+
+# 4. Health check configuration
+grep -q "endpoints:" .codex/cicd.yml 2>/dev/null && echo "PASS health endpoints" || echo "MISSING health endpoints"
+grep -q "smoke_tests:" .codex/cicd.yml 2>/dev/null && echo "PASS smoke tests" || echo "MISSING smoke tests"
+
+# 5. CI pipeline files
+[ -f ".woodpecker.yml" ] || [ -d ".woodpecker" ] && echo "PASS CI pipeline" || echo "MISSING CI pipeline"
+
+# 6. Dockerfile (optional)
+[ -f "Dockerfile" ] && echo "PASS Dockerfile" || echo "OPTIONAL Dockerfile"
+```
+
+If `CPP_DIR` is not found, skip this entire section and note in the report:
+```
+CI/CD Readiness: skipped (lib/cicd not available)
+```
+
+### Step 7c: MCP Server Connectivity
+
+Check whether MCP servers are reachable on their expected ports:
+
+```bash
+echo ""
+echo "MCP Server Connectivity:"
+
+MCP_ISSUES=0
+for entry in "8080:second-opinion" "8081:playwright-persistent"; do
+  PORT="${entry%%:*}"
+  NAME="${entry#*:}"
+  if curl -sf --max-time 2 "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+    echo "  [x] $NAME (port $PORT): reachable"
+  elif ss -tlnp 2>/dev/null | grep -q ":${PORT} " 2>/dev/null; then
+    echo "  [~] $NAME (port $PORT): port open (no /health endpoint)"
+  else
+    echo "  [ ] $NAME (port $PORT): not reachable"
+    MCP_ISSUES=$((MCP_ISSUES + 1))
+  fi
+done
+
+if (( MCP_ISSUES > 0 )); then
+  echo "  Status: $MCP_ISSUES server(s) not reachable"
+else
+  echo "  Status: All MCP servers reachable"
+fi
+```
+
+### Step 8: Generate Report
+
+Output a single diagnostic report in this format:
+
+```markdown
+## Flow Doctor - {repo}
+
+### Environment
+
+| Check | Status | Details |
+|-------|--------|---------|
+| git | ✅ | v2.43.0 |
+| gh CLI | ✅ | v2.62.0 |
+| gh auth | ✅ | Logged in as {user} |
+| uv | ✅ | v0.5.14 |
+
+### Repository
+
+| Check | Status | Details |
+|-------|--------|---------|
+| Git repo | ✅ | codex-power-pack |
+| Remote | ✅ | github.com/cooneycw/codex-power-pack |
+| User identity | ✅ | {name} <{email}> |
+
+### Workflow Readiness
+
+| Check | Status | Details |
+|-------|--------|---------|
+| Makefile | ✅/⚠️/❌ | Targets: lint, test, deploy / Not found |
+| hooks.json | ✅/❌ | 3 hooks configured / Not found |
+| validate-command hook | ✅/❌ | ~/.codex/scripts/hook-validate-command.sh |
+| mask-output hook | ✅/❌ | ~/.codex/scripts/hook-mask-output.sh |
+| prompt-context.sh | ✅/❌ | Shell prompt context |
+| worktree-remove.sh | ✅/❌ | Safe worktree removal |
+| secrets-mask.sh | ✅/❌ | Output masking filter |
+
+### MCP Server Connectivity
+
+| Server | Port | Status | Details |
+|--------|------|--------|---------|
+| second-opinion | 8080 | ✅/⚠️/❌ | Reachable / Port open (no /health) / Not reachable |
+| playwright-persistent | 8081 | ✅/⚠️/❌ | Reachable / Port open (no /health) / Not reachable |
+
+### Active Worktrees
+
+| Worktree | Issue | Branch | Status |
+|----------|-------|--------|--------|
+| ../{repo}-issue-42 | #42 | issue-42-fix-auth | 3 dirty, 1 unpushed |
+| ../{repo}-issue-55 | #55 | issue-55-add-tests | Clean |
+
+*No worktrees* → "No active worktrees. Run `/flow:start <issue>` to begin."
+
+### GitHub Integration
+
+| Check | Status |
+|-------|--------|
+| List issues | ✅/❌ |
+| List PRs | ✅/❌ |
+
+### CI/CD & Verification
+
+*(Only shown when lib/cicd is available. If not available, show: "CI/CD Readiness: skipped (lib/cicd not available - install CPP for CI/CD features)")*
+
+| Check | Status | Details |
+|-------|--------|---------|
+| .codex/cicd.yml | ✅/❌ | Config file present / missing |
+| Framework detected | ✅ | Python (uv) / Node (npm) / etc. |
+| Makefile completeness | ✅/⚠️ | 6/7 targets (typecheck missing) |
+| Health endpoints | ✅/⚠️ | 2 configured / Not configured |
+| Smoke tests | ✅/⚠️ | 3 configured / Not configured |
+| CI pipeline | ✅/❌ | .woodpecker.yml / Not found |
+| Dockerfile | ⚠️ | Not configured (optional) |
+
+### Actions Needed
+
+(Only if there are failures or warnings)
+
+1. ❌ **Makefile missing** - Create a Makefile with `lint`, `test`, and `deploy` targets for `/flow:finish` and `/flow:deploy`. Run `/cicd:init` to auto-generate from a stack-specific template, or copy one manually:
+   - Python (uv): `cp ~/Projects/codex-power-pack/templates/makefiles/python-uv.mk Makefile`
+   - Python (pip): `cp ~/Projects/codex-power-pack/templates/makefiles/python-pip.mk Makefile`
+   - Django (uv): `cp ~/Projects/codex-power-pack/templates/makefiles/django-uv.mk Makefile`
+   - Node (npm): `cp ~/Projects/codex-power-pack/templates/makefiles/node-npm.mk Makefile`
+   - Node (yarn): `cp ~/Projects/codex-power-pack/templates/makefiles/node-yarn.mk Makefile`
+   - Go: `cp ~/Projects/codex-power-pack/templates/makefiles/go.mk Makefile`
+   - Rust: `cp ~/Projects/codex-power-pack/templates/makefiles/rust.mk Makefile`
+   - Monorepo: `cp ~/Projects/codex-power-pack/templates/makefiles/multi.mk Makefile`
+2. ❌ **worktree-remove.sh not found** - Run: `ln -sf ~/Projects/codex-power-pack/scripts/worktree-remove.sh ~/.codex/scripts/`
+3. ⚠️ **uv not installed** - Install: `curl -LsSf https://astral.sh/uv/install.sh | sh`
+4. ❌ **cicd.yml missing** - Run `/cicd:init` to auto-detect framework and generate configuration
+5. ⚠️ **Makefile gaps** - Run `/cicd:check` for details or `/cicd:init` to add missing targets
+6. ❌ **No CI pipeline** - Run `/cicd:pipeline` to generate Woodpecker CI config
+7. ⚠️ **No health endpoints** - Add `health.endpoints` to `.codex/cicd.yml` for post-deploy verification
+8. ⚠️ **No smoke tests** - Add `health.smoke_tests` to `.codex/cicd.yml` for post-deploy testing
+9. ⚠️ **MCP server(s) not reachable** - Start servers: `cd mcp-second-opinion && ./start-server.sh` (or use stdio transport)
+
+*All checks passed!* → "Environment is ready for `/flow` workflow."
+```
+
+## Status Symbols
+
+- ✅ = Check passed
+- ⚠️ = Optional/non-critical issue
+- ❌ = Required check failed - action needed
+
+## Notes
+
+- This is a read-only diagnostic - it never modifies anything
+- `uv` is recommended but not required (⚠️ if missing, not ❌)
+- Makefile is recommended but not required (⚠️ if missing)
+- Scripts and hooks are ❌ if missing since they provide security protection
+- Keep the report concise - one table per section, actions at the end

--- a/.codex/prompts/flow/finish.md
+++ b/.codex/prompts/flow/finish.md
@@ -1,0 +1,232 @@
+> Trigger parity entrypoint for `/flow:finish`.
+> Backing skill: `flow-finish` (`.codex/skills/flow-finish/SKILL.md`).
+
+# Flow: Finish - Quality Gates, Commit, Push, and Create PR
+
+Run quality checks, commit changes, push the branch, and create a pull request.
+
+## Instructions
+
+When the user invokes `/flow:finish`, perform these steps:
+
+### Step 1: Validate Context
+
+```bash
+# Ensure we're on a feature branch (not main)
+BRANCH=$(git branch --show-current)
+if [[ "$BRANCH" == "main" || "$BRANCH" == "master" ]]; then
+    echo "ERROR: Cannot finish from main/master. Switch to a feature branch or worktree."
+    exit 1
+fi
+
+# Extract issue number from branch
+ISSUE_NUM=$(echo "$BRANCH" | grep -oP 'issue-\K[0-9]+' || echo "")
+```
+
+### Step 2: Run Quality Gates via Deterministic Runner (primary path)
+
+**Primary path:** Use the deterministic CI/CD runner for reproducible quality gates:
+
+```bash
+# Locate CPP source for lib/cicd
+CPP_DIR=""
+for dir in ~/Projects/codex-power-pack /opt/codex-power-pack ~/.codex-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/AGENTS.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+
+if [ -n "$CPP_DIR" ]; then
+    PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd run --plan finish
+    RUNNER_EXIT=$?
+fi
+```
+
+- If runner **succeeds** (exit 0): quality gates passed, skip to Step 2d.
+- If runner **fails** (exit non-zero): parse the JSON output for the failed step, report it, and **stop**.
+- If runner is **not available** (no CPP_DIR or import error): fall back to manual execution below.
+
+**Fallback path** (only if runner unavailable):
+
+```bash
+if [[ -f "Makefile" ]]; then
+    # Run lint if target exists
+    if grep -q "^lint:" Makefile; then
+        echo "Running: make lint"
+        make lint
+    fi
+
+    # Run tests if target exists
+    if grep -q "^test:" Makefile; then
+        echo "Running: make test"
+        make test
+    fi
+fi
+```
+
+- If tests or lint fail, **stop and report**. Do not proceed to PR creation.
+- If no Makefile exists, skip quality gates (warn the user).
+
+### Step 2b: Run Security Quick Scan (fallback only - runner includes this)
+
+**Skip this step if the deterministic runner was used above** (it already includes security_scan).
+
+Only run manually if the runner was unavailable:
+
+```bash
+PYTHONPATH="${HOME}/Projects/codex-power-pack/lib" python3 -m lib.security gate flow_finish
+```
+
+- If the gate **fails** (critical findings): **stop and report**. Show findings and remediation.
+- If the gate produces **warnings** (high findings): display them but proceed.
+- If `lib/security` is not available, skip this step (warn the user).
+
+**Gate behavior by severity (defaults - configurable in `.codex/security.yml`):**
+
+| Severity | Effect on `/flow:finish` | What to do |
+|----------|--------------------------|------------|
+| CRITICAL | **BLOCKS** - flow stops, no PR created | Fix the finding, then re-run `/flow:finish` |
+| HIGH | **WARNS** - displayed, flow continues | Review finding; fix if real, suppress if false positive |
+| MEDIUM | Passes silently | No action needed |
+| LOW | Passes silently | No action needed |
+
+To suppress a known false positive, add it to `.codex/security.yml`:
+```yaml
+suppressions:
+  - id: HARDCODED_SECRET
+    path: tests/fixtures/.*
+    reason: "Test fixtures with fake credentials"
+```
+
+### Step 2d: Documentation Update Check (optional, non-blocking)
+
+If the Makefile has an `update_docs` target:
+
+```bash
+if [[ -f "Makefile" ]] && grep -q "^update_docs:" Makefile; then
+    echo "Running: make update_docs"
+    make update_docs
+fi
+```
+
+When this target exists, check documentation freshness:
+
+1. **C4 diagrams** - If `docs/architecture/` exists, check if C4 HTML files are older than recent code changes. If stale, warn:
+   ```
+   Docs may be stale - C4 diagrams last updated {date}, code changed since then.
+   Run /documentation:c4 to regenerate.
+   ```
+
+2. **AGENTS.md / README.md** - Scan for obviously stale references (e.g., commands that no longer exist, file paths that don't match). Report as non-blocking warnings.
+
+**This step never blocks the flow** - it is purely informational.
+
+### Step 2c: Makefile Completeness Check (optional, non-blocking)
+
+If `lib/cicd` is available, run a quick Makefile validation and report any gaps as warnings:
+
+```bash
+# Locate CPP source for lib/cicd
+CPP_DIR=""
+for dir in ~/Projects/codex-power-pack /opt/codex-power-pack ~/.codex-power-pack; do
+  if [ -d "$dir" ] && [ -f "$dir/AGENTS.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+```
+
+If `CPP_DIR` is found and a Makefile exists:
+
+```bash
+PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -m lib.cicd check --summary
+CHECK_EXIT=$?
+```
+
+- If check reports **missing required targets**: display as a warning but **do NOT block**.
+  ```
+  ⚠️  Makefile check: 1 required target missing (typecheck)
+      Run /cicd:check for details or /cicd:init to fix
+  ```
+- If check passes: report briefly - `"Makefile check: OK (6/6 targets present)"`
+- If `lib/cicd` is not available: skip silently
+- If no Makefile exists: skip silently (Step 2 already handles this)
+
+**This step never blocks the flow** - it is purely informational.
+
+### Step 3: Check for Changes
+
+```bash
+# Check for uncommitted changes
+git status --porcelain
+```
+
+- If there are uncommitted changes, help the user commit them using standard git commit workflow.
+- Use conventional commit format: `type(scope): Description (Closes #N)`
+- Include a `Co-Authored-By` trailer when required by team policy.
+
+### Step 4: Push Branch
+
+```bash
+# Push with tracking
+git push -u origin "$BRANCH"
+```
+
+### Step 5: Check for Existing PR
+
+```bash
+EXISTING_PR=$(gh pr list --head "$BRANCH" --json number,url --jq '.[0]' 2>/dev/null)
+```
+
+- If a PR already exists, report its URL and ask if the user wants to update it.
+- If no PR exists, proceed to create one.
+
+### Step 6: Create PR
+
+Use standard PR creation:
+
+```bash
+gh pr create \
+  --title "type(scope): Description (Closes #ISSUE_NUM)" \
+  --body "## Summary
+- <bullet points>
+
+## Test plan
+- [ ] Tests pass
+- [ ] Linting passes
+
+Closes #ISSUE_NUM"
+```
+
+- Title: Conventional commit style, derived from changes
+- Body: Summary of changes + test plan + `Closes #N`
+- Analyze all commits on the branch to draft the summary
+
+### Step 7: Output
+
+```
+Quality gates passed:
+  ✅ make lint
+  ✅ make test
+  ✅ security scan (quick)
+
+Branch pushed: issue-42-fix-login → origin
+
+PR created: https://github.com/owner/repo/pull/78
+  Title: fix(auth): Resolve login redirect loop (Closes #42)
+```
+
+## Error Handling
+
+- **Lint/test failure:** Stop, show output, ask user to fix
+- **Push failure:** Report error (likely needs `git pull --rebase`)
+- **PR already exists:** Report URL, offer to update
+- **No issue number in branch:** Create PR without `Closes #N` reference
+- **No Makefile:** Skip quality gates, warn user
+
+## Notes
+
+- Quality gates are optional - if no Makefile exists, the flow still works
+- The commit step follows standard git commit conventions (the user controls the message)
+- This command works from any worktree directory

--- a/.codex/prompts/flow/help.md
+++ b/.codex/prompts/flow/help.md
@@ -1,0 +1,119 @@
+> Trigger parity entrypoint for `/flow:help`.
+> Backing skill: `flow-help` (`.codex/skills/flow-help/SKILL.md`).
+
+# Flow Commands
+
+Streamlined worktree-based development workflow. No locks, no Redis - just git.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/flow:start <issue>` | Create worktree and branch from a GitHub issue |
+| `/flow:status` | Show all active worktrees with issue/PR state |
+| `/flow:check` | Run quality checks (lint, test, security) without committing |
+| `/flow:finish` | Run quality gates, commit, push, and create PR |
+| `/flow:merge` | Merge PR, clean up worktree and branch |
+| `/flow:deploy [target]` | Run Makefile deploy target |
+| `/flow:sync` | Push WIP branch to remote for cross-machine pickup |
+| `/flow:auto <issue>` | Full lifecycle: start → analyze → implement → update docs → finish → merge → deploy |
+| `/flow:cleanup` | Prune stale worktree references and delete merged branches |
+| `/flow:doctor` | Diagnose workflow environment and readiness |
+| `/flow:help` | This help page |
+
+## The Golden Path
+
+```
+/flow:auto 42
+  ↓
+  start → analyze → implement → update docs → finish → merge → deploy
+```
+
+Or step by step:
+```
+/flow:start 42  →  work  →  /flow:check  →  /flow:finish  →  /flow:merge  →  /flow:deploy
+```
+
+Cross-machine (optional):
+```
+Machine A: /flow:start 42  →  work  →  /flow:sync
+Machine B: /flow:start 42  →  picks up remote branch  →  continue working
+```
+
+## Security Gates
+
+`/flow:finish` and `/flow:deploy` run automatic security scans as quality gates. Gate behavior is controlled by `.codex/security.yml`:
+
+| Severity | `/flow:finish` (default) | `/flow:deploy` (default) |
+|----------|--------------------------|--------------------------|
+| CRITICAL | **Blocks** - must fix before PR | **Blocks** - must fix before deploy |
+| HIGH | **Warns** - shows findings, proceeds | **Blocks** - must fix before deploy |
+| MEDIUM | Passes | **Warns** - shows findings, proceeds |
+| LOW | Passes | Passes |
+
+**What happens when blocked:**
+- The flow stops and displays all blocking findings with remediation hints
+- You fix the issue, then re-run `/flow:finish` or `/flow:deploy`
+- To suppress known false positives, add entries to `.codex/security.yml` `suppressions:`
+
+**Configuration** (`.codex/security.yml`):
+```yaml
+gates:
+  flow_finish:
+    block_on: [critical]       # Severities that stop the flow
+    warn_on: [high]            # Severities shown as warnings
+  flow_deploy:
+    block_on: [critical, high]
+    warn_on: [medium]
+suppressions:
+  - id: HARDCODED_SECRET       # Finding type to suppress
+    path: tests/fixtures/.*    # Regex for file path (optional)
+    reason: "Test fixtures with fake credentials"
+```
+
+If no `.codex/security.yml` exists, the defaults above are used. If `lib/security` is not available, the gate is skipped with a warning.
+
+## Conventions
+
+- **Worktree directory:** `../{repo}-issue-{N}` (sibling to main repo)
+- **Branch name:** `issue-{N}-{slug}` (derived from issue title)
+- **Commit style:** `type(scope): Description (Closes #N)`
+- **All context is derived from git** - no external state tracking
+
+## Quick Examples
+
+```bash
+# Start working on issue #42
+/flow:start 42
+# → Creates worktree ../my-project-issue-42
+# → Branch: issue-42-fix-login-bug
+
+# Check what's active
+/flow:status
+# → Shows worktrees, dirty state, PR status
+
+# Pre-flight check (lint + test + security, no commit)
+/flow:check
+# → Reports pass/fail per check
+
+# Done coding - push and create PR
+/flow:finish
+# → Runs make test/lint if available
+# → Commits, pushes, creates PR
+
+# PR approved - merge and clean up
+/flow:merge
+# → Merges PR, deletes branch, removes worktree
+
+# Deploy to production
+/flow:deploy
+# → Runs make deploy
+
+# Sync WIP to remote (for cross-machine work)
+/flow:sync
+# → Auto-commits WIP, pushes branch to origin
+
+# Or do it all in one shot (start to deploy):
+/flow:auto 42
+# → start → analyze → implement → finish → merge → deploy
+```

--- a/.codex/prompts/flow/merge.md
+++ b/.codex/prompts/flow/merge.md
@@ -1,0 +1,168 @@
+> Trigger parity entrypoint for `/flow:merge`.
+> Backing skill: `flow-merge` (`.codex/skills/flow-merge/SKILL.md`).
+
+# Flow: Merge PR and Clean Up
+
+Merge the current branch's PR, then clean up the worktree and branch.
+
+## Instructions
+
+When the user invokes `/flow:merge`, perform these steps:
+
+### Step 1: Detect Context
+
+```bash
+BRANCH=$(git branch --show-current)
+REPO=$(basename "$(git rev-parse --show-toplevel)")
+
+# Extract issue number
+ISSUE_NUM=$(echo "$BRANCH" | grep -oP 'issue-\K[0-9]+' || echo "")
+
+# Detect if we're in a worktree
+WORKTREE_PATH=$(pwd)
+IS_WORKTREE=false
+if [[ -f ".git" ]]; then
+    IS_WORKTREE=true
+fi
+```
+
+### Step 2: Find and Verify PR
+
+```bash
+PR_JSON=$(gh pr list --head "$BRANCH" --json number,state,mergeable,reviewDecision,statusCheckRollup --jq '.[0]')
+```
+
+- If no PR found: "No PR found for branch `$BRANCH`. Run `/flow:finish` first."
+- If PR is already merged: "PR is already merged. Run cleanup only? [y/N]"
+- Report PR state: checks passing, review status, mergeable
+
+### Step 3: Merge the PR
+
+```bash
+PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+
+# Squash merge (default) - keeps history clean
+gh pr merge "$PR_NUMBER" --squash --delete-branch
+```
+
+- Use `--squash` by default (clean history)
+- `--delete-branch` removes the remote branch automatically
+- If merge fails (conflicts, checks failing), report and stop
+
+### Step 4: Update Local Main
+
+Determine the main repo path:
+
+```bash
+if [[ "$IS_WORKTREE" == true ]]; then
+    # Get main repo path from worktree .git file
+    MAIN_REPO=$(cat .git | sed 's/gitdir: //' | sed 's|/.git/worktrees/.*||')
+else
+    MAIN_REPO=$(pwd)
+fi
+
+# Pull latest main
+git -C "$MAIN_REPO" checkout main
+git -C "$MAIN_REPO" pull origin main
+```
+
+### Step 5: Clean Up Worktree
+
+**CRITICAL: You MUST `cd` to the main repo BEFORE removing the worktree. NEVER remove a worktree while your working directory is inside it - this destroys your CWD and kills all subsequent bash commands. Execute these as SEPARATE Bash calls.**
+
+If we're in a worktree (`IS_WORKTREE=true`):
+
+**Step 5a - Exit the worktree (separate Bash call):**
+```bash
+cd "$MAIN_REPO"
+pwd  # Verify you are in the main repo, NOT the worktree
+```
+
+**Step 5b - Remove the worktree (separate Bash call, AFTER confirming cd succeeded):**
+```bash
+if [[ -f ~/.codex/scripts/worktree-remove.sh ]]; then
+    ~/.codex/scripts/worktree-remove.sh "$WORKTREE_PATH" --force --delete-branch
+else
+    git worktree remove "$WORKTREE_PATH" --force
+    git branch -D "$BRANCH" 2>/dev/null || true
+fi
+```
+
+**Step 5c - Verify working directory is valid:**
+```bash
+pwd  # MUST show main repo path, NOT the deleted worktree
+git status  # MUST succeed - if this fails, your CWD was deleted
+```
+
+If we're in the main repo (not a worktree):
+```bash
+# Just delete the local branch
+git branch -D "$BRANCH" 2>/dev/null || true
+```
+
+### Step 6: Close Issue (if linked)
+
+```bash
+if [[ -n "$ISSUE_NUM" ]]; then
+    # Check if issue is still open (gh pr merge with Closes # may have closed it)
+    ISSUE_STATE=$(gh issue view "$ISSUE_NUM" --json state --jq '.state' 2>/dev/null)
+    if [[ "$ISSUE_STATE" == "OPEN" ]]; then
+        gh issue close "$ISSUE_NUM" --comment "Closed via /flow:merge - PR #${PR_NUMBER} merged."
+    fi
+fi
+```
+
+### Step 7: Prune Stale Branches
+
+After merge cleanup, prune any other stale references:
+
+```bash
+# Prune stale worktree references (folders deleted but git still tracking)
+git -C "$MAIN_REPO" worktree prune
+
+# Delete local issue-* branches that are fully merged to main
+MERGED=$(git -C "$MAIN_REPO" branch --merged main | grep -v '^\*' | grep -v 'main$' | grep -v 'master$' | sed 's/^[ ]*//')
+# Protect branches with active worktrees
+WORKTREE_BRANCHES=$(git -C "$MAIN_REPO" worktree list --porcelain | grep "^branch " | sed 's|branch refs/heads/||')
+for b in $MERGED; do
+    echo "$WORKTREE_BRANCHES" | grep -q "^${b}$" && continue
+    git -C "$MAIN_REPO" branch -d "$b" 2>/dev/null && echo "Deleted merged branch: $b"
+done
+
+# Prune stale remote tracking branches
+git -C "$MAIN_REPO" fetch --prune
+```
+
+### Step 8: Output
+
+```
+PR #78 merged (squash) ✅
+
+Cleanup:
+  ✅ Remote branch deleted: issue-42-fix-login
+  ✅ Worktree removed: ../my-project-issue-42
+  ✅ Local branch deleted: issue-42-fix-login
+  ✅ Issue #42 closed
+  ✅ Pruned stale worktree references
+  ✅ Deleted 2 merged local branches
+  ✅ Pruned stale remote tracking branches
+
+Current directory: /home/user/Projects/my-project (main)
+```
+
+## Error Handling
+
+- **PR not found:** Direct user to `/flow:finish`
+- **Merge conflicts:** Report conflict, suggest manual resolution
+- **Checks failing:** Report which checks failed, ask if user wants to wait or force
+- **Inside worktree being removed:** `worktree-remove.sh` handles this safely
+- **Issue already closed:** Skip close step silently
+
+## Notes
+
+- Squash merge is the default - produces clean single-commit history
+- The remote branch is deleted by `gh pr merge --delete-branch`
+- The worktree removal uses the safe `worktree-remove.sh` script when available
+- After merge, the user ends up in the main repo on the `main` branch
+- Automatically prunes stale worktree references, merged branches, and remote tracking branches
+- For a standalone cleanup (without merging), use `/flow:cleanup`

--- a/.codex/prompts/flow/start.md
+++ b/.codex/prompts/flow/start.md
@@ -1,0 +1,107 @@
+> Trigger parity entrypoint for `/flow:start`.
+> Backing skill: `flow-start` (`.codex/skills/flow-start/SKILL.md`).
+
+# Flow: Start Working on an Issue
+
+Create a worktree and branch for a GitHub issue. Stateless - all context from git and GitHub.
+
+## Arguments
+
+- `ISSUE` (required): GitHub issue number (e.g., `42`)
+
+## Instructions
+
+When the user invokes `/flow:start <ISSUE>`, perform these steps:
+
+### Step 1: Validate Prerequisites
+
+```bash
+# Ensure gh is authenticated
+gh auth status
+
+# Ensure we're in a git repo
+git rev-parse --show-toplevel
+```
+
+### Step 2: Fetch Issue Details
+
+```bash
+ISSUE_NUM="$1"
+gh issue view "$ISSUE_NUM" --json number,title,state,body
+```
+
+- If issue is not OPEN, warn the user and ask whether to proceed
+- Extract the title for branch naming
+
+### Step 3: Derive Branch and Worktree Names
+
+```bash
+REPO=$(basename "$(git rev-parse --show-toplevel)")
+
+# Sanitize title: lowercase, replace non-alphanum with hyphens, truncate
+SLUG=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-50)
+
+BRANCH="issue-${ISSUE_NUM}-${SLUG}"
+WORKTREE_DIR="../${REPO}-issue-${ISSUE_NUM}"
+```
+
+### Step 4: Check for Existing Work
+
+```bash
+# Check if worktree already exists
+git worktree list | grep "issue-${ISSUE_NUM}"
+
+# Check if remote branch exists (cross-machine pickup)
+git fetch origin
+git branch -r | grep "issue-${ISSUE_NUM}-"
+```
+
+- **If worktree exists:** Inform user of the path. Do not recreate. `cd` into the existing worktree.
+- **If remote branch exists (no local worktree):** Create worktree tracking the remote branch, then `cd` into it:
+  ```bash
+  REMOTE_BRANCH=$(git branch -r | grep "issue-${ISSUE_NUM}-" | head -1 | xargs)
+  LOCAL_BRANCH="${REMOTE_BRANCH#origin/}"
+  git worktree add -b "$LOCAL_BRANCH" "$WORKTREE_DIR" "$REMOTE_BRANCH"
+  cd "$WORKTREE_DIR"
+  ```
+- **If neither exists:** Create fresh, then `cd` into it:
+  ```bash
+  git fetch origin main
+  git worktree add -b "$BRANCH" "$WORKTREE_DIR" origin/main
+  cd "$WORKTREE_DIR"
+  ```
+
+### Step 5: Verify and Output
+
+**CRITICAL: Verify you are in the worktree, not on main/master.**
+
+```bash
+CURRENT_BRANCH=$(git branch --show-current)
+if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "master" ]]; then
+    echo "ERROR: Still on main/master. Worktree creation or cd failed."
+    exit 1
+fi
+echo "Verified: on branch '$CURRENT_BRANCH' in $(pwd)"
+```
+
+Report to the user:
+
+```
+Created worktree for issue #42: "Fix login bug"
+
+  Directory: ../my-project-issue-42
+  Branch:    issue-42-fix-login-bug
+  Verified:  Working directory is now the worktree (not main)
+```
+
+## Error Handling
+
+- **Issue not found:** `gh issue view` fails → report "Issue #N not found"
+- **Issue closed:** Warn but allow user to proceed (they may want to reopen)
+- **Worktree exists:** Report existing path, do not error
+- **Branch name collision:** Append short hash if needed
+- **Not in a git repo:** Report error clearly
+
+## Idempotency
+
+Running `/flow:start 42` when the worktree already exists should detect it and report the path, not error or create a duplicate.

--- a/.codex/prompts/flow/status.md
+++ b/.codex/prompts/flow/status.md
@@ -1,0 +1,101 @@
+> Trigger parity entrypoint for `/flow:status`.
+> Backing skill: `flow-status` (`.codex/skills/flow-status/SKILL.md`).
+
+# Flow: Status of Active Worktrees
+
+Show all active worktrees with their issue, branch, dirty state, and PR status.
+
+## Instructions
+
+When the user invokes `/flow:status`, perform these steps:
+
+### Step 1: Detect Repository
+
+```bash
+REPO=$(basename "$(git rev-parse --show-toplevel)")
+```
+
+### Step 2: List Worktrees
+
+```bash
+git worktree list
+```
+
+### Step 3: For Each Worktree, Gather State
+
+For each worktree (skip the main repo entry):
+
+```bash
+# Get branch name
+BRANCH=$(git -C "$WORKTREE_PATH" branch --show-current 2>/dev/null)
+
+# Extract issue number from branch name (issue-N-*)
+ISSUE_NUM=$(echo "$BRANCH" | grep -oP 'issue-\K[0-9]+' || echo "")
+
+# Check for uncommitted changes
+DIRTY=$(git -C "$WORKTREE_PATH" status --porcelain 2>/dev/null | wc -l)
+
+# Check for unpushed commits
+UNPUSHED=$(git -C "$WORKTREE_PATH" rev-list --count origin/main..HEAD 2>/dev/null || echo "0")
+
+# Check PR status (if branch is pushed)
+if [[ -n "$BRANCH" ]]; then
+    PR_INFO=$(gh pr list --head "$BRANCH" --json number,url,state --jq '.[0]' 2>/dev/null || echo "")
+fi
+```
+
+### Step 4: Fetch Issue Titles
+
+For each detected issue number:
+```bash
+ISSUE_TITLE=$(gh issue view "$ISSUE_NUM" --json title --jq '.title' 2>/dev/null || echo "Unknown")
+```
+
+### Step 5: Output
+
+```markdown
+## Flow Status - {repo}
+
+| Worktree | Issue | Branch | Status | PR |
+|----------|-------|--------|--------|----|
+| ../{repo}-issue-42 | #42 Fix login bug | issue-42-fix-login | 3 dirty files, 2 unpushed | - |
+| ../{repo}-issue-55 | #55 Add tests | issue-55-add-tests | Clean | PR #78 (OPEN) |
+
+### Suggestions
+- **#42**: Has uncommitted work - commit or stash before switching
+- **#55**: PR is open - check for reviews, then `/flow:merge`
+```
+
+### Step 6: Detect Stale Branches
+
+Check for local branches that may need cleanup:
+
+```bash
+# Count local issue-* branches with no active worktree
+WORKTREE_BRANCHES=$(git worktree list --porcelain | grep "^branch " | sed 's|branch refs/heads/||')
+STALE_COUNT=0
+for branch in $(git branch | grep 'issue-' | sed 's/^[ *]*//'); do
+    echo "$WORKTREE_BRANCHES" | grep -q "^${branch}$" && continue
+    STALE_COUNT=$((STALE_COUNT + 1))
+done
+
+# Check for prunable worktree references
+PRUNABLE=$(git worktree list --porcelain | grep -c "prunable" || echo "0")
+```
+
+If stale branches or prunable references exist, append to output:
+
+```markdown
+### Cleanup Available
+- {N} local issue branches with no active worktree
+- {M} stale worktree references
+
+Run `/flow:cleanup` to remove stale branches and references.
+```
+
+## Notes
+
+- Worktrees on `main` or non-issue branches are listed but marked as "(not issue-linked)"
+- If no worktrees exist besides main, report "No active worktrees. Run `/flow:start <issue>` to begin."
+- Keep output concise - this is a quick status check
+- Stale branch detection helps identify cleanup opportunities

--- a/.codex/prompts/flow/sync.md
+++ b/.codex/prompts/flow/sync.md
@@ -1,0 +1,80 @@
+> Trigger parity entrypoint for `/flow:sync`.
+> Backing skill: `flow-sync` (`.codex/skills/flow-sync/SKILL.md`).
+
+# Flow: Sync - Push WIP to Remote for Cross-Machine Pickup
+
+Push the current branch to the remote so you can continue work on another machine. Optional feature - most users won't need this.
+
+## Arguments
+
+None. Operates on the current worktree/branch.
+
+## Instructions
+
+When the user invokes `/flow:sync`, perform these steps:
+
+### Step 1: Validate Context
+
+```bash
+# Ensure we're in a git repo
+git rev-parse --show-toplevel
+
+# Get current branch
+BRANCH=$(git branch --show-current)
+```
+
+- If on `main` or `master`: **STOP**. Report: "Cannot sync main branch. Use `/flow:start <issue>` to create a worktree first."
+- If not on an `issue-*` branch: Warn but allow (user may have custom branch names).
+
+### Step 2: Check for Uncommitted Changes
+
+```bash
+# Check working tree status
+git status --short
+```
+
+- **If clean:** Skip to Step 3.
+- **If dirty (uncommitted changes):** Auto-commit as WIP:
+  ```bash
+  git add -A
+  git commit -m "wip: sync work in progress
+
+  Auto-committed by /flow:sync for cross-machine pickup.
+  This commit will be squash-merged - no need to clean up."
+  ```
+  Report: "Auto-committed WIP changes."
+
+### Step 3: Push to Remote
+
+```bash
+git push -u origin "$BRANCH"
+```
+
+- If push fails (e.g., rejected): Report the error and suggest `git pull --rebase origin "$BRANCH"` to resolve.
+
+### Step 4: Output
+
+```
+Synced branch to remote.
+
+  Branch: issue-42-fix-login-bug
+  Remote: origin
+
+  To continue on another machine:
+    /flow:start 42
+    → Detects remote branch and creates worktree from it
+```
+
+## Error Handling
+
+- **Not in a git repo:** Report error clearly.
+- **On main branch:** Block sync, suggest `/flow:start`.
+- **Push rejected:** Suggest `git pull --rebase` to reconcile.
+- **No remote configured:** Report "No remote 'origin' found."
+
+## Notes
+
+- This command is intentionally simple - just commit WIP + push.
+- `/flow:start` already handles the receiving end (detects remote branches and creates worktrees tracking them).
+- WIP commits are harmless because `/flow:merge` uses squash-merge, collapsing all commits into one clean commit.
+- No configuration required - works with any git remote.

--- a/.codex/skills/flow-auto/SKILL.md
+++ b/.codex/skills/flow-auto/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: flow-auto
+description: Trigger `/flow:auto`.
+---
+
+# flow-auto
+
+## Trigger
+- Primary: `/flow:auto`
+- Text alias: `flow:auto`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/flow/auto.md`
+
+## Execution
+1. Use this skill when the user invokes `/flow:auto` or explicitly asks for the flow `auto` workflow.
+2. Follow the workflow steps in `.codex/prompts/flow/auto.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/flow-auto/agents/openai.yaml
+++ b/.codex/skills/flow-auto/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "flow:auto"
+  short_description: "Trigger /flow:auto"
+  default_prompt: "/flow:auto"

--- a/.codex/skills/flow-check/SKILL.md
+++ b/.codex/skills/flow-check/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: flow-check
+description: Trigger `/flow:check`.
+---
+
+# flow-check
+
+## Trigger
+- Primary: `/flow:check`
+- Text alias: `flow:check`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/flow/check.md`
+
+## Execution
+1. Use this skill when the user invokes `/flow:check` or explicitly asks for the flow `check` workflow.
+2. Follow the workflow steps in `.codex/prompts/flow/check.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/flow-check/agents/openai.yaml
+++ b/.codex/skills/flow-check/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "flow:check"
+  short_description: "Trigger /flow:check"
+  default_prompt: "/flow:check"

--- a/.codex/skills/flow-cleanup/SKILL.md
+++ b/.codex/skills/flow-cleanup/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: flow-cleanup
+description: Trigger `/flow:cleanup`.
+---
+
+# flow-cleanup
+
+## Trigger
+- Primary: `/flow:cleanup`
+- Text alias: `flow:cleanup`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/flow/cleanup.md`
+
+## Execution
+1. Use this skill when the user invokes `/flow:cleanup` or explicitly asks for the flow `cleanup` workflow.
+2. Follow the workflow steps in `.codex/prompts/flow/cleanup.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/flow-cleanup/agents/openai.yaml
+++ b/.codex/skills/flow-cleanup/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "flow:cleanup"
+  short_description: "Trigger /flow:cleanup"
+  default_prompt: "/flow:cleanup"

--- a/.codex/skills/flow-deploy/SKILL.md
+++ b/.codex/skills/flow-deploy/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: flow-deploy
+description: Trigger `/flow:deploy`.
+---
+
+# flow-deploy
+
+## Trigger
+- Primary: `/flow:deploy`
+- Text alias: `flow:deploy`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/flow/deploy.md`
+
+## Execution
+1. Use this skill when the user invokes `/flow:deploy` or explicitly asks for the flow `deploy` workflow.
+2. Follow the workflow steps in `.codex/prompts/flow/deploy.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/flow-deploy/agents/openai.yaml
+++ b/.codex/skills/flow-deploy/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "flow:deploy"
+  short_description: "Trigger /flow:deploy"
+  default_prompt: "/flow:deploy"

--- a/.codex/skills/flow-doctor/SKILL.md
+++ b/.codex/skills/flow-doctor/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: flow-doctor
+description: Trigger `/flow:doctor`.
+---
+
+# flow-doctor
+
+## Trigger
+- Primary: `/flow:doctor`
+- Text alias: `flow:doctor`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/flow/doctor.md`
+
+## Execution
+1. Use this skill when the user invokes `/flow:doctor` or explicitly asks for the flow `doctor` workflow.
+2. Follow the workflow steps in `.codex/prompts/flow/doctor.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/flow-doctor/agents/openai.yaml
+++ b/.codex/skills/flow-doctor/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "flow:doctor"
+  short_description: "Trigger /flow:doctor"
+  default_prompt: "/flow:doctor"

--- a/.codex/skills/flow-finish/SKILL.md
+++ b/.codex/skills/flow-finish/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: flow-finish
+description: Trigger `/flow:finish`.
+---
+
+# flow-finish
+
+## Trigger
+- Primary: `/flow:finish`
+- Text alias: `flow:finish`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/flow/finish.md`
+
+## Execution
+1. Use this skill when the user invokes `/flow:finish` or explicitly asks for the flow `finish` workflow.
+2. Follow the workflow steps in `.codex/prompts/flow/finish.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/flow-finish/agents/openai.yaml
+++ b/.codex/skills/flow-finish/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "flow:finish"
+  short_description: "Trigger /flow:finish"
+  default_prompt: "/flow:finish"

--- a/.codex/skills/flow-help/SKILL.md
+++ b/.codex/skills/flow-help/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: flow-help
+description: Trigger `/flow:help`.
+---
+
+# flow-help
+
+## Trigger
+- Primary: `/flow:help`
+- Text alias: `flow:help`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/flow/help.md`
+
+## Execution
+1. Use this skill when the user invokes `/flow:help` or explicitly asks for the flow `help` workflow.
+2. Follow the workflow steps in `.codex/prompts/flow/help.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/flow-help/agents/openai.yaml
+++ b/.codex/skills/flow-help/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "flow:help"
+  short_description: "Trigger /flow:help"
+  default_prompt: "/flow:help"

--- a/.codex/skills/flow-merge/SKILL.md
+++ b/.codex/skills/flow-merge/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: flow-merge
+description: Trigger `/flow:merge`.
+---
+
+# flow-merge
+
+## Trigger
+- Primary: `/flow:merge`
+- Text alias: `flow:merge`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/flow/merge.md`
+
+## Execution
+1. Use this skill when the user invokes `/flow:merge` or explicitly asks for the flow `merge` workflow.
+2. Follow the workflow steps in `.codex/prompts/flow/merge.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/flow-merge/agents/openai.yaml
+++ b/.codex/skills/flow-merge/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "flow:merge"
+  short_description: "Trigger /flow:merge"
+  default_prompt: "/flow:merge"

--- a/.codex/skills/flow-start/SKILL.md
+++ b/.codex/skills/flow-start/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: flow-start
+description: Trigger `/flow:start`.
+---
+
+# flow-start
+
+## Trigger
+- Primary: `/flow:start`
+- Text alias: `flow:start`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/flow/start.md`
+
+## Execution
+1. Use this skill when the user invokes `/flow:start` or explicitly asks for the flow `start` workflow.
+2. Follow the workflow steps in `.codex/prompts/flow/start.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/flow-start/agents/openai.yaml
+++ b/.codex/skills/flow-start/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "flow:start"
+  short_description: "Trigger /flow:start"
+  default_prompt: "/flow:start"

--- a/.codex/skills/flow-status/SKILL.md
+++ b/.codex/skills/flow-status/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: flow-status
+description: Trigger `/flow:status`.
+---
+
+# flow-status
+
+## Trigger
+- Primary: `/flow:status`
+- Text alias: `flow:status`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/flow/status.md`
+
+## Execution
+1. Use this skill when the user invokes `/flow:status` or explicitly asks for the flow `status` workflow.
+2. Follow the workflow steps in `.codex/prompts/flow/status.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/flow-status/agents/openai.yaml
+++ b/.codex/skills/flow-status/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "flow:status"
+  short_description: "Trigger /flow:status"
+  default_prompt: "/flow:status"

--- a/.codex/skills/flow-sync/SKILL.md
+++ b/.codex/skills/flow-sync/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: flow-sync
+description: Trigger `/flow:sync`.
+---
+
+# flow-sync
+
+## Trigger
+- Primary: `/flow:sync`
+- Text alias: `flow:sync`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/flow/sync.md`
+
+## Execution
+1. Use this skill when the user invokes `/flow:sync` or explicitly asks for the flow `sync` workflow.
+2. Follow the workflow steps in `.codex/prompts/flow/sync.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/flow-sync/agents/openai.yaml
+++ b/.codex/skills/flow-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "flow:sync"
+  short_description: "Trigger /flow:sync"
+  default_prompt: "/flow:sync"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,4 +35,5 @@
 ## Notes
 
 - CI/CD slash trigger parity is mapped in `docs/skills/cicd-command-skill-map.md`.
+- Flow slash trigger parity is mapped in `docs/skills/flow-command-skill-map.md`.
 - AGENTS.md governance trigger parity is mapped in `docs/skills/agents-md-command-skill-map.md`.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ The `/cicd:*` namespace is available through:
 - `.codex/skills/cicd-*/` - backing Codex skill packages
 - `docs/skills/cicd-command-skill-map.md` - trigger-to-skill inventory
 
+## Flow Trigger Parity
+
+The `/flow:*` namespace is available through:
+
+- `.claude/commands/flow/*.md` - source command inventory
+- `.codex/prompts/flow/*.md` - slash-compatible entrypoints
+- `.codex/skills/flow-*/` - backing Codex skill packages
+- `docs/skills/flow-command-skill-map.md` - trigger-to-skill inventory
+
 ## AGENTS.md Trigger Parity
 
 The `/agents-md:*` namespace is available through:

--- a/docs/skills/flow-command-skill-map.md
+++ b/docs/skills/flow-command-skill-map.md
@@ -1,0 +1,19 @@
+# Flow Trigger to Skill Map
+
+This file maps flow triggers to Codex prompts and skill packages.
+
+| Trigger | Prompt Entrypoint | Skill Package |
+|---|---|---|
+| `/flow:auto` | `.codex/prompts/flow/auto.md` | `.codex/skills/flow-auto/SKILL.md` |
+| `/flow:check` | `.codex/prompts/flow/check.md` | `.codex/skills/flow-check/SKILL.md` |
+| `/flow:cleanup` | `.codex/prompts/flow/cleanup.md` | `.codex/skills/flow-cleanup/SKILL.md` |
+| `/flow:deploy` | `.codex/prompts/flow/deploy.md` | `.codex/skills/flow-deploy/SKILL.md` |
+| `/flow:doctor` | `.codex/prompts/flow/doctor.md` | `.codex/skills/flow-doctor/SKILL.md` |
+| `/flow:finish` | `.codex/prompts/flow/finish.md` | `.codex/skills/flow-finish/SKILL.md` |
+| `/flow:help` | `.codex/prompts/flow/help.md` | `.codex/skills/flow-help/SKILL.md` |
+| `/flow:merge` | `.codex/prompts/flow/merge.md` | `.codex/skills/flow-merge/SKILL.md` |
+| `/flow:start` | `.codex/prompts/flow/start.md` | `.codex/skills/flow-start/SKILL.md` |
+| `/flow:status` | `.codex/prompts/flow/status.md` | `.codex/skills/flow-status/SKILL.md` |
+| `/flow:sync` | `.codex/prompts/flow/sync.md` | `.codex/skills/flow-sync/SKILL.md` |
+
+Canonical inventory: `.claude/commands/flow/*.md`, `.codex/prompts/flow/*.md`, and `.codex/skills/flow-*/`.

--- a/tests/test_flow_skill_trigger_parity.py
+++ b/tests/test_flow_skill_trigger_parity.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_DIR = ROOT / ".claude" / "commands" / "flow"
+PROMPT_DIR = ROOT / ".codex" / "prompts" / "flow"
+SKILLS_DIR = ROOT / ".codex" / "skills"
+
+
+def _source_commands() -> set[str]:
+    return {path.stem for path in SOURCE_DIR.glob("*.md")}
+
+
+def _target_prompts() -> set[str]:
+    return {path.stem for path in PROMPT_DIR.glob("*.md")}
+
+
+def test_flow_prompt_trigger_parity_with_source_commands() -> None:
+    assert _target_prompts() == _source_commands()
+
+
+def test_every_flow_prompt_has_backing_skill_package() -> None:
+    for command in sorted(_source_commands()):
+        trigger = f"/flow:{command}"
+        skill_name = f"flow-{command}"
+
+        skill_md = SKILLS_DIR / skill_name / "SKILL.md"
+        agent_yaml = SKILLS_DIR / skill_name / "agents" / "openai.yaml"
+        prompt_md = PROMPT_DIR / f"{command}.md"
+
+        assert skill_md.exists(), f"Missing skill file for {trigger}: {skill_md}"
+        assert agent_yaml.exists(), f"Missing agents metadata for {trigger}: {agent_yaml}"
+
+        prompt_text = prompt_md.read_text()
+        skill_text = skill_md.read_text()
+
+        assert f"Backing skill: `{skill_name}`" in prompt_text
+        assert trigger in skill_text
+        assert f".codex/prompts/flow/{command}.md" in skill_text


### PR DESCRIPTION
## Summary
- port all 11 /flow:* trigger entrypoints into .codex/prompts/flow/*.md
- add matching backing skill packages under .codex/skills/flow-* with trigger aliases and OpenAI metadata
- add flow trigger inventory docs and a parity test that enforces source command parity with skill coverage
- update repository discoverability docs for the flow namespace

## Testing
- env UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_flow_skill_trigger_parity.py tests/test_cicd_skill_trigger_parity.py tests/test_agents_md_skill_trigger_parity.py

Closes #7