### PR TITLE
feat(second-opinion): port trigger parity namespace (Closes #11)

### DIFF
--- a/.codex/prompts/second-opinion/help.md
+++ b/.codex/prompts/second-opinion/help.md
@@ -1,0 +1,77 @@
+---
+description: Overview of Second Opinion commands
+---
+
+> Trigger parity entrypoint for `/second-opinion:help`.
+> Backing skill: `second-opinion-help` (`.codex/skills/second-opinion-help/SKILL.md`).
+
+# Second Opinion Commands
+
+Commands for AI-powered code review using multiple LLM models.
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `/second-opinion:start` | Quick review with sensible defaults (file + model + depth) |
+| `/second-opinion:models` | Interactive model and depth selection with menus |
+| `/second-opinion:help` | This help overview |
+
+## Quick Usage
+
+```bash
+# Interactive model selection
+/second-opinion:models
+
+# Review specific code
+/second-opinion:models "review my auth middleware"
+```
+
+## Available Models
+
+| Key | Model | Provider | Best For |
+|-----|-------|----------|----------|
+| `gemini-3-pro` | Gemini 3.1 Pro | Google | Comprehensive analysis |
+| `gemini-2.5-pro` | Gemini 2.5 Pro | Google | Stable, proven |
+| `claude-sonnet` | Claude Sonnet 4.6 | Anthropic | Fast, excellent for code review |
+| `claude-haiku` | Claude Haiku 4.5 | Anthropic | Fastest Claude, cost-effective |
+| `claude-opus` | Claude Opus 4.6 | Anthropic | Most capable Claude |
+| `codex` | GPT-5.3 Codex | OpenAI | Default coding model |
+| `codex-mini` | GPT-5.2 Codex | OpenAI | Cost-effective coding |
+| `o4-mini` | o4-mini | OpenAI | Fast reasoning |
+| `o3` | o3 | OpenAI | Advanced reasoning |
+| `gpt-5.2` | GPT-5.2 | OpenAI | Latest GPT |
+| `gpt-4o` | GPT-4o | OpenAI | Fast multimodal |
+
+## Direct MCP Tool Usage
+
+You can also invoke the MCP tools directly without commands:
+
+- `get_code_second_opinion` - Single-model review (Gemini default)
+- `get_multi_model_second_opinion` - Multi-model parallel review
+- `list_available_models` - Check which models are configured
+- `create_session` / `consult` - Multi-turn conversations
+
+## Requirements
+
+- MCP Second Opinion server configured (stdio recommended, or SSE on port 9100)
+- At least one API key configured (GEMINI_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY)
+- All three recommended for cross-provider comparison
+
+## Troubleshooting
+
+**Error `-32602: Invalid request parameters`** usually means the server isn't running, not that parameters are wrong.
+
+**Fix:** Switch from SSE to stdio transport (auto-starts the server):
+
+```bash
+codex mcp remove second-opinion
+codex mcp add second-opinion --transport stdio -- uv run --directory /path/to/codex-power-pack/codex-second-opinion python src/server.py --stdio
+```
+
+**Diagnose configuration:**
+
+```bash
+cd /path/to/codex-power-pack/codex-second-opinion
+./start-server.sh --diagnose
+```

--- a/.codex/prompts/second-opinion/models.md
+++ b/.codex/prompts/second-opinion/models.md
@@ -1,0 +1,120 @@
+---
+description: Select models and depth for second opinion code review
+allowed-tools: mcp__second-opinion__list_available_models, mcp__second-opinion__get_multi_model_second_opinion, mcp__second-opinion__get_code_second_opinion
+---
+
+> Trigger parity entrypoint for `/second-opinion:models`.
+> Backing skill: `second-opinion-models` (`.codex/skills/second-opinion-models/SKILL.md`).
+
+# Second Opinion: Model Selection
+
+Interactive model and depth selection for code review consultations.
+
+ARGUMENTS: $ARGUMENTS
+
+---
+
+## Step 1: List Available Models
+
+Call `list_available_models` to get the current list of configured and available models.
+
+Display the results in a clear table showing:
+- Model key (what the user selects)
+- Display name
+- Provider
+- Description
+- Whether it's available (API key configured)
+
+---
+
+## Step 2: Two-Part Selection Menu
+
+Use AskUserQuestion to present **two questions simultaneously**:
+
+### Question 1: Select Models (multiSelect=true)
+
+Present available models grouped by provider. Only show models that are available (API key configured).
+
+Options (show up to 4 most relevant, user can type Others):
+- `gemini-3-pro + claude-sonnet` - Gemini 3.1 + Claude Sonnet (Recommended, best cross-provider coverage)
+- `gemini-3-pro + codex` - Gemini 3.1 + GPT-5.3 Codex (Google + OpenAI)
+- `claude-sonnet` - Claude Sonnet 4.6 only (fast, excellent for code)
+- `codex + o4-mini` - GPT-5.3 Codex + o4-mini (OpenAI coding + reasoning)
+
+If user types Other, they can specify any model keys: `gemini-2.5-pro`, `claude-haiku`, `claude-opus`, `codex-mini`, `o3`, `o1`, `gpt-5.2`, `gpt-4o`, etc.
+
+### Question 2: Analysis Depth
+
+Options:
+- `brief` - Quick feedback, key issues only (~4K tokens output)
+- `detailed` - Comprehensive analysis with recommendations (Recommended, ~48K tokens output)
+- `in_depth` - Exhaustive 64K analysis, covers edge cases, security, architecture
+
+---
+
+## Step 3: Get Code Context
+
+If the user provided code or a file path in the ARGUMENTS, use that.
+
+Otherwise, ask the user using AskUserQuestion:
+
+- **Paste code** - Provide code directly
+- **File path** - Specify a file to read
+- **Recent context** - Use code from current conversation
+
+If a file path is given, read it.
+
+---
+
+## Step 4: Ask for Context (Optional)
+
+Ask briefly if they have specific concerns:
+
+```
+Any specific concerns about this code? (optional)
+```
+
+---
+
+## Step 5: Run Consultation
+
+Based on selections:
+
+- **Single model:** Use `get_code_second_opinion` (Gemini) or `get_multi_model_second_opinion` with one model
+- **Multiple models:** Use `get_multi_model_second_opinion` with selected models
+
+Pass: code, language (auto-detect), verbosity (from depth selection), and any context/issue description.
+
+**Important:** Pass the verbosity parameter from the depth selection directly to the tool call. Do not hardcode it.
+
+---
+
+## Step 6: Display Results
+
+For multi-model results, display each model's response clearly separated:
+
+```
+=== {display_name} ({depth}) ===
+Cost: ${cost}
+
+{response}
+
+---
+```
+
+At the end:
+
+```
+Total cost: ${total_cost}
+Models consulted: {count}
+Depth: {verbosity}
+```
+
+---
+
+## Notes
+
+- Only models with configured API keys are shown as available
+- Cost estimates are approximate (token counting heuristics)
+- `in_depth` generates significantly more output and costs more
+- Model keys are stable across versions (e.g., `gemini-3-pro` always points to latest Gemini)

--- a/.codex/prompts/second-opinion/start.md
+++ b/.codex/prompts/second-opinion/start.md
@@ -1,0 +1,120 @@
+---
+description: Quick second opinion with sensible defaults
+allowed-tools: mcp__second-opinion__get_code_second_opinion, mcp__second-opinion__get_multi_model_second_opinion, mcp__second-opinion__list_available_models
+---
+
+> Trigger parity entrypoint for `/second-opinion:start`.
+> Backing skill: `second-opinion-start` (`.codex/skills/second-opinion-start/SKILL.md`).
+
+# Second Opinion: Quick Start
+
+Get a fast second opinion with sensible defaults. No menus - just review.
+
+ARGUMENTS: $ARGUMENTS
+
+---
+
+## How It Works
+
+This command provides quick shortcuts for common review patterns. Parse the ARGUMENTS to determine what the user wants:
+
+### Pattern 1: File path provided
+```
+/second-opinion:start src/auth.py
+```
+Read the file, auto-detect language, run default models (gemini-3-pro) at `detailed` depth.
+
+### Pattern 2: File path + depth
+```
+/second-opinion:start src/auth.py brief
+/second-opinion:start src/auth.py in_depth
+```
+Read the file, use specified depth.
+
+### Pattern 3: File path + model(s)
+```
+/second-opinion:start src/auth.py codex
+/second-opinion:start src/auth.py gemini-3-pro,codex
+```
+Read the file, use specified model(s) at `detailed` depth.
+
+### Pattern 4: File path + model(s) + depth
+```
+/second-opinion:start src/auth.py codex,o4-mini in_depth
+```
+Read the file, use specified models at specified depth.
+
+### Pattern 5: Description only
+```
+/second-opinion:start "review my recent changes"
+```
+Look at recent conversation context for code, or ask user to provide it.
+
+### Pattern 6: No arguments
+```
+/second-opinion:start
+```
+Ask the user what they want reviewed (file path or paste code).
+
+---
+
+## Argument Parsing Rules
+
+1. **File paths** end in common extensions: `.py`, `.js`, `.ts`, `.tsx`, `.rs`, `.go`, `.java`, `.rb`, `.c`, `.cpp`, `.h`, `.cs`, `.swift`, `.kt`, `.sh`, `.yml`, `.yaml`, `.json`, `.toml`, `.sql`, `.md`
+2. **Depth keywords**: `brief`, `detailed`, `in_depth`, `in-depth`, `comprehensive`, `thorough`, `exhaustive`
+3. **Model keys**: `gemini-3-pro`, `gemini-2.5-pro`, `claude-sonnet`, `claude-haiku`, `claude-opus`, `codex`, `codex-max`, `codex-mini`, `o4-mini`, `o3`, `o1`, `gpt-5.2`, `gpt-4o` (comma-separated for multiple)
+4. **Everything else** is treated as context/issue description
+
+---
+
+## Defaults
+
+| Setting | Default |
+|---------|---------|
+| Model | `gemini-3-pro` (single model, fastest) |
+| Depth | `detailed` |
+| Language | Auto-detected from file extension |
+
+---
+
+## Execution
+
+1. Parse arguments per rules above
+2. If file path given, read the file
+3. If no code found, ask user
+4. Auto-detect language from file extension or content
+5. If single model AND model is `gemini-3-pro` (default): use `get_code_second_opinion` with verbosity parameter
+6. If single model AND model is NOT `gemini-3-pro`: use `get_multi_model_second_opinion` with `models: ["<model_key>"]` and verbosity parameter
+7. If multiple models: use `get_multi_model_second_opinion` with verbosity parameter
+7. Display results with cost
+
+---
+
+## Examples
+
+```bash
+# Quick Gemini review of a file
+/second-opinion:start src/server.py
+
+# Brief review (just key issues)
+/second-opinion:start src/server.py brief
+
+# Claude Sonnet review
+/second-opinion:start src/auth.py claude-sonnet
+
+# Multi-model deep dive (3 providers)
+/second-opinion:start src/server.py gemini-3-pro,claude-sonnet,codex in_depth
+
+# Fast reasoning check
+/second-opinion:start src/config.py o4-mini brief
+
+# Cross-provider comparison
+/second-opinion:start src/api.py gemini-3-pro,claude-opus
+```
+
+---
+
+## Related Commands
+
+- `/second-opinion:models` - Full interactive model/depth selection with menus
+- `/second-opinion:help` - Overview of all commands

--- a/.codex/skills/second-opinion-help/SKILL.md
+++ b/.codex/skills/second-opinion-help/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: second-opinion-help
+description: Trigger `/second-opinion:help`.
+---
+
+# second-opinion-help
+
+## Trigger
+- Primary: `/second-opinion:help`
+- Text alias: `second-opinion:help`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/second-opinion/help.md`
+
+## Execution
+1. Use this skill when the user invokes `/second-opinion:help` or explicitly asks for the second-opinion `help` workflow.
+2. Follow the workflow steps in `.codex/prompts/second-opinion/help.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/second-opinion-help/agents/openai.yaml
+++ b/.codex/skills/second-opinion-help/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "second-opinion:help"
+  short_description: "Trigger /second-opinion:help"
+  default_prompt: "/second-opinion:help"

--- a/.codex/skills/second-opinion-models/SKILL.md
+++ b/.codex/skills/second-opinion-models/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: second-opinion-models
+description: Trigger `/second-opinion:models`.
+---
+
+# second-opinion-models
+
+## Trigger
+- Primary: `/second-opinion:models`
+- Text alias: `second-opinion:models`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/second-opinion/models.md`
+
+## Execution
+1. Use this skill when the user invokes `/second-opinion:models` or explicitly asks for the second-opinion `models` workflow.
+2. Follow the workflow steps in `.codex/prompts/second-opinion/models.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/second-opinion-models/agents/openai.yaml
+++ b/.codex/skills/second-opinion-models/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "second-opinion:models"
+  short_description: "Trigger /second-opinion:models"
+  default_prompt: "/second-opinion:models"

--- a/.codex/skills/second-opinion-start/SKILL.md
+++ b/.codex/skills/second-opinion-start/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: second-opinion-start
+description: Trigger `/second-opinion:start`.
+---
+
+# second-opinion-start
+
+## Trigger
+- Primary: `/second-opinion:start`
+- Text alias: `second-opinion:start`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/second-opinion/start.md`
+
+## Execution
+1. Use this skill when the user invokes `/second-opinion:start` or explicitly asks for the second-opinion `start` workflow.
+2. Follow the workflow steps in `.codex/prompts/second-opinion/start.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/second-opinion-start/agents/openai.yaml
+++ b/.codex/skills/second-opinion-start/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "second-opinion:start"
+  short_description: "Trigger /second-opinion:start"
+  default_prompt: "/second-opinion:start"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ Defaults are set in each service's `src/config.py` and can be overridden via `MC
 - CI/CD slash trigger parity is mapped in `docs/skills/cicd-command-skill-map.md`.
 - Flow slash trigger parity is mapped in `docs/skills/flow-command-skill-map.md`.
 - GitHub slash trigger parity is mapped in `docs/skills/github-command-skill-map.md`.
+- Second-opinion slash trigger parity is mapped in `docs/skills/second-opinion-command-skill-map.md`.
 - QA slash trigger parity is mapped in `docs/skills/qa-command-skill-map.md`.
 - Project slash trigger parity is mapped in `docs/skills/project-command-skill-map.md`.
 - AGENTS.md governance trigger parity is mapped in `docs/skills/agents-md-command-skill-map.md`.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ The `/github:*` namespace is available through:
 - `.codex/skills/github-*/` - backing Codex skill packages
 - `docs/skills/github-command-skill-map.md` - trigger-to-skill inventory
 
+## Second-Opinion Trigger Parity
+
+The `/second-opinion:*` namespace is available through:
+
+- `.claude/commands/second-opinion/*.md` - source command inventory
+- `.codex/prompts/second-opinion/*.md` - slash-compatible entrypoints
+- `.codex/skills/second-opinion-*/` - backing Codex skill packages
+- `docs/skills/second-opinion-command-skill-map.md` - trigger-to-skill inventory
+
 ## QA Trigger Parity
 
 The `/qa:*` namespace is available through:

--- a/docs/skills/second-opinion-command-skill-map.md
+++ b/docs/skills/second-opinion-command-skill-map.md
@@ -1,0 +1,11 @@
+# Second-Opinion Trigger to Skill Map
+
+This file maps second-opinion triggers to Codex prompts and skill packages.
+
+| Trigger | Prompt Entrypoint | Skill Package |
+|---|---|---|
+| `/second-opinion:help` | `.codex/prompts/second-opinion/help.md` | `.codex/skills/second-opinion-help/SKILL.md` |
+| `/second-opinion:models` | `.codex/prompts/second-opinion/models.md` | `.codex/skills/second-opinion-models/SKILL.md` |
+| `/second-opinion:start` | `.codex/prompts/second-opinion/start.md` | `.codex/skills/second-opinion-start/SKILL.md` |
+
+Canonical inventory: `.claude/commands/second-opinion/*.md`, `.codex/prompts/second-opinion/*.md`, and `.codex/skills/second-opinion-*/`.

--- a/tests/test_second_opinion_skill_trigger_parity.py
+++ b/tests/test_second_opinion_skill_trigger_parity.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_DIR = ROOT / ".claude" / "commands" / "second-opinion"
+PROMPT_DIR = ROOT / ".codex" / "prompts" / "second-opinion"
+SKILLS_DIR = ROOT / ".codex" / "skills"
+
+
+def _source_commands() -> set[str]:
+    return {path.stem for path in SOURCE_DIR.glob("*.md")}
+
+
+def _target_prompts() -> set[str]:
+    return {path.stem for path in PROMPT_DIR.glob("*.md")}
+
+
+def test_second_opinion_prompt_trigger_parity_with_source_commands() -> None:
+    assert _target_prompts() == _source_commands()
+
+
+def test_every_second_opinion_prompt_has_backing_skill_package() -> None:
+    for command in sorted(_source_commands()):
+        trigger = f"/second-opinion:{command}"
+        skill_name = f"second-opinion-{command}"
+
+        skill_md = SKILLS_DIR / skill_name / "SKILL.md"
+        agent_yaml = SKILLS_DIR / skill_name / "agents" / "openai.yaml"
+        prompt_md = PROMPT_DIR / f"{command}.md"
+
+        assert skill_md.exists(), f"Missing skill file for {trigger}: {skill_md}"
+        assert agent_yaml.exists(), f"Missing agents metadata for {trigger}: {agent_yaml}"
+
+        prompt_text = prompt_md.read_text()
+        skill_text = skill_md.read_text()
+
+        assert f"Backing skill: `{skill_name}`" in prompt_text
+        assert trigger in skill_text
+        assert f".codex/prompts/second-opinion/{command}.md" in skill_text
+
+
+def test_second_opinion_agent_metadata_points_to_expected_triggers() -> None:
+    for command in sorted(_source_commands()):
+        skill_name = f"second-opinion-{command}"
+        trigger = f"/second-opinion:{command}"
+        agent_yaml = SKILLS_DIR / skill_name / "agents" / "openai.yaml"
+        text = agent_yaml.read_text()
+
+        assert f'display_name: "second-opinion:{command}"' in text
+        assert f'default_prompt: "{trigger}"' in text


### PR DESCRIPTION
## Summary
- ported `/second-opinion:help`, `/second-opinion:models`, and `/second-opinion:start` to `.codex/prompts/second-opinion/*`
- added matching Codex skill packages with `agents/openai.yaml` metadata for each trigger
- added trigger inventory mapping and discoverability updates in `docs/skills/second-opinion-command-skill-map.md`, `AGENTS.md`, and `README.md`
- added namespace parity test coverage in `tests/test_second_opinion_skill_trigger_parity.py`

## Test Plan
- env UV_CACHE_DIR=/tmp/uv-cache make lint
- env UV_CACHE_DIR=/tmp/uv-cache make test

Closes #11