### PR TITLE
feat(qa): port qa command namespace to codex skills (Closes #10)

### DIFF
--- a/.codex/prompts/qa/help.md
+++ b/.codex/prompts/qa/help.md
@@ -1,0 +1,107 @@
+---
+description: Overview of QA testing commands for web applications
+---
+
+> Trigger parity entrypoint for `/qa:help`.
+> Backing skill: `qa-help` (`.codex/skills/qa-help/SKILL.md`).
+
+# QA Commands Help
+
+Automated QA testing commands for web applications.
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `/qa:test <target> [area]` | Run QA tests and log bugs as GitHub issues |
+| `/qa:help` | This help page |
+
+## Usage Examples
+
+```bash
+# Test a URL directly
+/qa:test https://myapp.example.com
+
+# Test using a shortcut from qa.yml
+/qa:test myapp dashboard
+
+# Find multiple bugs before stopping
+/qa:test myapp login --find 5
+
+# Test any external URL (no config needed)
+/qa:test https://other-site.com/page
+```
+
+## Configuration: `.codex/qa.yml`
+
+Place a `qa.yml` file in your project's `.codex/` directory to configure shortcuts, test areas, and project metadata.
+
+**Setup:**
+```bash
+# Copy the template
+cp ~/Projects/codex-power-pack/templates/qa.yml.example .codex/qa.yml
+
+# Edit for your project
+```
+
+**If no `.codex/qa.yml` exists**, `/qa:test` runs in interactive mode. It prompts for a URL and uses generic testing (clicking elements, checking forms, and scanning console errors).
+
+### Config Schema
+
+```yaml
+# Project information
+project:
+  url: https://myapp.example.com        # Default URL
+  repository: owner/repo-name           # GitHub repo for bug issues
+
+# Shortcuts - short names that resolve to URLs
+shortcuts:
+  myapp: https://myapp.example.com
+  staging: https://staging.myapp.example.com
+
+# Test areas - named sections with paths and test checklists
+test_areas:
+  home:
+    path: /                              # URL path appended to project URL
+    description: "Homepage and landing"  # Shown in test reports
+    tests:                               # Checklist of things to verify
+      - "Page loads without errors"
+      - "Navigation links work"
+      - "Key content visible"
+
+  login:
+    path: /login
+    description: "Authentication flow"
+    tests:
+      - "Login form renders"
+      - "Form validation works"
+      - "Successful login redirects"
+```
+
+### Config Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `project.url` | Yes | Default base URL for the application |
+| `project.repository` | No | GitHub `owner/repo` for issue creation (auto-detected if omitted) |
+| `shortcuts` | No | Map of short names to URLs |
+| `test_areas` | No | Named test areas with paths and test checklists |
+| `test_areas.<name>.path` | Yes | URL path relative to project URL |
+| `test_areas.<name>.description` | No | Human-readable area description |
+| `test_areas.<name>.tests` | No | List of specific checks to perform |
+
+## How It Works
+
+1. Loads `.codex/qa.yml` config (or prompts interactively)
+2. Creates a headless Playwright browser session
+3. Navigates to target URL (resolving shortcuts and area paths)
+4. Runs a test checklist from config (or generic element testing)
+5. Checks console for errors
+6. Logs bugs as GitHub issues
+7. Reports a summary with test coverage
+
+## Requirements
+
+- Playwright MCP server running (`mcp-playwright`)
+- GitHub CLI authenticated (`gh auth status`)
+- Repository access for issue creation

--- a/.codex/prompts/qa/test.md
+++ b/.codex/prompts/qa/test.md
@@ -1,0 +1,159 @@
+---
+description: Run automated QA testing against a URL or configured shortcut and file bugs as GitHub issues
+allowed-tools: Bash(cat:*), Bash(gh:*), Read, AskUserQuestion
+---
+
+> Trigger parity entrypoint for `/qa:test`.
+> Backing skill: `qa-test` (`.codex/skills/qa-test/SKILL.md`).
+
+# QA Test - Automated Web Testing
+
+Perform automated QA testing on a web application using Playwright MCP.
+
+**Arguments:** `$ARGUMENTS`
+- Format: `<url-or-shortcut> [area] [--find N]`
+- Examples:
+  - `/qa:test https://example.com` - Test full site
+  - `/qa:test myapp dashboard` - Test a named area via shortcut
+  - `/qa:test myapp login --find 3` - Find up to 3 bugs in login area
+
+---
+
+## Step 1: Load Configuration
+
+Check for `.codex/qa.yml` in the project root:
+
+```bash
+cat .codex/qa.yml 2>/dev/null
+```
+
+If `.codex/qa.yml` exists, parse:
+- `project.url` - default project URL
+- `project.repository` - GitHub repo for issue creation
+- `shortcuts` - shortcut-to-URL map
+- `test_areas` - named areas with paths, descriptions, and checks
+
+If `.codex/qa.yml` does not exist, use interactive fallback.
+
+## Step 1b: Interactive Fallback (No Config)
+
+If no `.codex/qa.yml` exists and no URL was provided:
+
+1. Inform the user:
+   ```
+   No .codex/qa.yml found. Running in interactive mode.
+   Tip: Copy templates/qa.yml.example to .codex/qa.yml for persistent config.
+   ```
+2. Ask for target URL via AskUserQuestion.
+3. Ask for repository (or detect via `gh repo view`).
+4. Run generic test areas:
+   - Click interactive elements
+   - Fill and submit forms
+   - Check browser console for errors
+   - Test navigation links
+
+## Step 2: Parse Arguments
+
+Extract from `$ARGUMENTS`:
+1. Target URL or shortcut (resolve via `shortcuts`)
+2. Optional `area` (must exist in `test_areas`)
+3. Optional `--find N` bug cap (default: 1)
+
+If shortcut is missing, report available shortcuts.
+If area is missing, report available areas.
+
+## Step 3: Create Browser Session
+
+Use regular Playwright MCP to create a headless browser session:
+
+```
+create_session(headless=true, viewport_width=1280, viewport_height=720)
+```
+
+Store `session_id`.
+
+## Step 4: Navigate to Target
+
+- Resolve shortcut to URL when needed
+- Append area `path` when an area is specified
+
+```
+browser_navigate(session_id, url, wait_until="networkidle")
+```
+
+## Step 5: Test Methodology
+
+### Area-driven checks (when area + tests are configured)
+
+For each checklist item:
+1. Locate relevant elements
+2. Perform the interaction
+3. Verify expected behavior
+4. Check console: `browser_console_messages(session_id)`
+5. Record failures
+
+### Full-site checks (when no area provided)
+
+Iterate configured `test_areas`, navigate to each path, run each area's checks.
+
+### Generic checks (no config or no explicit test plans)
+
+1. Click response testing
+   ```
+   browser_query_selector_all(session_id, "button, [onclick], a[href], input[type=submit], [role=button]")
+   ```
+2. Form testing
+3. Navigation testing
+
+Record JS errors, broken navigation, and 4xx/5xx failures.
+
+## Step 6: Bug Classification
+
+| Severity | Description | Example |
+|----------|-------------|---------|
+| Critical | Blocks core functionality | 403 on main action |
+| High | Major feature broken | Form submission fails |
+| Medium | Feature partially works | Missing validation |
+| Low | UI/UX issues | Misaligned elements |
+
+## Step 7: Log Bugs as GitHub Issues
+
+For each bug:
+1. Resolve repository from config or `gh repo view`
+2. Title: `[Bug] <Area>: <Brief description>`
+3. Include in body:
+   - Repro steps
+   - Expected vs actual behavior
+   - Console errors
+   - Technical analysis
+   - Environment details
+4. Apply labels (`bug`, optional severity label)
+
+```bash
+gh issue create --repo <repo> --title "<title>" --body "<body>" --label "bug"
+```
+
+## Step 8: Report Summary
+
+```markdown
+## QA Test Results
+
+**Target:** <URL>
+**Config:** .codex/qa.yml | interactive mode
+**Areas Tested:** <list>
+**Bugs Found:** N
+
+### Issues Created
+| # | Severity | Area | Description |
+|---|----------|------|-------------|
+| 1 | Critical | login | Form 500 on submit |
+
+### Test Coverage
+(Dynamic checklist from config test_areas, or generic areas tested)
+```
+
+## Step 9: Cleanup
+
+```
+close_session(session_id)
+```

--- a/.codex/skills/qa-help/SKILL.md
+++ b/.codex/skills/qa-help/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: qa-help
+description: Trigger `/qa:help` to show QA command guidance.
+---
+
+# qa-help
+
+## Trigger
+- Primary: `/qa:help`
+- Text alias: `qa:help`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/qa/help.md`
+
+## Execution
+1. Use this skill when the user asks for QA command help.
+2. Follow `.codex/prompts/qa/help.md` as the authoritative runbook.
+3. Keep guidance Codex-native and focused on `.codex/*` paths.

--- a/.codex/skills/qa-help/agents/openai.yaml
+++ b/.codex/skills/qa-help/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "qa:help"
+  short_description: "Trigger /qa:help"
+  default_prompt: "/qa:help"

--- a/.codex/skills/qa-test/SKILL.md
+++ b/.codex/skills/qa-test/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: qa-test
+description: Trigger `/qa:test`. Run automated QA testing workflow with Playwright MCP and GitHub issue logging.
+---
+
+# qa-test
+
+## Trigger
+- Primary: `/qa:test`
+- Text alias: `qa:test`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/qa/test.md`
+
+## Execution
+1. Use this skill when the user invokes `/qa:test` or explicitly asks for the QA `test` workflow.
+2. Follow the workflow steps in `.codex/prompts/qa/test.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before creating GitHub issues or changing external systems.

--- a/.codex/skills/qa-test/agents/openai.yaml
+++ b/.codex/skills/qa-test/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "qa:test"
+  short_description: "Trigger /qa:test"
+  default_prompt: "/qa:test"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,5 +37,6 @@
 - CI/CD slash trigger parity is mapped in `docs/skills/cicd-command-skill-map.md`.
 - Flow slash trigger parity is mapped in `docs/skills/flow-command-skill-map.md`.
 - GitHub slash trigger parity is mapped in `docs/skills/github-command-skill-map.md`.
+- QA slash trigger parity is mapped in `docs/skills/qa-command-skill-map.md`.
 - Project slash trigger parity is mapped in `docs/skills/project-command-skill-map.md`.
 - AGENTS.md governance trigger parity is mapped in `docs/skills/agents-md-command-skill-map.md`.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ The `/github:*` namespace is available through:
 - `.codex/skills/github-*/` - backing Codex skill packages
 - `docs/skills/github-command-skill-map.md` - trigger-to-skill inventory
 
+## QA Trigger Parity
+
+The `/qa:*` namespace is available through:
+
+- `.claude/commands/qa/*.md` - source command inventory
+- `.codex/prompts/qa/*.md` - slash-compatible entrypoints
+- `.codex/skills/qa-*/` - backing Codex skill packages
+- `docs/skills/qa-command-skill-map.md` - trigger-to-skill inventory
+
 ## Project Trigger Parity
 
 The `/project:*` namespace is available through:

--- a/docs/skills/qa-command-skill-map.md
+++ b/docs/skills/qa-command-skill-map.md
@@ -1,0 +1,10 @@
+# QA Trigger to Skill Map
+
+This file maps QA testing triggers to Codex prompts and skill packages.
+
+| Trigger | Prompt Entrypoint | Skill Package |
+|---|---|---|
+| `/qa:help` | `.codex/prompts/qa/help.md` | `.codex/skills/qa-help/SKILL.md` |
+| `/qa:test` | `.codex/prompts/qa/test.md` | `.codex/skills/qa-test/SKILL.md` |
+
+Canonical inventory: `.claude/commands/qa/*.md`, `.codex/prompts/qa/*.md`, and `.codex/skills/qa-*/`.

--- a/tests/test_qa_skill_trigger_parity.py
+++ b/tests/test_qa_skill_trigger_parity.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_DIR = ROOT / ".claude" / "commands" / "qa"
+PROMPT_DIR = ROOT / ".codex" / "prompts" / "qa"
+SKILLS_DIR = ROOT / ".codex" / "skills"
+
+
+def _source_commands() -> set[str]:
+    return {path.stem for path in SOURCE_DIR.glob("*.md")}
+
+
+def _target_prompts() -> set[str]:
+    return {path.stem for path in PROMPT_DIR.glob("*.md")}
+
+
+def test_qa_prompt_trigger_parity_with_source_commands() -> None:
+    assert _target_prompts() == _source_commands()
+
+
+def test_every_qa_prompt_has_backing_skill_package() -> None:
+    for command in sorted(_source_commands()):
+        trigger = f"/qa:{command}"
+        skill_name = f"qa-{command}"
+
+        skill_md = SKILLS_DIR / skill_name / "SKILL.md"
+        agent_yaml = SKILLS_DIR / skill_name / "agents" / "openai.yaml"
+        prompt_md = PROMPT_DIR / f"{command}.md"
+
+        assert skill_md.exists(), f"Missing skill file for {trigger}: {skill_md}"
+        assert agent_yaml.exists(), f"Missing agents metadata for {trigger}: {agent_yaml}"
+
+        prompt_text = prompt_md.read_text()
+        skill_text = skill_md.read_text()
+
+        assert f"Backing skill: `{skill_name}`" in prompt_text
+        assert trigger in skill_text
+        assert f".codex/prompts/qa/{command}.md" in skill_text
+
+
+def test_qa_agent_metadata_points_to_expected_triggers() -> None:
+    for command in sorted(_source_commands()):
+        skill_name = f"qa-{command}"
+        trigger = f"/qa:{command}"
+        agent_yaml = SKILLS_DIR / skill_name / "agents" / "openai.yaml"
+        text = agent_yaml.read_text()
+
+        assert f'display_name: "qa:{command}"' in text
+        assert f'default_prompt: "{trigger}"' in text


### PR DESCRIPTION
## Summary
- port `/qa:help` and `/qa:test` into Codex prompts and skill packages with trigger parity
- add skill agent metadata for both QA skills and a dedicated QA trigger parity test
- add QA trigger mapping docs and wire discoverability updates in `AGENTS.md` and `README.md`
- update QA guidance to use regular Playwright MCP wording (`mcp-playwright`)

## Validation
- `env UV_CACHE_DIR=/tmp/uv-cache make verify`

## Follow-up
- tracked MCP cleanup for legacy references in #23 (`mcp-playwright-persistent` and `sequential-thinking`)

Closes #10
