### PR TITLE
feat(project): port project namespace to codex skills (Closes #9)

### DIFF
--- a/.codex/prompts/project/help.md
+++ b/.codex/prompts/project/help.md
@@ -1,0 +1,53 @@
+---
+description: Overview of project management commands
+---
+
+> Trigger parity entrypoint for `/project:help`.
+> Backing skill: `project-help` (`.codex/skills/project-help/SKILL.md`).
+
+
+# Project Commands
+
+Commands for creating and managing projects.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/project:init <name>` | Full project scaffolding - zero to GitHub repo |
+| `/project-next` | Scan issues and worktrees to recommend next steps |
+| `/project-lite` | Quick project reference with minimal context |
+| `/agents-md:lint` | Audit AGENTS.md for CI/CD and troubleshooting directives |
+
+## /project:init
+
+One-command project setup that orchestrates:
+
+1. Creates `~/Projects/<name>` with framework scaffold (Python/Node/Go/Rust)
+2. Initializes git and pushes to a new GitHub repo
+3. Generates Makefile from detected framework (`lib/cicd`)
+4. Installs CPP commands, skills, and hooks (symlinks)
+5. Initializes `.specify/` for spec-driven development
+6. Optionally creates an initial feature spec
+
+**Example:**
+```
+/project:init my-api
+```
+
+**Features:**
+- Idempotent - safe to re-run if interrupted (completed steps are skipped)
+- Framework-specific scaffolds with best-practice project structure
+- Integrates with `/flow`, `/spec`, `/security`, and all CPP commands
+
+## /project-next
+
+Full GitHub issue analysis with prioritized recommendations. Scans open issues, maps worktrees, detects hierarchy (Waves/Phases), and suggests what to work on next.
+
+**Use when:** Unsure what to work on, need issue triage, or want cleanup suggestions.
+
+## /project-lite
+
+Lightweight project reference for quick orientation. Shows repo info, conventions, worktrees, and available commands with minimal context usage.
+
+**Use when:** Starting a session, context is high, or you already know what to work on.

--- a/.codex/prompts/project/init.md
+++ b/.codex/prompts/project/init.md
@@ -1,0 +1,690 @@
+---
+description: Full project scaffolding orchestrator - zero to GitHub repo in one command
+allowed-tools: Bash(mkdir:*), Bash(cd:*), Bash(ls:*), Bash(git:*), Bash(gh:*), Bash(uv:*), Bash(npm:*), Bash(cat:*), Bash(test:*), Bash(echo:*), Bash(cp:*), Bash(ln:*), Bash(touch:*), Bash(PYTHONPATH=:*), Read, Write, Glob, Grep, AskUserQuestion, Skill
+---
+
+> Trigger parity entrypoint for `/project:init`.
+> Backing skill: `project-init` (`.codex/skills/project-init/SKILL.md`).
+
+
+# /project:init - Full Project Scaffolding
+
+Create a new project from zero to pushed GitHub repo in one command.
+
+## Arguments
+
+- `PROJECT_NAME` (required): Name of the project (e.g., `my-awesome-app`)
+
+## Orchestration Flow
+
+```
+/project:init my-awesome-app
+  Step 1: Validate & create ~/Projects/my-awesome-app
+  Step 2: Select framework, generate scaffold
+  Step 3: Initialize git, push to GitHub
+  Step 4: Run /cicd:init, /cpp:init, /spec:init
+  Step 5: Initial spec (mandatory) + sync
+  Step 6: Summary
+```
+
+---
+
+## Step 1: Validate & Create Project Directory
+
+```bash
+PROJECT_NAME="$1"
+
+# Validate project name
+if [[ ! "$PROJECT_NAME" =~ ^[a-z][a-z0-9-]*$ ]]; then
+    echo "ERROR: Project name must be lowercase, start with a letter, and contain only letters, numbers, and hyphens."
+    echo "Example: my-awesome-app"
+    exit 1
+fi
+
+# Check if directory already exists
+if [ -d "$HOME/Projects/$PROJECT_NAME" ]; then
+    echo "Directory ~/Projects/$PROJECT_NAME already exists."
+    echo "Checking state for resume..."
+fi
+```
+
+If the directory already exists, check what steps have been completed and resume from the first incomplete step:
+
+- Has `pyproject.toml` / `package.json` / `go.mod` / `Cargo.toml`? → Step 2 done.
+- Has `.git/`? → Step 3 partially done. Check if GitHub remote exists.
+- Has `Makefile` + `.codex/cicd.yml`? → cicd:init done.
+- Has `.codex/commands` symlink? → cpp:init done.
+- Has `.specify/`? → spec:init done.
+
+If the directory doesn't exist:
+
+```bash
+mkdir -p "$HOME/Projects/$PROJECT_NAME"
+cd "$HOME/Projects/$PROJECT_NAME"
+echo "Created ~/Projects/$PROJECT_NAME"
+```
+
+Report: `Step 1/6: Project directory ready at ~/Projects/{PROJECT_NAME}`
+
+---
+
+## Step 2: Framework Selection & Scaffold
+
+Ask the user which framework to use with `AskUserQuestion`:
+
+**Options:**
+
+| Framework | What's Generated |
+|-----------|-----------------|
+| **Python (uv)** | `pyproject.toml`, `src/{pkg}/__init__.py`, `tests/conftest.py` |
+| **Node.js (npm)** | `package.json`, `src/index.ts`, `tests/` |
+| **Go** | `go.mod`, `cmd/main.go`, `internal/` |
+| **Rust** | `Cargo.toml`, `src/main.rs` |
+
+### Python Scaffold
+
+```bash
+PROJECT_NAME="..."
+PKG_NAME=$(echo "$PROJECT_NAME" | tr '-' '_')
+
+# pyproject.toml (PEP 621 + uv)
+cat > pyproject.toml << PYEOF
+[project]
+name = "$PROJECT_NAME"
+version = "0.1.0"
+description = ""
+requires-python = ">=3.11"
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "ruff>=0.4",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.backends"
+
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "W"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+PYEOF
+
+# Source directory
+mkdir -p "src/$PKG_NAME"
+cat > "src/$PKG_NAME/__init__.py" << 'INITEOF'
+"""$PROJECT_NAME."""
+
+__version__ = "0.1.0"
+INITEOF
+
+# Tests
+mkdir -p tests
+cat > tests/conftest.py << 'TESTEOF'
+"""Shared test fixtures."""
+TESTEOF
+
+cat > tests/test_placeholder.py << 'TESTEOF'
+"""Placeholder test to verify setup."""
+
+
+def test_import():
+    """Verify the package can be imported."""
+    import importlib
+    mod = importlib.import_module("$PKG_NAME")
+    assert hasattr(mod, "__version__")
+TESTEOF
+
+# Initialize uv
+uv sync
+```
+
+### Node.js Scaffold
+
+```bash
+PROJECT_NAME="..."
+
+cat > package.json << PKGEOF
+{
+  "name": "$PROJECT_NAME",
+  "version": "0.1.0",
+  "description": "",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "lint": "eslint src/",
+    "test": "vitest run",
+    "dev": "tsx watch src/index.ts"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^2.0.0"
+  }
+}
+PKGEOF
+
+cat > tsconfig.json << TSEOF
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+TSEOF
+
+mkdir -p src tests
+echo 'console.log("Hello from $PROJECT_NAME");' > src/index.ts
+cat > tests/placeholder.test.ts << 'TESTEOF'
+import { describe, it, expect } from 'vitest';
+
+describe('placeholder', () => {
+  it('passes', () => {
+    expect(true).toBe(true);
+  });
+});
+TESTEOF
+
+npm install
+```
+
+### Go Scaffold
+
+```bash
+PROJECT_NAME="..."
+# Ask user for module path or default to github.com/USER/PROJECT_NAME
+MODULE_PATH="github.com/$(gh api user --jq '.login')/$PROJECT_NAME"
+
+cat > go.mod << GOEOF
+module $MODULE_PATH
+
+go 1.22
+GOEOF
+
+mkdir -p cmd internal
+cat > cmd/main.go << 'GOEOF'
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello from $PROJECT_NAME")
+}
+GOEOF
+```
+
+### Rust Scaffold
+
+```bash
+PROJECT_NAME="..."
+
+cat > Cargo.toml << RUSTEOF
+[package]
+name = "$PROJECT_NAME"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+RUSTEOF
+
+mkdir -p src
+cat > src/main.rs << 'RUSTEOF'
+fn main() {
+    println!("Hello from $PROJECT_NAME");
+}
+RUSTEOF
+```
+
+### .gitignore (all frameworks)
+
+Generate a `.gitignore` appropriate for the selected framework. Use templates from GitHub's gitignore collection or create a sensible default.
+
+**Python:**
+```
+__pycache__/
+*.py[cod]
+.venv/
+dist/
+build/
+*.egg-info/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+.env
+.codex/settings.local.json
+```
+
+**Node:**
+```
+node_modules/
+dist/
+build/
+.next/
+coverage/
+.env
+.codex/settings.local.json
+```
+
+**Go:**
+```
+bin/
+coverage.out
+.env
+.codex/settings.local.json
+```
+
+**Rust:**
+```
+target/
+.env
+.codex/settings.local.json
+```
+
+Report: `Step 2/6: {Framework} scaffold created`
+
+---
+
+## Step 3: Git & GitHub
+
+```bash
+# Initialize git
+git init
+
+# Configure git user if not set globally
+if ! git config user.name &>/dev/null; then
+    echo "Git user.name not configured. Please set it:"
+    # Ask user for name and email, or use gh auth info
+    GH_USER=$(gh api user --jq '.login' 2>/dev/null)
+    GH_EMAIL=$(gh api user --jq '.email // empty' 2>/dev/null)
+    # Fall back to asking
+fi
+
+# Initial commit
+git add .
+git commit -m "Initial project scaffold
+
+Co-Authored-By: <agent identity>"
+```
+
+Ask the user about repository visibility using `AskUserQuestion`:
+
+**Options:**
+- **Private (Recommended)** - Only you and collaborators can see the repo
+- **Public** - Anyone can see the repo
+
+```bash
+VISIBILITY="--private"  # or "--public" based on user choice
+
+# Create GitHub repo and push
+gh repo create "$PROJECT_NAME" $VISIBILITY --source=. --push
+```
+
+If `gh repo create` fails (e.g., repo name taken), report the error and suggest alternatives.
+
+Report: `Step 3/6: Git initialized, pushed to github.com/{user}/{PROJECT_NAME}`
+
+---
+
+## Step 4: CPP Setup (Orchestrate Sub-Commands)
+
+Run each sub-command in sequence. These are orchestrated directly - NOT by invoking `/skill` (which would require user interaction for each one). Instead, execute the same logic as each command but non-interactively with sensible defaults.
+
+### 4a: Makefile Generation (from lib/cicd)
+
+The `lib/cicd` library can detect the framework and generate a Makefile:
+
+```bash
+# Locate CPP source
+CPP_DIR=""
+for dir in ~/Projects/codex-power-pack /opt/codex-power-pack ~/.codex-power-pack; do
+    if [ -d "$dir" ] && [ -f "$dir/AGENTS.md" ]; then
+        CPP_DIR="$dir"
+        break
+    fi
+done
+
+if [ -z "$CPP_DIR" ]; then
+    echo "WARNING: codex-power-pack not found. Skipping cicd:init."
+else
+    # Generate Makefile from detected framework
+    if [ ! -f "Makefile" ]; then
+        PYTHONPATH="$CPP_DIR/lib:$PYTHONPATH" python3 -c "
+from lib.cicd.makefile import generate_makefile
+content = generate_makefile('.')
+print(content)
+" > Makefile
+        echo "Generated Makefile from detected framework"
+    fi
+
+    # Create .codex/cicd.yml config
+    mkdir -p .codex
+    if [ ! -f ".codex/cicd.yml" ]; then
+        cp "$CPP_DIR/templates/cicd.yml.example" .codex/cicd.yml 2>/dev/null || true
+        echo "Created .codex/cicd.yml"
+    fi
+fi
+```
+
+### 4b: CPP Init (symlinks)
+
+```bash
+if [ -n "$CPP_DIR" ]; then
+    mkdir -p .codex
+
+    # Symlink commands
+    if [ ! -L ".codex/commands" ] && [ ! -d ".codex/commands" ]; then
+        ln -sf "$CPP_DIR/.codex/commands" .codex/commands
+        echo "Symlinked .codex/commands"
+    fi
+
+    # Symlink skills
+    if [ ! -L ".codex/skills" ] && [ ! -d ".codex/skills" ]; then
+        ln -sf "$CPP_DIR/.codex/skills" .codex/skills
+        echo "Symlinked .codex/skills"
+    fi
+
+    # Copy hooks.json
+    if [ ! -f ".codex/hooks.json" ]; then
+        cp "$CPP_DIR/.codex/hooks.json" .codex/hooks.json 2>/dev/null || true
+        echo "Copied hooks.json"
+    fi
+fi
+```
+
+### 4c: Generate AGENTS.md
+
+If no AGENTS.md exists yet, generate one with CI/CD governance directives:
+
+```bash
+if [ ! -f "AGENTS.md" ]; then
+    # Detect Docker presence
+    HAS_DOCKER="no"
+    [ -f "Dockerfile" ] || [ -f "docker-compose.yml" ] || [ -f "docker-compose.yaml" ] && HAS_DOCKER="yes"
+
+    cat > AGENTS.md << 'CLAUDEEOF'
+# $PROJECT_NAME
+
+## Overview
+
+{Brief project description.}
+
+## Key Conventions
+
+- {Framework} project
+- {Package manager} for dependency management
+
+## CI/CD Protocol
+
+- Use Makefile targets for all build, test, and deploy operations
+- Never run raw build commands - use `make lint`, `make test`, `make build`, `make deploy`
+- The Makefile is the single source of truth for project commands
+- If a Makefile target is missing for your operation, ADD the target rather than running raw commands
+
+## Troubleshooting Protocol
+
+- Before debugging manually, run `make lint` and `make test` to surface known issues
+- When fixing errors, fix BOTH the application code AND the CI/CD process (Makefile, Dockerfile, docker-compose.yml)
+- After any fix, verify through the full pipeline: `make verify`
+- Never bypass quality gates - if `make lint` or `make test` fails, fix the root cause
+- Use `make troubleshoot` for a single-command diagnostic pass (clean + lint + test)
+
+## Quality Gates
+
+| Target | Purpose | When to Run |
+|--------|---------|-------------|
+| `make lint` | Run linter | Before every commit |
+| `make test` | Run tests | Before every commit |
+| `make verify` | Full check (lint + test + typecheck) | Before deployment |
+| `make troubleshoot` | Diagnostic pass (clean + lint + test) | When debugging issues |
+
+## Deployment
+
+- Deploy: `make deploy` (runs verify first)
+- Customize the deploy target in the Makefile for your environment
+- Post-deploy: run `/cicd:health` to verify endpoints
+CLAUDEEOF
+
+    # Append Docker section if Docker files detected
+    if [ "$HAS_DOCKER" = "yes" ]; then
+        cat >> AGENTS.md << 'DOCKEREOF'
+
+## Docker Conventions
+
+- Build images: `make docker-build` (not raw `docker build`)
+- Start services: `make docker-up` (not raw `docker compose up`)
+- Stop services: `make docker-down`
+- View logs: `make docker-logs`
+- Check status: `make docker-ps`
+- If Docker errors occur, check Dockerfile and docker-compose.yml alongside application code
+DOCKEREOF
+    fi
+
+    echo "Generated AGENTS.md with CI/CD governance directives"
+fi
+```
+
+Fill in the framework/package-manager placeholders based on what was detected in Step 2.
+
+### 4d: Spec Init
+
+```bash
+if [ ! -d ".specify" ]; then
+    mkdir -p .specify/memory .specify/specs .specify/templates .specify/scripts
+
+    # Create constitution template
+    DATE=$(date +%Y-%m-%d)
+    cat > .specify/memory/constitution.md << CONSTEOF
+# Project Constitution
+
+> Governing principles for $PROJECT_NAME.
+> All specifications and implementations must align with these principles.
+
+---
+
+## Core Principles
+
+### P1: {First Principle}
+
+{Description of the principle and how it guides development.}
+
+### P2: {Second Principle}
+
+{Description of the principle and how it guides development.}
+
+---
+
+## Development Workflow
+
+1. Write specification before code
+2. Review spec for completeness
+3. Create technical plan
+4. Break into tasks
+5. Sync tasks to issues
+6. Implement with tests
+
+---
+
+*Created: $DATE*
+CONSTEOF
+
+    # Copy templates if CPP source is available
+    if [ -n "$CPP_DIR" ] && [ -d "$CPP_DIR/.specify/templates" ]; then
+        cp "$CPP_DIR/.specify/templates/"*.md .specify/templates/ 2>/dev/null || true
+    fi
+
+    echo "Initialized .specify/"
+fi
+```
+
+Report: `Step 4/6: CPP setup complete - Makefile, commands, skills, hooks, .specify/`
+
+---
+
+## Step 5: Initial Spec (Mandatory)
+
+Create an initial feature specification for the project. This step is mandatory to
+ensure every project starts with a spec-driven foundation. The spec can be minimal
+and refined later.
+
+Ask the user with `AskUserQuestion`:
+
+**Question:** "What is the first feature or MVP for this project? (Enter a name or press enter to use the project name)"
+
+Use the project name as the default feature name if the user doesn't provide one.
+
+```bash
+FEATURE_NAME="$PROJECT_NAME"
+mkdir -p ".specify/specs/$FEATURE_NAME"
+
+# Create spec.md, plan.md, tasks.md from templates or minimal stubs
+cat > ".specify/specs/$FEATURE_NAME/spec.md" << SPECEOF
+# Feature Specification: $FEATURE_NAME
+
+## Overview
+
+{Brief description of the project's first feature or MVP.}
+
+## User Stories
+
+### US1: {Story Title}
+**As a** {role}, **I want** {capability}, **So that** {benefit}.
+
+**Acceptance Criteria:**
+- [ ] {Criterion}
+
+## Requirements
+
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| R1 | {Requirement} | Must |
+
+## Success Criteria
+- [ ] All acceptance criteria met
+- [ ] Tests passing
+SPECEOF
+
+cat > ".specify/specs/$FEATURE_NAME/plan.md" << PLANEOF
+# Implementation Plan: $FEATURE_NAME
+
+## Summary
+{Technical approach}
+
+## Architecture
+{Component design}
+
+## Dependencies
+| Package | Purpose |
+|---------|---------|
+
+## Phases
+| Phase | Tasks | Dependencies |
+|-------|-------|--------------|
+PLANEOF
+
+cat > ".specify/specs/$FEATURE_NAME/tasks.md" << TASKEOF
+# Tasks: $FEATURE_NAME
+
+## Format
+\`[ID] [P?] [Story] Description\`
+
+## Wave 1: Foundation
+- [ ] **T001** [US1] {First task}
+
+## Issue Sync
+| Task | Issue | Status |
+|------|-------|--------|
+TASKEOF
+
+echo "Created spec: .specify/specs/$FEATURE_NAME/"
+```
+
+Then ask: "Sync tasks to GitHub issues now?"
+- **Yes** → invoke `/spec:sync $FEATURE_NAME`
+- **Skip** → sync later
+
+Report: `Step 5/6: Initial spec created` or `Step 5/6: Skipped`
+
+---
+
+## Step 6: Final Commit & Summary
+
+```bash
+# Stage all new CPP/spec files
+git add .
+git diff --cached --stat
+
+# Commit the CPP setup
+git commit -m "chore: add CPP setup, Makefile, and spec structure
+
+Co-Authored-By: <agent identity>"
+
+# Push
+git push origin main
+```
+
+Report the final summary:
+
+```
+Project created: {PROJECT_NAME}
+
+  Directory:  ~/Projects/{PROJECT_NAME}
+  GitHub:     github.com/{user}/{PROJECT_NAME} (private)
+  Framework:  {Framework} ({PackageManager})
+  Makefile:   lint, test, build, deploy, clean, verify
+  CPP:        Commands + Skills + Hooks
+  Spec:       .specify/ initialized
+
+Next steps:
+  cd ~/Projects/{PROJECT_NAME}
+  /project-next              # See recommended actions
+  /spec:create {feature}     # Add a feature spec
+  /flow:start {N}            # Start working on an issue
+```
+
+---
+
+## Error Handling
+
+At each step, if something fails:
+
+```
+/project:init stopped at Step N/6: {Step Name}
+
+  Failed: [description]
+  Fix:    [suggestion]
+
+  To resume: /project:init {PROJECT_NAME}
+  (Idempotent - completed steps will be skipped)
+```
+
+Key failure scenarios:
+- **Invalid project name:** Stop at Step 1 with format guidance
+- **Directory exists with work:** Resume from first incomplete step
+- **gh not authenticated:** Stop at Step 3, suggest `gh auth login`
+- **Repo name taken on GitHub:** Suggest alternative name or link to existing
+- **CPP source not found:** Skip Step 4 with warning, still complete other steps
+- **uv/npm not installed:** Warn but continue (user can install deps later)
+
+## Notes
+
+- This command is **idempotent** - safe to run again if interrupted
+- Each step checks for prior completion before executing
+- The scaffold is minimal - just enough to start coding
+- Framework detection from `lib/cicd` is reused for Makefile generation
+- Sub-commands (cicd:init, cpp:init, spec:init) are executed inline, not via `/skill`

--- a/.codex/skills/project-help/SKILL.md
+++ b/.codex/skills/project-help/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: project-help
+description: Trigger `/project:help`.
+---
+
+# project-help
+
+## Trigger
+- Primary: `/project:help`
+- Text alias: `project:help`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/project/help.md`
+
+## Execution
+1. Use this skill when the user invokes `/project:help` or explicitly asks for the project `help` workflow.
+2. Follow the workflow steps in `.codex/prompts/project/help.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/project-help/agents/openai.yaml
+++ b/.codex/skills/project-help/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "project:help"
+  short_description: "Trigger /project:help"
+  default_prompt: "/project:help"

--- a/.codex/skills/project-init/SKILL.md
+++ b/.codex/skills/project-init/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: project-init
+description: Trigger `/project:init`.
+---
+
+# project-init
+
+## Trigger
+- Primary: `/project:init`
+- Text alias: `project:init`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/project/init.md`
+
+## Execution
+1. Use this skill when the user invokes `/project:init` or explicitly asks for the project `init` workflow.
+2. Follow the workflow steps in `.codex/prompts/project/init.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/project-init/agents/openai.yaml
+++ b/.codex/skills/project-init/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "project:init"
+  short_description: "Trigger /project:init"
+  default_prompt: "/project:init"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,4 +37,5 @@
 - CI/CD slash trigger parity is mapped in `docs/skills/cicd-command-skill-map.md`.
 - Flow slash trigger parity is mapped in `docs/skills/flow-command-skill-map.md`.
 - GitHub slash trigger parity is mapped in `docs/skills/github-command-skill-map.md`.
+- Project slash trigger parity is mapped in `docs/skills/project-command-skill-map.md`.
 - AGENTS.md governance trigger parity is mapped in `docs/skills/agents-md-command-skill-map.md`.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ The `/github:*` namespace is available through:
 - `.codex/skills/github-*/` - backing Codex skill packages
 - `docs/skills/github-command-skill-map.md` - trigger-to-skill inventory
 
+## Project Trigger Parity
+
+The `/project:*` namespace is available through:
+
+- `.claude/commands/project/*.md` - source command inventory
+- `.codex/prompts/project/*.md` - slash-compatible entrypoints
+- `.codex/skills/project-*/` - backing Codex skill packages
+- `docs/skills/project-command-skill-map.md` - trigger-to-skill inventory
+
 ## AGENTS.md Trigger Parity
 
 The `/agents-md:*` namespace is available through:

--- a/docs/skills/project-command-skill-map.md
+++ b/docs/skills/project-command-skill-map.md
@@ -1,0 +1,10 @@
+# Project Trigger to Skill Map
+
+This file maps project command triggers to Codex prompts and skill packages.
+
+| Trigger | Prompt Entrypoint | Skill Package |
+|---|---|---|
+| `/project:help` | `.codex/prompts/project/help.md` | `.codex/skills/project-help/SKILL.md` |
+| `/project:init` | `.codex/prompts/project/init.md` | `.codex/skills/project-init/SKILL.md` |
+
+Canonical inventory: `.claude/commands/project/*.md`, `.codex/prompts/project/*.md`, and `.codex/skills/project-*/`.

--- a/tests/test_project_skill_trigger_parity.py
+++ b/tests/test_project_skill_trigger_parity.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_DIR = ROOT / ".claude" / "commands" / "project"
+PROMPT_DIR = ROOT / ".codex" / "prompts" / "project"
+SKILLS_DIR = ROOT / ".codex" / "skills"
+
+
+def _source_commands() -> set[str]:
+    return {path.stem for path in SOURCE_DIR.glob("*.md")}
+
+
+def _target_prompts() -> set[str]:
+    return {path.stem for path in PROMPT_DIR.glob("*.md")}
+
+
+def test_project_prompt_trigger_parity_with_source_commands() -> None:
+    assert _target_prompts() == _source_commands()
+
+
+def test_every_project_prompt_has_backing_skill_package() -> None:
+    for command in sorted(_source_commands()):
+        trigger = f"/project:{command}"
+        skill_name = f"project-{command}"
+
+        skill_md = SKILLS_DIR / skill_name / "SKILL.md"
+        agent_yaml = SKILLS_DIR / skill_name / "agents" / "openai.yaml"
+        prompt_md = PROMPT_DIR / f"{command}.md"
+
+        assert skill_md.exists(), f"Missing skill file for {trigger}: {skill_md}"
+        assert agent_yaml.exists(), f"Missing agents metadata for {trigger}: {agent_yaml}"
+
+        prompt_text = prompt_md.read_text()
+        skill_text = skill_md.read_text()
+
+        assert f"Backing skill: `{skill_name}`" in prompt_text
+        assert trigger in skill_text
+        assert f".codex/prompts/project/{command}.md" in skill_text
+
+
+def test_project_agent_metadata_points_to_expected_triggers() -> None:
+    for command in sorted(_source_commands()):
+        skill_name = f"project-{command}"
+        trigger = f"/project:{command}"
+        agent_yaml = SKILLS_DIR / skill_name / "agents" / "openai.yaml"
+        text = agent_yaml.read_text()
+
+        assert f'display_name: "project:{command}"' in text
+        assert f'default_prompt: "{trigger}"' in text


### PR DESCRIPTION
## Summary
- port /project:help and /project:init trigger entrypoints into .codex/prompts/project/*.md
- add backing skill packages under .codex/skills/project-* with explicit trigger alias metadata
- add project trigger inventory docs and a parity test that enforces source-command coverage
- update README and AGENTS trigger discoverability notes for the project namespace

## Testing
- env UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_project_skill_trigger_parity.py tests/test_github_skill_trigger_parity.py tests/test_flow_skill_trigger_parity.py tests/test_cicd_skill_trigger_parity.py tests/test_agents_md_skill_trigger_parity.py
- smoke: /project:help -> project-help
- smoke: /project:init -> project-init

Closes #9