### PR TITLE
feat(github): port github namespace to codex skills (Closes #8)

### DIFF
--- a/.codex/prompts/github/help.md
+++ b/.codex/prompts/github/help.md
@@ -1,0 +1,62 @@
+---
+description: Overview of all GitHub issue management commands
+---
+
+> Trigger parity entrypoint for `/github:help`.
+> Backing skill: `github-help` (`.codex/skills/github-help/SKILL.md`).
+
+
+# GitHub Issue Management Commands
+
+Manage issues in the codex-power-pack repository directly from Codex.
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `/github:issue-create` | Create a new issue with guided prompts |
+| `/github:issue-list` | List and search issues |
+| `/github:issue-view` | View issue details and comments |
+| `/github:issue-update` | Update an existing issue |
+| `/github:issue-close` | Close an issue |
+
+## Quick Examples
+
+### Create an issue
+```
+/github:issue-create
+```
+Then follow the prompts to select issue type and provide details.
+
+### List open issues
+```
+/github:issue-list
+```
+
+### View a specific issue
+```
+/github:issue-view 42
+```
+
+### Close an issue with comment
+```
+/github:issue-close 42
+```
+
+## Issue Types
+
+When creating issues, you can choose from:
+
+- **Best Practice** - Suggest a new best practice or technique
+- **Correction** - Report errors or outdated information
+- **Feature Request** - Request new commands, skills, or capabilities
+- **Bug Report** - Report bugs in MCP server or commands
+
+## Prerequisites
+
+- GitHub CLI (`gh`) must be installed and authenticated
+- Run `gh auth status` to verify authentication
+
+## Target Repository
+
+All commands operate on: `cooneycw/codex-power-pack`

--- a/.codex/prompts/github/issue-close.md
+++ b/.codex/prompts/github/issue-close.md
@@ -1,0 +1,157 @@
+---
+description: Close a GitHub issue with optional comment
+allowed-tools: Bash(gh issue close:*), Bash(gh issue comment:*), Bash(gh issue view:*), Bash(gh auth status:*)
+---
+
+> Trigger parity entrypoint for `/github:issue-close`.
+> Backing skill: `github-issue-close` (`.codex/skills/github-issue-close/SKILL.md`).
+
+
+# Close GitHub Issue
+
+Close an issue in the codex-power-pack repository.
+
+## Usage
+
+The user should provide an issue number. If not provided, ask for it.
+
+## Flow
+
+### Step 1: Verify Issue
+
+First, fetch and display the issue to confirm:
+```bash
+gh issue view NUMBER --repo cooneycw/codex-power-pack
+```
+
+Show:
+- Title
+- Current state
+- Labels
+- Brief description
+
+### Step 2: Ask for Closing Comment (Optional)
+
+Ask if the user wants to add a closing comment. Common patterns:
+
+- "Implemented in [commit/PR]"
+- "Fixed in v1.x.x"
+- "Duplicate of #XX"
+- "Won't fix: [reason]"
+- "Completed"
+
+### Step 3: Close Reason (Optional)
+
+For tracking purposes, ask about the close reason:
+- **Completed** - Issue was resolved
+- **Not Planned** - Won't be implemented
+- **Duplicate** - Duplicate of another issue
+
+```bash
+# Close as completed (default)
+gh issue close NUMBER --repo cooneycw/codex-power-pack
+
+# Close as not planned
+gh issue close NUMBER --repo cooneycw/codex-power-pack --reason "not planned"
+```
+
+### Step 4: Execute
+
+If closing comment provided, add it first:
+```bash
+gh issue comment NUMBER --repo cooneycw/codex-power-pack --body "COMMENT"
+```
+
+Then close:
+```bash
+gh issue close NUMBER --repo cooneycw/codex-power-pack
+```
+
+### Step 5: Confirm
+
+After closing, confirm success and show final state.
+
+## Example Interactions
+
+### Simple Close
+```
+User: /github:issue-close 42
+
+Codex: [Shows issue #42 details]
+
+This will close issue #42: "Use Plan Mode for complex refactors"
+
+Would you like to add a closing comment? (optional)
+
+User: no
+
+Codex: Close reason?
+1. Completed (default)
+2. Not Planned
+3. Duplicate
+
+User: 1
+
+Codex: Closing issue #42...
+
+Done! Issue #42 has been closed.
+```
+
+### Close with Comment
+```
+User: /github:issue-close 38
+
+Codex: [Shows issue #38 details]
+
+Would you like to add a closing comment?
+
+User: Fixed in commit abc123
+
+Codex: Close reason?
+1. Completed (default)
+2. Not Planned
+3. Duplicate
+
+User: 1
+
+Codex: I'll:
+1. Add comment: "Fixed in commit abc123"
+2. Close issue #38 as completed
+
+Proceed? (yes/no)
+
+User: yes
+
+Codex: Done! Issue #38 has been closed with your comment.
+```
+
+### Close as Duplicate
+```
+User: /github:issue-close 45
+
+Codex: [Shows issue details]
+
+Would you like to add a closing comment?
+
+User: Duplicate of #42
+
+Codex: Close reason?
+1. Completed
+2. Not Planned
+3. Duplicate
+
+User: 3
+
+Codex: I'll also add the "duplicate" label for tracking.
+
+[Adds label, adds comment, closes issue]
+
+Done! Issue #45 closed as duplicate of #42.
+```
+
+## Reopen Option
+
+Mention that issues can be reopened if needed:
+```bash
+gh issue reopen NUMBER --repo cooneycw/codex-power-pack
+```

--- a/.codex/prompts/github/issue-create.md
+++ b/.codex/prompts/github/issue-create.md
@@ -1,0 +1,127 @@
+---
+description: Create a new GitHub issue in codex-power-pack
+allowed-tools: Bash(gh issue create:*), Bash(gh auth status:*)
+---
+
+> Trigger parity entrypoint for `/github:issue-create`.
+> Backing skill: `github-issue-create` (`.codex/skills/github-issue-create/SKILL.md`).
+
+
+# Create GitHub Issue
+
+Create a new issue in the codex-power-pack repository.
+
+## Prerequisites Check
+
+First, verify GitHub CLI authentication:
+```bash
+gh auth status
+```
+
+If not authenticated, the user needs to run `gh auth login`.
+
+## Issue Creation Flow
+
+### Step 1: Ask Issue Type
+
+Ask the user which type of issue they want to create:
+
+1. **Best Practice Suggestion** - Suggest a new technique or tip
+2. **Documentation Correction** - Report errors or outdated info
+3. **Feature Request** - Request new commands/skills/capabilities
+4. **Bug Report** - Report bugs in MCP server or commands
+
+### Step 2: Gather Information
+
+Based on the issue type, gather the required information:
+
+**For Best Practice:**
+- Title (required)
+- Category (Skills, MCP, Session Management, etc.)
+- Description (required)
+- Example (optional)
+- Source (optional)
+
+**For Correction:**
+- Document name
+- Section/location
+- Current content
+- Suggested correction
+- Reason for change
+
+**For Feature Request:**
+- Feature type (command, skill, MCP, etc.)
+- Feature name
+- Problem/use case
+- Proposed solution
+
+**For Bug Report:**
+- Component affected
+- Bug description
+- Steps to reproduce
+- Error message (if any)
+- Environment details
+
+### Step 3: Create Issue
+
+Use the `gh` CLI to create the issue:
+
+```bash
+gh issue create \
+  --repo cooneycw/codex-power-pack \
+  --title "TITLE" \
+  --body "BODY" \
+  --label "LABELS"
+```
+
+**Labels by type:**
+- Best Practice: `enhancement,best-practice`
+- Correction: `documentation,correction`
+- Feature Request: `enhancement,feature-request`
+- Bug Report: `bug`
+
+### Step 4: Confirm
+
+After creation:
+1. Display the issue URL
+2. Offer to open in browser: `gh issue view NUMBER --web --repo cooneycw/codex-power-pack`
+
+## Example Interaction
+
+```
+User: /github:issue-create
+
+Codex: What type of issue would you like to create?
+1. Best Practice Suggestion
+2. Documentation Correction
+3. Feature Request
+4. Bug Report
+
+User: 1
+
+Codex: Great! Let's create a best practice suggestion.
+
+What's the title of this practice?
+
+User: Use session resets after git commits
+
+Codex: Which category does this practice belong to?
+- Skills & Activation
+- MCP Optimization
+- Session Management
+- Context Efficiency
+- AGENTS.md Configuration
+- Hooks & Automation
+- Workflow Patterns
+- Plan Mode
+- Code Quality
+- Other
+
+User: Session Management
+
+Codex: Please describe the practice and why it's useful.
+
+User: After completing a feature and committing, reset your Codex session...
+
+[Codex creates the issue and returns the URL]
+```

--- a/.codex/prompts/github/issue-list.md
+++ b/.codex/prompts/github/issue-list.md
@@ -1,0 +1,89 @@
+---
+description: List and search GitHub issues in codex-power-pack
+allowed-tools: Bash(gh issue list:*), Bash(gh auth status:*)
+---
+
+> Trigger parity entrypoint for `/github:issue-list`.
+> Backing skill: `github-issue-list` (`.codex/skills/github-issue-list/SKILL.md`).
+
+
+# List GitHub Issues
+
+List and search issues in the codex-power-pack repository.
+
+## Default Behavior
+
+If the user just runs `/github:issue-list` without specifying filters, show open issues:
+
+```bash
+gh issue list --repo cooneycw/codex-power-pack --state open --limit 20
+```
+
+## Available Filters
+
+Ask the user if they want to apply any filters:
+
+### State Filter
+- `open` (default) - Open issues only
+- `closed` - Closed issues only
+- `all` - All issues
+
+### Label Filter
+Common labels:
+- `best-practice` - Best practice suggestions
+- `correction` - Documentation corrections
+- `feature-request` - Feature requests
+- `bug` - Bug reports
+- `enhancement` - Enhancements
+- `documentation` - Documentation related
+
+### Search Filter
+Search issue titles and bodies:
+```bash
+gh issue list --repo cooneycw/codex-power-pack --search "QUERY"
+```
+
+### Author/Assignee Filter
+- `--author USERNAME` - Issues created by specific user
+- `--assignee USERNAME` - Issues assigned to specific user
+- `--assignee @me` - Issues assigned to current user
+
+## Command Examples
+
+```bash
+# Open issues (default)
+gh issue list --repo cooneycw/codex-power-pack --state open --limit 20
+
+# Filter by label
+gh issue list --repo cooneycw/codex-power-pack --label "best-practice"
+
+# Search issues
+gh issue list --repo cooneycw/codex-power-pack --search "MCP token"
+
+# Closed issues
+gh issue list --repo cooneycw/codex-power-pack --state closed --limit 10
+
+# My issues
+gh issue list --repo cooneycw/codex-power-pack --author @me
+
+# Combine filters
+gh issue list --repo cooneycw/codex-power-pack --state open --label "bug" --limit 10
+```
+
+## Output Format
+
+Present results in a clean table format:
+
+```
+#    TITLE                                    LABELS              UPDATED
+42   Use Plan Mode for complex refactors      best-practice       2h ago
+38   MCP server fails on Python 3.12          bug                 1d ago
+35   Add /test:setup command                  feature-request     3d ago
+```
+
+## Follow-up Options
+
+After listing issues, offer:
+1. View a specific issue: `/github:issue-view NUMBER`
+2. Refine search with different filters
+3. Create a new issue: `/github:issue-create`

--- a/.codex/prompts/github/issue-update.md
+++ b/.codex/prompts/github/issue-update.md
@@ -1,0 +1,151 @@
+---
+description: Update an existing GitHub issue (title, body, labels, assignees, comments)
+allowed-tools: Bash(gh issue edit:*), Bash(gh issue comment:*), Bash(gh issue view:*), Bash(gh auth status:*)
+---
+
+> Trigger parity entrypoint for `/github:issue-update`.
+> Backing skill: `github-issue-update` (`.codex/skills/github-issue-update/SKILL.md`).
+
+
+# Update GitHub Issue
+
+Modify an existing issue in the codex-power-pack repository.
+
+## Usage
+
+The user should provide an issue number. If not provided, ask for it.
+
+## First: Show Current State
+
+Before making changes, fetch and display the current issue:
+```bash
+gh issue view NUMBER --repo cooneycw/codex-power-pack
+```
+
+## Update Options
+
+Ask the user what they want to update:
+
+1. **Edit title**
+2. **Edit body**
+3. **Add/remove labels**
+4. **Assign/unassign**
+5. **Add comment**
+
+### Edit Title
+
+```bash
+gh issue edit NUMBER --repo cooneycw/codex-power-pack --title "NEW TITLE"
+```
+
+### Edit Body
+
+```bash
+gh issue edit NUMBER --repo cooneycw/codex-power-pack --body "NEW BODY"
+```
+
+For multiline bodies, use a heredoc:
+```bash
+gh issue edit NUMBER --repo cooneycw/codex-power-pack --body "$(cat <<'EOF'
+## Description
+
+New description content here.
+
+## Details
+
+More details...
+EOF
+)"
+```
+
+### Add Labels
+
+```bash
+gh issue edit NUMBER --repo cooneycw/codex-power-pack --add-label "label1,label2"
+```
+
+### Remove Labels
+
+```bash
+gh issue edit NUMBER --repo cooneycw/codex-power-pack --remove-label "label1"
+```
+
+### Assign User
+
+```bash
+gh issue edit NUMBER --repo cooneycw/codex-power-pack --add-assignee "username"
+gh issue edit NUMBER --repo cooneycw/codex-power-pack --add-assignee "@me"
+```
+
+### Unassign User
+
+```bash
+gh issue edit NUMBER --repo cooneycw/codex-power-pack --remove-assignee "username"
+```
+
+### Add Comment
+
+```bash
+gh issue comment NUMBER --repo cooneycw/codex-power-pack --body "Comment text"
+```
+
+For multiline comments:
+```bash
+gh issue comment NUMBER --repo cooneycw/codex-power-pack --body "$(cat <<'EOF'
+Thanks for the suggestion!
+
+I'll look into implementing this in the next update.
+EOF
+)"
+```
+
+## Confirmation
+
+Before applying changes:
+1. Show what will be changed
+2. Ask for confirmation
+3. Apply changes
+4. Show updated issue state
+
+## Available Labels
+
+- `best-practice` - Best practice suggestions
+- `correction` - Documentation corrections
+- `feature-request` - Feature requests
+- `bug` - Bug reports
+- `enhancement` - Enhancements
+- `documentation` - Documentation related
+- `mcp-server` - MCP Second Opinion issues
+- `wontfix` - Won't be fixed
+- `duplicate` - Duplicate issue
+- `good first issue` - Good for newcomers
+
+## Example Interaction
+
+```
+User: /github:issue-update 42
+
+Codex: [Shows current state of issue #42]
+
+What would you like to update?
+1. Edit title
+2. Edit body
+3. Add/remove labels
+4. Assign/unassign
+5. Add comment
+
+User: 5
+
+Codex: What comment would you like to add?
+
+User: This has been implemented in v1.1.0
+
+Codex: I'll add this comment to issue #42:
+"This has been implemented in v1.1.0"
+
+Proceed? (yes/no)
+
+User: yes
+
+[Codex adds comment and confirms]
+```

--- a/.codex/prompts/github/issue-view.md
+++ b/.codex/prompts/github/issue-view.md
@@ -1,0 +1,92 @@
+---
+description: View GitHub issue details and comments
+allowed-tools: Bash(gh issue view:*), Bash(gh api:*), Bash(gh auth status:*)
+---
+
+> Trigger parity entrypoint for `/github:issue-view`.
+> Backing skill: `github-issue-view` (`.codex/skills/github-issue-view/SKILL.md`).
+
+
+# View GitHub Issue
+
+View detailed information about a specific issue in codex-power-pack.
+
+## Usage
+
+The user should provide an issue number. If not provided, ask for it.
+
+## Fetch Issue Details
+
+```bash
+gh issue view NUMBER --repo cooneycw/codex-power-pack
+```
+
+This returns:
+- Title
+- State (open/closed)
+- Author
+- Labels
+- Assignees
+- Created/updated timestamps
+- Body content
+- Comments
+
+## For More Detail (Comments)
+
+To get comments:
+```bash
+gh issue view NUMBER --repo cooneycw/codex-power-pack --comments
+```
+
+## Output Format
+
+Present the issue in a readable format:
+
+```
+## Issue #42: Use Plan Mode for complex refactors
+
+**State:** Open
+**Author:** @username
+**Labels:** best-practice, enhancement
+**Assignees:** None
+**Created:** 2025-12-10
+**Updated:** 2025-12-12
+
+---
+
+### Description
+
+[Issue body content here]
+
+---
+
+### Comments (2)
+
+**@commenter1** (2025-12-11):
+[Comment content]
+
+**@commenter2** (2025-12-12):
+[Comment content]
+```
+
+## Follow-up Options
+
+After viewing, offer:
+1. **Open in browser**: `gh issue view NUMBER --web --repo cooneycw/codex-power-pack`
+2. **Add a comment**: `/github:issue-update NUMBER` (then add comment)
+3. **Close the issue**: `/github:issue-close NUMBER`
+4. **Edit the issue**: `/github:issue-update NUMBER`
+
+## Example Interaction
+
+```
+User: /github:issue-view 42
+
+Codex: [Fetches and displays issue #42 details]
+
+Would you like to:
+1. Open in browser
+2. Add a comment
+3. Edit this issue
+4. Close this issue
+```

--- a/.codex/skills/github-help/SKILL.md
+++ b/.codex/skills/github-help/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: github-help
+description: Trigger `/github:help`.
+---
+
+# github-help
+
+## Trigger
+- Primary: `/github:help`
+- Text alias: `github:help`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/github/help.md`
+
+## Execution
+1. Use this skill when the user invokes `/github:help` or explicitly asks for the GitHub `help` workflow.
+2. Follow the workflow steps in `.codex/prompts/github/help.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/github-help/agents/openai.yaml
+++ b/.codex/skills/github-help/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "github:help"
+  short_description: "Trigger /github:help"
+  default_prompt: "/github:help"

--- a/.codex/skills/github-issue-close/SKILL.md
+++ b/.codex/skills/github-issue-close/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: github-issue-close
+description: Trigger `/github:issue-close`.
+---
+
+# github-issue-close
+
+## Trigger
+- Primary: `/github:issue-close`
+- Text alias: `github:issue-close`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/github/issue-close.md`
+
+## Execution
+1. Use this skill when the user invokes `/github:issue-close` or explicitly asks for the GitHub `issue-close` workflow.
+2. Follow the workflow steps in `.codex/prompts/github/issue-close.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/github-issue-close/agents/openai.yaml
+++ b/.codex/skills/github-issue-close/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "github:issue-close"
+  short_description: "Trigger /github:issue-close"
+  default_prompt: "/github:issue-close"

--- a/.codex/skills/github-issue-create/SKILL.md
+++ b/.codex/skills/github-issue-create/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: github-issue-create
+description: Trigger `/github:issue-create`.
+---
+
+# github-issue-create
+
+## Trigger
+- Primary: `/github:issue-create`
+- Text alias: `github:issue-create`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/github/issue-create.md`
+
+## Execution
+1. Use this skill when the user invokes `/github:issue-create` or explicitly asks for the GitHub `issue-create` workflow.
+2. Follow the workflow steps in `.codex/prompts/github/issue-create.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/github-issue-create/agents/openai.yaml
+++ b/.codex/skills/github-issue-create/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "github:issue-create"
+  short_description: "Trigger /github:issue-create"
+  default_prompt: "/github:issue-create"

--- a/.codex/skills/github-issue-list/SKILL.md
+++ b/.codex/skills/github-issue-list/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: github-issue-list
+description: Trigger `/github:issue-list`.
+---
+
+# github-issue-list
+
+## Trigger
+- Primary: `/github:issue-list`
+- Text alias: `github:issue-list`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/github/issue-list.md`
+
+## Execution
+1. Use this skill when the user invokes `/github:issue-list` or explicitly asks for the GitHub `issue-list` workflow.
+2. Follow the workflow steps in `.codex/prompts/github/issue-list.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/github-issue-list/agents/openai.yaml
+++ b/.codex/skills/github-issue-list/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "github:issue-list"
+  short_description: "Trigger /github:issue-list"
+  default_prompt: "/github:issue-list"

--- a/.codex/skills/github-issue-update/SKILL.md
+++ b/.codex/skills/github-issue-update/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: github-issue-update
+description: Trigger `/github:issue-update`.
+---
+
+# github-issue-update
+
+## Trigger
+- Primary: `/github:issue-update`
+- Text alias: `github:issue-update`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/github/issue-update.md`
+
+## Execution
+1. Use this skill when the user invokes `/github:issue-update` or explicitly asks for the GitHub `issue-update` workflow.
+2. Follow the workflow steps in `.codex/prompts/github/issue-update.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/github-issue-update/agents/openai.yaml
+++ b/.codex/skills/github-issue-update/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "github:issue-update"
+  short_description: "Trigger /github:issue-update"
+  default_prompt: "/github:issue-update"

--- a/.codex/skills/github-issue-view/SKILL.md
+++ b/.codex/skills/github-issue-view/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: github-issue-view
+description: Trigger `/github:issue-view`.
+---
+
+# github-issue-view
+
+## Trigger
+- Primary: `/github:issue-view`
+- Text alias: `github:issue-view`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/github/issue-view.md`
+
+## Execution
+1. Use this skill when the user invokes `/github:issue-view` or explicitly asks for the GitHub `issue-view` workflow.
+2. Follow the workflow steps in `.codex/prompts/github/issue-view.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/github-issue-view/agents/openai.yaml
+++ b/.codex/skills/github-issue-view/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "github:issue-view"
+  short_description: "Trigger /github:issue-view"
+  default_prompt: "/github:issue-view"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,4 +36,5 @@
 
 - CI/CD slash trigger parity is mapped in `docs/skills/cicd-command-skill-map.md`.
 - Flow slash trigger parity is mapped in `docs/skills/flow-command-skill-map.md`.
+- GitHub slash trigger parity is mapped in `docs/skills/github-command-skill-map.md`.
 - AGENTS.md governance trigger parity is mapped in `docs/skills/agents-md-command-skill-map.md`.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ The `/flow:*` namespace is available through:
 - `.codex/skills/flow-*/` - backing Codex skill packages
 - `docs/skills/flow-command-skill-map.md` - trigger-to-skill inventory
 
+## GitHub Trigger Parity
+
+The `/github:*` namespace is available through:
+
+- `.claude/commands/github/*.md` - source command inventory
+- `.codex/prompts/github/*.md` - slash-compatible entrypoints
+- `.codex/skills/github-*/` - backing Codex skill packages
+- `docs/skills/github-command-skill-map.md` - trigger-to-skill inventory
+
 ## AGENTS.md Trigger Parity
 
 The `/agents-md:*` namespace is available through:

--- a/docs/skills/github-command-skill-map.md
+++ b/docs/skills/github-command-skill-map.md
@@ -1,0 +1,14 @@
+# GitHub Trigger to Skill Map
+
+This file maps GitHub issue-management triggers to Codex prompts and skill packages.
+
+| Trigger | Prompt Entrypoint | Skill Package |
+|---|---|---|
+| `/github:help` | `.codex/prompts/github/help.md` | `.codex/skills/github-help/SKILL.md` |
+| `/github:issue-close` | `.codex/prompts/github/issue-close.md` | `.codex/skills/github-issue-close/SKILL.md` |
+| `/github:issue-create` | `.codex/prompts/github/issue-create.md` | `.codex/skills/github-issue-create/SKILL.md` |
+| `/github:issue-list` | `.codex/prompts/github/issue-list.md` | `.codex/skills/github-issue-list/SKILL.md` |
+| `/github:issue-update` | `.codex/prompts/github/issue-update.md` | `.codex/skills/github-issue-update/SKILL.md` |
+| `/github:issue-view` | `.codex/prompts/github/issue-view.md` | `.codex/skills/github-issue-view/SKILL.md` |
+
+Canonical inventory: `.claude/commands/github/*.md`, `.codex/prompts/github/*.md`, and `.codex/skills/github-*/`.

--- a/tests/test_github_skill_trigger_parity.py
+++ b/tests/test_github_skill_trigger_parity.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_DIR = ROOT / ".claude" / "commands" / "github"
+PROMPT_DIR = ROOT / ".codex" / "prompts" / "github"
+SKILLS_DIR = ROOT / ".codex" / "skills"
+
+
+def _source_commands() -> set[str]:
+    return {path.stem for path in SOURCE_DIR.glob("*.md")}
+
+
+def _target_prompts() -> set[str]:
+    return {path.stem for path in PROMPT_DIR.glob("*.md")}
+
+
+def test_github_prompt_trigger_parity_with_source_commands() -> None:
+    assert _target_prompts() == _source_commands()
+
+
+def test_every_github_prompt_has_backing_skill_package() -> None:
+    for command in sorted(_source_commands()):
+        trigger = f"/github:{command}"
+        skill_name = f"github-{command}"
+
+        skill_md = SKILLS_DIR / skill_name / "SKILL.md"
+        agent_yaml = SKILLS_DIR / skill_name / "agents" / "openai.yaml"
+        prompt_md = PROMPT_DIR / f"{command}.md"
+
+        assert skill_md.exists(), f"Missing skill file for {trigger}: {skill_md}"
+        assert agent_yaml.exists(), f"Missing agents metadata for {trigger}: {agent_yaml}"
+
+        prompt_text = prompt_md.read_text()
+        skill_text = skill_md.read_text()
+
+        assert f"Backing skill: `{skill_name}`" in prompt_text
+        assert trigger in skill_text
+        assert f".codex/prompts/github/{command}.md" in skill_text


### PR DESCRIPTION
## Summary
- port all 6 /github:* trigger entrypoints into .codex/prompts/github/*.md
- add matching backing skill packages under .codex/skills/github-* with trigger aliases and OpenAI metadata
- add GitHub trigger inventory docs and a parity test that enforces source command parity with skill coverage
- update README and AGENTS mapping notes for GitHub trigger discoverability

## Testing
- env UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_github_skill_trigger_parity.py tests/test_flow_skill_trigger_parity.py tests/test_cicd_skill_trigger_parity.py tests/test_agents_md_skill_trigger_parity.py

Closes #8