### PR TITLE
chore(mcp): standardize codex-* server names (Closes #23)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,10 @@
 - `.codex/skills/` - Codex skill packages backing slash-style command workflows
 - `.codex/cicd.yml` - CI/CD config
 - `.codex/cicd_tasks.yml` - deterministic CI/CD task manifest
-- `mcp-second-opinion/` - external review server
-- `mcp-playwright-persistent/` - browser automation server
-- `mcp-nano-banana/` - diagram and PowerPoint server
-- `mcp-woodpecker-ci/` - Woodpecker CI server
+- `codex-second-opinion/` - external review server
+- `codex-playwright/` - browser automation server
+- `codex-nano-banana/` - diagram and PowerPoint server
+- `codex-woodpecker/` - Woodpecker CI server
 - `lib/` - reusable Python libraries for creds, security, CI/CD, and spec sync
 - `templates/` - starter Makefiles and workflow templates
 - `scripts/` - shell helpers

--- a/INSTALLATION_ISSUES.md
+++ b/INSTALLATION_ISSUES.md
@@ -21,7 +21,7 @@ playwright._impl._errors.Error: Executable doesn't exist at /home/user/.cache/ms
 
 **Solution**: Install Playwright browsers:
 ```bash
-cd mcp-playwright-persistent
+cd mcp-playwright-persistent  # codex-playwright service
 uv run playwright install chromium
 ```
 
@@ -38,7 +38,7 @@ Missing API key: GEMINI_API_KEY or OPENAI_API_KEY
 
 **Solution**: Copy the .env.example and add your keys:
 ```bash
-cd mcp-second-opinion
+cd mcp-second-opinion  # codex-second-opinion service
 cp .env.example .env
 # Edit .env with your API keys
 ```

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ update_docs:
 ## Docker (MCP server containers)
 ## Usage: make docker-up PROFILE=core
 ##        make docker-up PROFILE="core browser"
-## Profiles: core (second-opinion + nano-banana), browser, coord
+## Profiles: core (codex-second-opinion + codex-nano-banana), browser, cicd
 
 PROFILE ?= core
 
@@ -58,13 +58,13 @@ docker-up: docker-check-env
 	$(foreach p,$(PROFILE),docker compose --profile $(p) up -d;)
 
 docker-down:
-	docker compose --profile core --profile browser --profile cicd --profile coord down
+	docker compose --profile core --profile browser --profile cicd down
 
 docker-logs:
-	docker compose --profile core --profile browser --profile cicd --profile coord logs -f
+	docker compose --profile core --profile browser --profile cicd logs -f
 
 docker-ps:
-	docker compose --profile core --profile browser --profile cicd --profile coord ps
+	docker compose --profile core --profile browser --profile cicd ps
 
 ## Deploy (used by Woodpecker CI and /flow:deploy)
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ management, templates, and tests for Codex-centric workflows.
 - `.codex/skills/` - Codex skill packages that back slash-style trigger workflows
 - `.codex/cicd.yml` and `.codex/cicd_tasks.yml` - Codex-local CI/CD manifests
 - `AGENTS.md` - the canonical repo instructions for Codex
-- `mcp-second-opinion/` - external LLM code review server
-- `mcp-playwright-persistent/` - persistent browser automation server
-- `mcp-nano-banana/` - diagram and PowerPoint generation server
-- `mcp-woodpecker-ci/` - Woodpecker CI monitoring and control server
+- `codex-second-opinion/` - external LLM code review server
+- `codex-playwright/` - browser automation server
+- `codex-nano-banana/` - diagram and PowerPoint generation server
+- `codex-woodpecker/` - Woodpecker CI monitoring and control server
 - `lib/creds/`, `lib/security/`, `lib/cicd/`, `lib/spec_bridge/` - reusable Python libraries
 - `templates/`, `scripts/`, `docs/skills/`, `tests/` - supporting workflow assets
 
@@ -29,8 +29,8 @@ make docker-up PROFILE=core
 
 The default Docker profile starts:
 
-- `mcp-second-opinion` on `127.0.0.1:8080`
-- `mcp-nano-banana` on `127.0.0.1:8084`
+- `codex-second-opinion` on `127.0.0.1:8080`
+- `codex-nano-banana` on `127.0.0.1:8084`
 
 Add the browser profile for Playwright:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,12 +17,12 @@
 #   WOODPECKER_API_TOKEN=...    (optional local override)
 
 services:
-  mcp-second-opinion:
+  codex-second-opinion:
     build:
-      context: ./mcp-second-opinion
+      context: ./codex-second-opinion
       dockerfile: deploy/Dockerfile
-    image: mcp-second-opinion:latest
-    container_name: mcp-second-opinion
+    image: codex-second-opinion:latest
+    container_name: codex-second-opinion
     ports:
       - "8080:8080"
     env_file:
@@ -53,12 +53,12 @@ services:
           cpus: "0.5"
           memory: 256M
 
-  mcp-nano-banana:
+  codex-nano-banana:
     build:
-      context: ./mcp-nano-banana
+      context: ./codex-nano-banana
       dockerfile: deploy/Dockerfile
-    image: mcp-nano-banana:latest
-    container_name: mcp-nano-banana
+    image: codex-nano-banana:latest
+    container_name: codex-nano-banana
     ports:
       - "8084:8084"
     environment:
@@ -80,12 +80,12 @@ services:
           cpus: "0.25"
           memory: 128M
 
-  mcp-woodpecker-ci:
+  codex-woodpecker:
     build:
-      context: ./mcp-woodpecker-ci
+      context: ./codex-woodpecker
       dockerfile: deploy/Dockerfile
-    image: mcp-woodpecker-ci:latest
-    container_name: mcp-woodpecker-ci
+    image: codex-woodpecker:latest
+    container_name: codex-woodpecker
     ports:
       - "8085:8085"
     environment:
@@ -112,12 +112,12 @@ services:
           cpus: "0.25"
           memory: 128M
 
-  mcp-playwright-persistent:
+  codex-playwright:
     build:
-      context: ./mcp-playwright-persistent
+      context: ./codex-playwright
       dockerfile: deploy/Dockerfile
-    image: mcp-playwright-persistent:latest
-    container_name: mcp-playwright-persistent
+    image: codex-playwright:latest
+    container_name: codex-playwright
     ports:
       - "8081:8081"
     shm_size: "2gb"
@@ -142,4 +142,4 @@ services:
 
 networks:
   default:
-    name: mcp-net
+    name: codex-mcp-net

--- a/docs/skills/mcp-optimization.md
+++ b/docs/skills/mcp-optimization.md
@@ -106,8 +106,8 @@ claude mcp add playwright -- npx -y @playwright/mcp@latest
 ## Related Resources
 
 - `MCP_TOKEN_AUDIT_CHECKLIST.md` - Token audit checklist
-- `mcp-second-opinion/` - Gemini-powered code review MCP
-- `mcp-playwright-persistent/` - Persistent browser automation MCP
+- `codex-second-opinion/` - Gemini-powered code review MCP
+- `codex-playwright/` - Persistent browser automation MCP
 
 ---
 

--- a/lib/creds/masking.py
+++ b/lib/creds/masking.py
@@ -18,7 +18,7 @@ Usage:
     safe = masker.mask(some_output)
 
 Pattern sources:
-    mcp-second-opinion/src/prompts.py:7-30
+    codex-second-opinion/src/prompts.py:7-30
 """
 
 from __future__ import annotations

--- a/mcp-nano-banana/pyproject.toml
+++ b/mcp-nano-banana/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "mcp-nano-banana"
+name = "codex-nano-banana"
 version = "1.1.0"
 description = "Diagram generation MCP server — best-in-class HTML/SVG diagrams for presentations"
 readme = "README.md"

--- a/mcp-nano-banana/src/config.py
+++ b/mcp-nano-banana/src/config.py
@@ -24,7 +24,7 @@ def _get_int_env(name: str, default: int) -> int:
 class Config:
     """Server configuration."""
 
-    SERVER_NAME: str = "mcp-nano-banana"
+    SERVER_NAME: str = "codex-nano-banana"
     SERVER_VERSION: str = "1.0.0"
     SERVER_HOST: str = os.getenv("MCP_SERVER_HOST", "127.0.0.1")
     SERVER_PORT: int = _get_int_env("MCP_SERVER_PORT", 8084)

--- a/mcp-playwright-persistent/deploy/install-service.sh
+++ b/mcp-playwright-persistent/deploy/install-service.sh
@@ -113,8 +113,8 @@ fi
 echo
 
 # Read template and substitute variables
-TEMPLATE_FILE="$MCP_SERVER_DIR/deploy/mcp-playwright.service.template"
-OUTPUT_FILE="$MCP_SERVER_DIR/deploy/mcp-playwright.service"
+TEMPLATE_FILE="$MCP_SERVER_DIR/deploy/codex-playwright.service.template"
+OUTPUT_FILE="$MCP_SERVER_DIR/deploy/codex-playwright.service"
 
 if [[ ! -f "$TEMPLATE_FILE" ]]; then
     echo -e "${RED}Error: Template file not found: $TEMPLATE_FILE${NC}"
@@ -145,13 +145,13 @@ if $GENERATE_ONLY; then
         echo "  mkdir -p ~/.config/systemd/user"
         echo "  cp $OUTPUT_FILE ~/.config/systemd/user/"
         echo "  systemctl --user daemon-reload"
-        echo "  systemctl --user enable mcp-playwright"
-        echo "  systemctl --user start mcp-playwright"
+        echo "  systemctl --user enable codex-playwright"
+        echo "  systemctl --user start codex-playwright"
     else
         echo "  sudo cp $OUTPUT_FILE /etc/systemd/system/"
         echo "  sudo systemctl daemon-reload"
-        echo "  sudo systemctl enable mcp-playwright"
-        echo "  sudo systemctl start mcp-playwright"
+        echo "  sudo systemctl enable codex-playwright"
+        echo "  sudo systemctl start codex-playwright"
     fi
     exit 0
 fi
@@ -167,10 +167,10 @@ if [[ "$INSTALL_MODE" == "user" ]]; then
     echo -e "${GREEN}Service installed successfully!${NC}"
     echo
     echo "Commands:"
-    echo "  systemctl --user enable mcp-playwright  # Enable on login"
-    echo "  systemctl --user start mcp-playwright   # Start now"
-    echo "  systemctl --user status mcp-playwright  # Check status"
-    echo "  journalctl --user -u mcp-playwright -f  # View logs"
+    echo "  systemctl --user enable codex-playwright  # Enable on login"
+    echo "  systemctl --user start codex-playwright   # Start now"
+    echo "  systemctl --user status codex-playwright  # Check status"
+    echo "  journalctl --user -u codex-playwright -f  # View logs"
 else
     echo "Installing as system service (requires sudo)..."
     sudo cp "$OUTPUT_FILE" /etc/systemd/system/
@@ -179,10 +179,10 @@ else
     echo -e "${GREEN}Service installed successfully!${NC}"
     echo
     echo "Commands:"
-    echo "  sudo systemctl enable mcp-playwright  # Enable on boot"
-    echo "  sudo systemctl start mcp-playwright   # Start now"
-    echo "  sudo systemctl status mcp-playwright  # Check status"
-    echo "  sudo journalctl -u mcp-playwright -f  # View logs"
+    echo "  sudo systemctl enable codex-playwright  # Enable on boot"
+    echo "  sudo systemctl start codex-playwright   # Start now"
+    echo "  sudo systemctl status codex-playwright  # Check status"
+    echo "  sudo journalctl -u codex-playwright -f  # View logs"
 fi
 
 echo

--- a/mcp-playwright-persistent/deploy/mcp-playwright.service
+++ b/mcp-playwright-persistent/deploy/mcp-playwright.service
@@ -1,25 +1,25 @@
-# Install as a user service: systemctl --user enable mcp-playwright
-# Copy to: ~/.config/systemd/user/mcp-playwright.service
+# Install as a user service: systemctl --user enable codex-playwright
+# Copy to: ~/.config/systemd/user/codex-playwright.service
 # %h expands to the user's home directory in user services.
 
 [Unit]
-Description=MCP Playwright Persistent Server (SSE Transport)
+Description=codex-playwright server (SSE Transport)
 After=network.target
 Documentation=https://github.com/cooneycw/codex-power-pack
 
 [Service]
 Type=simple
-WorkingDirectory=%h/Projects/codex-power-pack/mcp-playwright-persistent
+WorkingDirectory=%h/Projects/codex-power-pack/codex-playwright-persistent
 
 # Load environment variables from .env file (if exists)
-EnvironmentFile=-%h/Projects/codex-power-pack/mcp-playwright-persistent/.env
+EnvironmentFile=-%h/Projects/codex-power-pack/codex-playwright-persistent/.env
 
 # Explicit port configuration
 Environment="SERVER_PORT=8081"
 Environment="SERVER_HOST=127.0.0.1"
 
 # Use uv to run in the project environment
-ExecStart=%h/.local/bin/uv run --project %h/Projects/codex-power-pack/mcp-playwright-persistent python src/server.py
+ExecStart=%h/.local/bin/uv run --project %h/Projects/codex-power-pack/codex-playwright-persistent python src/server.py
 
 # Restart policy
 Restart=on-failure
@@ -30,7 +30,7 @@ StartLimitIntervalSec=300
 # Logging
 StandardOutput=journal
 StandardError=journal
-SyslogIdentifier=mcp-playwright
+SyslogIdentifier=codex-playwright
 
 # Security hardening
 NoNewPrivileges=true

--- a/mcp-playwright-persistent/deploy/mcp-playwright.service.template
+++ b/mcp-playwright-persistent/deploy/mcp-playwright.service.template
@@ -1,5 +1,5 @@
 [Unit]
-Description=MCP Playwright Persistent Server (SSE Transport)
+Description=codex-playwright server (SSE Transport)
 After=network.target
 Documentation=https://github.com/cooneycw/codex-power-pack
 
@@ -27,7 +27,7 @@ StartLimitIntervalSec=300
 # Logging
 StandardOutput=journal
 StandardError=journal
-SyslogIdentifier=mcp-playwright
+SyslogIdentifier=codex-playwright
 
 # Security hardening
 NoNewPrivileges=true

--- a/mcp-playwright-persistent/pyproject.toml
+++ b/mcp-playwright-persistent/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "mcp-playwright-persistent"
+name = "codex-playwright"
 version = "1.0.0"
 description = "Persistent browser automation MCP server for Codex"
 readme = "README.md"

--- a/mcp-playwright-persistent/src/server.py
+++ b/mcp-playwright-persistent/src/server.py
@@ -44,7 +44,7 @@ SESSION_TIMEOUT = int(os.getenv("SESSION_TIMEOUT", "3600"))  # 1 hour default
 
 # Initialize FastMCP
 mcp = FastMCP(
-    "MCP Playwright Persistent",
+    "codex-playwright",
     instructions="""Persistent browser automation with session management.
 
     Create a session first with create_session(), then use session_id for all operations.
@@ -70,7 +70,7 @@ async def root_health_check(request: Request) -> JSONResponse:
     """Health check endpoint for Codex MCP connection verification."""
     return JSONResponse({
         "status": "healthy",
-        "server": "MCP Playwright Persistent",
+        "server": "codex-playwright",
         "port": SERVER_PORT,
         "sessions": len(sessions),
     })
@@ -716,7 +716,7 @@ async def health_check() -> dict:
     """Check MCP server health and browser status."""
     return {
         "status": "healthy",
-        "server": "MCP Playwright Persistent",
+        "server": "codex-playwright",
         "port": SERVER_PORT,
         "sessions": len(sessions),
         "browser_running": browser_instance is not None
@@ -729,7 +729,7 @@ async def health_check() -> dict:
 
 def main():
     """Main entry point for the MCP server."""
-    parser = argparse.ArgumentParser(description="MCP Playwright Persistent")
+    parser = argparse.ArgumentParser(description="codex-playwright")
     parser.add_argument(
         "--stdio",
         action="store_true",

--- a/mcp-second-opinion/deploy/mcp-second-opinion.service
+++ b/mcp-second-opinion/deploy/mcp-second-opinion.service
@@ -1,5 +1,5 @@
-# Install as a user service: systemctl --user enable mcp-second-opinion
-# Copy to: ~/.config/systemd/user/mcp-second-opinion.service
+# Install as a user service: systemctl --user enable codex-second-opinion
+# Copy to: ~/.config/systemd/user/codex-second-opinion.service
 # %h expands to the user's home directory in user services.
 
 [Unit]
@@ -9,17 +9,17 @@ Documentation=https://github.com/cooneycw/codex-power-pack
 
 [Service]
 Type=simple
-WorkingDirectory=%h/Projects/codex-power-pack/mcp-second-opinion
+WorkingDirectory=%h/Projects/codex-power-pack/codex-second-opinion
 
 # Load environment variables from .env file
-EnvironmentFile=%h/Projects/codex-power-pack/mcp-second-opinion/.env
+EnvironmentFile=%h/Projects/codex-power-pack/codex-second-opinion/.env
 
 # Explicit port configuration (won't conflict with web servers on 80/443)
 Environment="MCP_SERVER_PORT=8080"
 Environment="MCP_SERVER_HOST=127.0.0.1"
 
 # Use uv to run in the project environment
-ExecStart=%h/.local/bin/uv run --project %h/Projects/codex-power-pack/mcp-second-opinion python src/server.py
+ExecStart=%h/.local/bin/uv run --project %h/Projects/codex-power-pack/codex-second-opinion python src/server.py
 
 # Restart policy
 Restart=on-failure
@@ -30,7 +30,7 @@ StartLimitIntervalSec=300
 # Logging
 StandardOutput=journal
 StandardError=journal
-SyslogIdentifier=mcp-second-opinion
+SyslogIdentifier=codex-second-opinion
 
 # Security hardening
 NoNewPrivileges=true

--- a/mcp-second-opinion/deploy/mcp-second-opinion.service.template
+++ b/mcp-second-opinion/deploy/mcp-second-opinion.service.template
@@ -27,7 +27,7 @@ StartLimitIntervalSec=300
 # Logging
 StandardOutput=journal
 StandardError=journal
-SyslogIdentifier=mcp-second-opinion
+SyslogIdentifier=codex-second-opinion
 
 # Security hardening
 NoNewPrivileges=true

--- a/mcp-second-opinion/pyproject.toml
+++ b/mcp-second-opinion/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "mcp-second-opinion"
+name = "codex-second-opinion"
 version = "1.0.0"
 description = "Gemini-powered code review MCP server for Codex"
 readme = "README.md"

--- a/mcp-second-opinion/scripts/install-service.sh
+++ b/mcp-second-opinion/scripts/install-service.sh
@@ -108,8 +108,8 @@ fi
 echo
 
 # Read template and substitute variables
-TEMPLATE_FILE="$MCP_SERVER_DIR/deploy/mcp-second-opinion.service.template"
-OUTPUT_FILE="$MCP_SERVER_DIR/deploy/mcp-second-opinion.service"
+TEMPLATE_FILE="$MCP_SERVER_DIR/deploy/codex-second-opinion.service.template"
+OUTPUT_FILE="$MCP_SERVER_DIR/deploy/codex-second-opinion.service"
 
 if [[ ! -f "$TEMPLATE_FILE" ]]; then
     echo -e "${RED}Error: Template file not found: $TEMPLATE_FILE${NC}"
@@ -140,13 +140,13 @@ if $GENERATE_ONLY; then
         echo "  mkdir -p ~/.config/systemd/user"
         echo "  cp $OUTPUT_FILE ~/.config/systemd/user/"
         echo "  systemctl --user daemon-reload"
-        echo "  systemctl --user enable mcp-second-opinion"
-        echo "  systemctl --user start mcp-second-opinion"
+        echo "  systemctl --user enable codex-second-opinion"
+        echo "  systemctl --user start codex-second-opinion"
     else
         echo "  sudo cp $OUTPUT_FILE /etc/systemd/system/"
         echo "  sudo systemctl daemon-reload"
-        echo "  sudo systemctl enable mcp-second-opinion"
-        echo "  sudo systemctl start mcp-second-opinion"
+        echo "  sudo systemctl enable codex-second-opinion"
+        echo "  sudo systemctl start codex-second-opinion"
     fi
     exit 0
 fi
@@ -162,10 +162,10 @@ if [[ "$INSTALL_MODE" == "user" ]]; then
     echo -e "${GREEN}Service installed successfully!${NC}"
     echo
     echo "Commands:"
-    echo "  systemctl --user enable mcp-second-opinion  # Enable on login"
-    echo "  systemctl --user start mcp-second-opinion   # Start now"
-    echo "  systemctl --user status mcp-second-opinion  # Check status"
-    echo "  journalctl --user -u mcp-second-opinion -f  # View logs"
+    echo "  systemctl --user enable codex-second-opinion  # Enable on login"
+    echo "  systemctl --user start codex-second-opinion   # Start now"
+    echo "  systemctl --user status codex-second-opinion  # Check status"
+    echo "  journalctl --user -u codex-second-opinion -f  # View logs"
 else
     echo "Installing as system service (requires sudo)..."
     sudo cp "$OUTPUT_FILE" /etc/systemd/system/
@@ -174,10 +174,10 @@ else
     echo -e "${GREEN}Service installed successfully!${NC}"
     echo
     echo "Commands:"
-    echo "  sudo systemctl enable mcp-second-opinion  # Enable on boot"
-    echo "  sudo systemctl start mcp-second-opinion   # Start now"
-    echo "  sudo systemctl status mcp-second-opinion  # Check status"
-    echo "  sudo journalctl -u mcp-second-opinion -f  # View logs"
+    echo "  sudo systemctl enable codex-second-opinion  # Enable on boot"
+    echo "  sudo systemctl start codex-second-opinion   # Start now"
+    echo "  sudo systemctl status codex-second-opinion  # Check status"
+    echo "  sudo journalctl -u codex-second-opinion -f  # View logs"
 fi
 
 echo

--- a/mcp-second-opinion/src/config.py
+++ b/mcp-second-opinion/src/config.py
@@ -372,7 +372,7 @@ class Config:
     RETRY_MAX_WAIT: int = 10  # seconds
 
     # Server Configuration
-    SERVER_NAME: str = "second-opinion-server"
+    SERVER_NAME: str = "codex-second-opinion"
     SERVER_VERSION: str = "2.1.0"  # FastMCP 3.x, SSE transport
 
     # HTTP/SSE Transport Configuration (with safe parsing)

--- a/mcp-woodpecker-ci/pyproject.toml
+++ b/mcp-woodpecker-ci/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "mcp-woodpecker-ci"
+name = "codex-woodpecker"
 version = "1.0.0"
 description = "Woodpecker CI MCP server - pipeline management and monitoring for Codex"
 readme = "README.md"

--- a/mcp-woodpecker-ci/src/config.py
+++ b/mcp-woodpecker-ci/src/config.py
@@ -77,7 +77,7 @@ _wp_url, _wp_token = _resolve_woodpecker_config()
 class Config:
     """Server configuration."""
 
-    SERVER_NAME: str = "mcp-woodpecker-ci"
+    SERVER_NAME: str = "codex-woodpecker"
     SERVER_VERSION: str = "1.0.0"
     SERVER_HOST: str = os.getenv("MCP_SERVER_HOST", "127.0.0.1")
     SERVER_PORT: int = _get_int_env("MCP_SERVER_PORT", 8085)

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ wheels = [
 ]
 
 [[package]]
-name = "claude-power-pack"
+name = "codex-power-pack"
 version = "5.2.0"
 source = { virtual = "." }
 


### PR DESCRIPTION
## Summary
- standardize active MCP runtime/service naming to `codex-*` for the retained four MCPs:
  - `codex-second-opinion`
  - `codex-nano-banana`
  - `codex-woodpecker`
  - `codex-playwright`
- update docker compose service/image/container identifiers and shared network naming
- align server-reported names and systemd installer/service identifiers with `codex-*`
- update top-level docs and guidance to reflect codex naming policy and remove stale references to deprecated MCPs
- refresh `uv.lock` project package name alignment to `codex-power-pack`

## Validation
- `env UV_CACHE_DIR=/tmp/uv-cache make verify`

Closes #23
