### PR TITLE
feat(spec): port trigger parity namespace (Closes #15)

### DIFF
--- a/.codex/prompts/spec/create.md
+++ b/.codex/prompts/spec/create.md
@@ -1,0 +1,282 @@
+---
+description: Create a new feature specification
+---
+
+> Trigger parity entrypoint for `/spec:create`.
+> Backing skill: `spec-create` (`.codex/skills/spec-create/SKILL.md`).
+
+
+# Create Feature Specification
+
+Create a new feature spec directory with templates for spec, plan, and tasks.
+
+## Arguments
+
+`/spec:create {feature-name}`
+
+- `{feature-name}`: Kebab-case name for the feature (e.g., `user-authentication`, `api-refactor`)
+
+## Execution Steps
+
+### Step 1: Validate Arguments
+
+If no feature name provided, ask:
+
+> "What should the feature be named? Use kebab-case (e.g., `user-authentication`, `payment-flow`)"
+
+Validate the name:
+- Must be kebab-case (lowercase, hyphens)
+- No spaces or special characters
+- Descriptive but concise
+
+### Step 2: Check Prerequisites
+
+```bash
+if [ ! -d ".specify" ]; then
+    echo "Error: .specify/ not found. Run /spec:init first."
+    exit 1
+fi
+
+if [ -d ".specify/specs/{feature-name}" ]; then
+    echo "Error: Spec already exists at .specify/specs/{feature-name}/"
+    exit 1
+fi
+```
+
+### Step 3: Create Feature Directory
+
+```bash
+mkdir -p .specify/specs/{feature-name}
+```
+
+### Step 4: Create spec.md
+
+Create `.specify/specs/{feature-name}/spec.md` from template:
+
+```markdown
+# Feature Specification: {FEATURE_NAME_TITLE}
+
+> **Branch:** `issue-{N}-{feature-name}`
+> **Created:** {DATE}
+> **Status:** Draft
+
+---
+
+## Overview
+
+{Describe what this feature does and why it's needed.}
+
+---
+
+## User Stories
+
+### US1: {Primary User Story} [P1]
+
+**As a** {role},
+**I want** {capability},
+**So that** {benefit}.
+
+**Acceptance Criteria:**
+- [ ] {Criterion 1}
+- [ ] {Criterion 2}
+- [ ] {Criterion 3}
+
+**Test Scenarios:**
+1. Given {context}, when {action}, then {result}
+
+---
+
+## Edge Cases
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| {Edge case 1} | {Behavior} |
+
+---
+
+## Out of Scope
+
+- {What this feature explicitly does NOT include}
+
+---
+
+## Requirements
+
+| ID | Requirement | Priority | User Story |
+|----|-------------|----------|------------|
+| R1 | {Requirement} | Must | US1 |
+
+---
+
+## Success Criteria
+
+- [ ] All acceptance criteria met
+- [ ] All tests passing
+- [ ] Documentation updated
+
+---
+
+## Open Questions
+
+- [ ] {Question 1}
+
+---
+
+*Based on [GitHub Spec Kit](https://github.com/github/spec-kit) (MIT License)*
+```
+
+Replace:
+- `{FEATURE_NAME_TITLE}`: Title-cased version (e.g., "User Authentication")
+- `{feature-name}`: The provided feature name
+- `{DATE}`: Today's date
+- `{N}`: Leave as placeholder for issue number
+
+### Step 5: Create plan.md
+
+Create `.specify/specs/{feature-name}/plan.md` from template:
+
+```markdown
+# Implementation Plan: {FEATURE_NAME_TITLE}
+
+> **Spec:** [spec.md](./spec.md)
+> **Created:** {DATE}
+> **Status:** Draft
+
+---
+
+## Summary
+
+{One-paragraph summary of the technical approach.}
+
+---
+
+## Constitution Check
+
+- [ ] Aligns with project principles
+- [ ] Follows established patterns
+- [ ] Minimizes complexity
+
+---
+
+## Technical Context
+
+| Aspect | Choice | Rationale |
+|--------|--------|-----------|
+| Language | Python 3.11+ | {Why} |
+| Testing | pytest | Standard |
+
+---
+
+## Architecture
+
+{Describe component relationships.}
+
+---
+
+## Implementation Phases
+
+### Phase 1: Core
+
+| Task ID | Description | Files |
+|---------|-------------|-------|
+| T001 | {Task} | `path/file.py` |
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| {Risk} | {Mitigation} |
+
+---
+
+*Based on [GitHub Spec Kit](https://github.com/github/spec-kit) (MIT License)*
+```
+
+### Step 6: Create tasks.md
+
+Create `.specify/specs/{feature-name}/tasks.md` from template:
+
+```markdown
+# Tasks: {FEATURE_NAME_TITLE}
+
+> **Plan:** [plan.md](./plan.md)
+> **Created:** {DATE}
+> **Status:** Draft
+
+---
+
+## Task Format
+
+`[ID] [P?] [Story] Description`
+
+- **ID**: T001, T002, etc.
+- **[P]**: Parallelizable task
+- **[Story]**: US1, US2, etc.
+
+---
+
+## Wave 1: Core Implementation
+
+- [ ] **T001** [US1] {Task description} `path/to/file.py`
+- [ ] **T002** [US1] {Task description} (depends on T001)
+
+**Checkpoint:** Core functionality works
+
+---
+
+## Wave 2: Integration
+
+- [ ] **T003** [US1] Integration testing
+- [ ] **T004** [P] Documentation updates
+
+**Checkpoint:** All tests pass
+
+---
+
+## Issue Sync
+
+Use `/spec:sync {feature-name}` to create GitHub issues.
+
+| Wave | Tasks | Issue | Status |
+|------|-------|-------|--------|
+| Wave 1 | T001-T002 | - | pending |
+| Wave 2 | T003-T004 | - | pending |
+
+---
+
+*Based on [GitHub Spec Kit](https://github.com/github/spec-kit) (MIT License)*
+```
+
+### Step 7: Output Summary
+
+```
+Feature spec created: {feature-name}
+
+Created:
+  .specify/specs/{feature-name}/
+  ├── spec.md      <- Define requirements here
+  ├── plan.md      <- Technical approach
+  └── tasks.md     <- Actionable items
+
+Next steps:
+1. Edit spec.md with user stories and requirements
+2. Edit plan.md with technical approach
+3. Edit tasks.md with actionable items
+4. Run /spec:sync {feature-name} to create GitHub issues
+```
+
+## Examples
+
+```
+/spec:create user-authentication
+/spec:create api-rate-limiting
+/spec:create dashboard-redesign
+```
+
+## Notes
+
+- Feature names should be descriptive but concise
+- Each feature gets its own spec directory
+- Specs can reference each other for dependencies

--- a/.codex/prompts/spec/help.md
+++ b/.codex/prompts/spec/help.md
@@ -1,0 +1,93 @@
+---
+description: Overview of all spec-driven development commands
+---
+
+> Trigger parity entrypoint for `/spec:help`.
+> Backing skill: `spec-help` (`.codex/skills/spec-help/SKILL.md`).
+
+
+# Spec-Driven Development Commands
+
+Manage feature specifications following the GitHub Spec Kit workflow.
+
+## Overview
+
+Spec-Driven Development (SDD) ensures quality by requiring specifications before implementation:
+
+```
+Constitution (principles) → Spec (what) → Plan (how) → Tasks (work) → Issues → Code
+```
+
+## Available Commands
+
+| Command | Description |
+|---------|-------------|
+| `/spec:init` | Initialize .specify/ structure in project |
+| `/spec:create` | Create a new feature specification |
+| `/spec:sync` | Sync tasks.md to GitHub issues |
+| `/spec:status` | Show spec/issue alignment status |
+| `/spec:help` | This help overview |
+
+## Directory Structure
+
+After `/spec:init`, your project will have:
+
+```
+.specify/
+├── memory/
+│   └── constitution.md    # Project principles (edit this!)
+├── specs/
+│   └── {feature-name}/    # Created by /spec:create
+│       ├── spec.md        # Requirements
+│       ├── plan.md        # Technical design
+│       └── tasks.md       # Actionable items
+└── templates/
+    ├── spec-template.md
+    ├── plan-template.md
+    └── tasks-template.md
+```
+
+## Typical Workflow
+
+1. **Initialize** (once per project):
+   ```
+   /spec:init
+   ```
+   Then edit `.specify/memory/constitution.md` with your project principles.
+
+2. **Create Feature Spec**:
+   ```
+   /spec:create user-authentication
+   ```
+   This creates `.specify/specs/user-authentication/` with templates.
+
+3. **Write Specification**:
+   - Edit `spec.md` with user stories and requirements
+   - Edit `plan.md` with technical approach
+   - Edit `tasks.md` with actionable items
+
+4. **Sync to Issues**:
+   ```
+   /spec:sync user-authentication
+   ```
+   Creates GitHub issues from tasks.md with proper labels.
+
+5. **Check Status**:
+   ```
+   /spec:status
+   ```
+   Shows which specs have pending tasks or missing issues.
+
+## Integration with IDD
+
+Spec commands integrate with Issue-Driven Development:
+
+- Tasks become GitHub issues with wave labels
+- Issues link back to spec files
+- `/project-next` shows spec status alongside issues
+
+## Attribution
+
+Based on [GitHub Spec Kit](https://github.com/github/spec-kit) (MIT License).
+
+See [GitHub Blog: Spec-Driven Development](https://github.blog/ai-and-ml/generative-ai/spec-driven-development-with-ai-get-started-with-a-new-open-source-toolkit/) for methodology details.

--- a/.codex/prompts/spec/init.md
+++ b/.codex/prompts/spec/init.md
@@ -1,0 +1,197 @@
+---
+description: Initialize .specify/ structure for spec-driven development
+---
+
+> Trigger parity entrypoint for `/spec:init`.
+> Backing skill: `spec-init` (`.codex/skills/spec-init/SKILL.md`).
+
+
+# Initialize Spec-Driven Development
+
+Set up the `.specify/` directory structure for spec-driven development in this project.
+
+## What This Does
+
+1. Creates the `.specify/` directory structure
+2. Copies template files for specs, plans, and tasks
+3. Creates a starter `constitution.md` for project principles
+
+## Execution Steps
+
+### Step 1: Check if Already Initialized
+
+```bash
+if [ -d ".specify" ]; then
+    echo "Already initialized: .specify/ directory exists"
+    ls -la .specify/
+    exit 0
+fi
+```
+
+If `.specify/` exists, show its contents and stop.
+
+### Step 2: Create Directory Structure
+
+Create the following directories:
+
+```bash
+mkdir -p .specify/memory
+mkdir -p .specify/specs
+mkdir -p .specify/templates
+mkdir -p .specify/scripts
+```
+
+### Step 3: Create Constitution Template
+
+Create `.specify/memory/constitution.md` with this content:
+
+```markdown
+# Project Constitution
+
+> Governing principles for {PROJECT_NAME}.
+> All specifications and implementations must align with these principles.
+
+---
+
+## Core Principles
+
+### P1: {First Principle}
+
+{Description of the principle and how it guides development.}
+
+### P2: {Second Principle}
+
+{Description of the principle and how it guides development.}
+
+### P3: {Third Principle}
+
+{Description of the principle and how it guides development.}
+
+---
+
+## Development Workflow
+
+1. Write specification before code
+2. Review spec for completeness
+3. Create technical plan
+4. Break into tasks
+5. Sync tasks to issues
+6. Implement with tests
+
+---
+
+## Governance
+
+- All PRs must align with constitution
+- Violations require documented justification
+- Constitution changes require team discussion
+
+---
+
+## Attribution
+
+Based on [GitHub Spec Kit](https://github.com/github/spec-kit) (MIT License).
+
+---
+
+*Created: {DATE}*
+```
+
+Replace `{PROJECT_NAME}` with the repository name and `{DATE}` with today's date.
+
+### Step 4: Copy Templates
+
+Copy the spec, plan, and tasks templates from codex-power-pack if available, or create minimal versions:
+
+**spec-template.md:**
+```markdown
+# Feature Specification: {FEATURE_NAME}
+
+## Overview
+{Brief description}
+
+## User Stories
+
+### US1: {Story Title}
+**As a** {role}, **I want** {capability}, **So that** {benefit}.
+
+**Acceptance Criteria:**
+- [ ] {Criterion}
+
+## Requirements
+| ID | Requirement | Priority |
+|----|-------------|----------|
+| R1 | {Requirement} | Must |
+
+## Success Criteria
+- [ ] All acceptance criteria met
+- [ ] Tests passing
+```
+
+**plan-template.md:**
+```markdown
+# Implementation Plan: {FEATURE_NAME}
+
+## Summary
+{Technical approach}
+
+## Architecture
+{Component design}
+
+## Dependencies
+| Package | Purpose |
+|---------|---------|
+
+## Phases
+| Phase | Tasks | Dependencies |
+|-------|-------|--------------|
+```
+
+**tasks-template.md:**
+```markdown
+# Tasks: {FEATURE_NAME}
+
+## Format
+`[ID] [P?] [Story] Description`
+
+## Wave 1
+- [ ] **T001** [US1] {Task description}
+
+## Issue Sync
+| Task | Issue | Status |
+|------|-------|--------|
+```
+
+### Step 5: Add to .gitignore (Optional)
+
+Ask the user if they want to add any `.specify/` patterns to `.gitignore`:
+
+> "The `.specify/` directory has been created. Do you want to add any exclusions to .gitignore? (Typically, everything is tracked)"
+
+### Step 6: Output Summary
+
+```
+Spec-driven development initialized!
+
+Created:
+  .specify/
+  ├── memory/
+  │   └── constitution.md    <- Edit with your project principles
+  ├── specs/                 <- Feature specs go here
+  ├── templates/             <- Reusable templates
+  │   ├── spec-template.md
+  │   ├── plan-template.md
+  │   └── tasks-template.md
+  └── scripts/               <- Automation scripts
+
+Next steps:
+1. Edit .specify/memory/constitution.md with your project principles
+2. Use /spec:create {feature-name} to create your first spec
+3. See /spec:help for full workflow
+```
+
+## Notes
+
+- Constitution should be customized for each project
+- Templates can be modified to match team preferences
+- Based on GitHub Spec Kit (MIT License)

--- a/.codex/prompts/spec/status.md
+++ b/.codex/prompts/spec/status.md
@@ -1,0 +1,185 @@
+---
+description: Show spec/issue alignment status
+---
+
+> Trigger parity entrypoint for `/spec:status`.
+> Backing skill: `spec-status` (`.codex/skills/spec-status/SKILL.md`).
+
+
+# Spec Status Overview
+
+Display the status of all feature specifications and their alignment with GitHub issues.
+
+## Arguments
+
+`/spec:status [feature-name]`
+
+- `[feature-name]`: Optional. If provided, shows detailed status for that feature only.
+
+## Execution Steps
+
+### Step 1: Check Prerequisites
+
+```bash
+if [ ! -d ".specify" ]; then
+    echo "No .specify/ directory found. Run /spec:init first."
+    exit 0
+fi
+```
+
+### Step 2: Discover Features
+
+Find all feature spec directories:
+
+```bash
+find .specify/specs -mindepth 1 -maxdepth 1 -type d
+```
+
+### Step 3: Analyze Each Feature
+
+For each feature, determine:
+
+1. **Spec Status:**
+   - `spec.md` exists and has content
+   - User stories defined
+   - Requirements listed
+
+2. **Plan Status:**
+   - `plan.md` exists and has content
+   - Architecture defined
+   - Phases listed
+
+3. **Tasks Status:**
+   - `tasks.md` exists and has content
+   - Tasks defined with IDs
+   - Waves organized
+
+4. **Issue Sync Status:**
+   - Parse Issue Sync table from tasks.md
+   - Check each issue exists and its state (open/closed)
+   - Identify unsynced waves
+
+### Step 4: Fetch GitHub Issues
+
+Get current issue states:
+
+```bash
+# Get all issues with spec-related labels
+gh issue list --state all --limit 100 --json number,title,state,labels
+```
+
+Match issues to features by:
+- Label matching (`{feature-name}`)
+- Wave labels (`wave-N`)
+- Title patterns (`[Wave N] Feature:`)
+
+### Step 5: Output Summary (All Features)
+
+```
+=== Spec Status ===
+
+Feature: user-authentication
+  Spec:   ✓ Complete (3 user stories, 5 requirements)
+  Plan:   ✓ Complete (2 phases)
+  Tasks:  ✓ 8 tasks in 2 waves
+  Issues: 2/2 synced
+    #42 [Wave 1] Core Implementation - OPEN
+    #43 [Wave 2] Integration - OPEN
+
+Feature: api-rate-limiting
+  Spec:   ✓ Complete (2 user stories)
+  Plan:   ○ Draft (missing architecture)
+  Tasks:  ○ 4 tasks, not synced
+  Issues: 0/1 synced
+    Wave 1: Not synced → Run /spec:sync api-rate-limiting
+
+Feature: dashboard-redesign
+  Spec:   ○ Draft (1 user story)
+  Plan:   ✗ Missing
+  Tasks:  ✗ Missing
+  Issues: -
+
+Summary:
+  Features: 3
+  Synced:   1
+  Pending:  2
+
+Next steps:
+  - Complete plan for: api-rate-limiting
+  - Create tasks for: api-rate-limiting
+  - Sync issues for: api-rate-limiting
+  - Add plan/tasks for: dashboard-redesign
+```
+
+### Step 6: Output Detail (Single Feature)
+
+When a feature name is provided:
+
+```
+=== Feature: user-authentication ===
+
+Spec: .specify/specs/user-authentication/spec.md
+  Status: Complete
+  User Stories:
+    US1: User can register with email [P1]
+    US2: User can login with credentials [P1]
+    US3: User can reset password [P2]
+  Requirements: 5 (3 Must, 2 Should)
+  Open Questions: 0
+
+Plan: .specify/specs/user-authentication/plan.md
+  Status: Complete
+  Phases: 2
+  Dependencies: 3 packages
+  Risks: 2 identified
+
+Tasks: .specify/specs/user-authentication/tasks.md
+  Status: Synced
+  Waves: 2
+  Tasks: 8 total (5 complete, 3 pending)
+
+Issues:
+  #42 [Wave 1] Core Implementation
+    State: OPEN
+    Tasks: 3/5 complete
+    Branch: issue-42-user-auth
+    Worktree: ../project-issue-42
+
+  #43 [Wave 2] Integration
+    State: OPEN
+    Tasks: 0/3 complete
+    Branch: (not created)
+
+Timeline:
+  Created: 2025-12-20
+  Last Updated: 2025-12-24
+  Issues Created: 2025-12-21
+```
+
+## Status Indicators
+
+| Symbol | Meaning |
+|--------|---------|
+| ✓ | Complete/Synced |
+| ○ | Draft/Partial |
+| ✗ | Missing |
+| - | Not applicable |
+
+## Examples
+
+```
+# Show all specs
+/spec:status
+
+# Show specific feature
+/spec:status user-authentication
+
+# Quick check for unsynced
+/spec:status | grep "Not synced"
+```
+
+## Integration
+
+Status information can also be seen in:
+- `/project-next` (shows spec features alongside issues)
+- GitHub issue descriptions (link to spec files)

--- a/.codex/prompts/spec/sync.md
+++ b/.codex/prompts/spec/sync.md
@@ -1,0 +1,190 @@
+---
+description: Sync tasks.md to GitHub issues
+---
+
+> Trigger parity entrypoint for `/spec:sync`.
+> Backing skill: `spec-sync` (`.codex/skills/spec-sync/SKILL.md`).
+
+
+# Sync Spec Tasks to GitHub Issues
+
+Parse tasks.md and create/update GitHub issues for each wave.
+
+## Arguments
+
+`/spec:sync [feature-name]`
+
+- `[feature-name]`: Optional. If not provided, syncs all features with pending tasks.
+
+## Execution Steps
+
+### Step 1: Find Specs to Sync
+
+If feature-name provided:
+```bash
+SPEC_DIR=".specify/specs/{feature-name}"
+if [ ! -d "$SPEC_DIR" ]; then
+    echo "Error: Spec not found at $SPEC_DIR"
+    exit 1
+fi
+```
+
+If not provided, find all specs with tasks.md:
+```bash
+find .specify/specs -name "tasks.md" -type f
+```
+
+### Step 2: Parse tasks.md
+
+For each tasks.md, extract:
+
+1. **Feature name** from directory path
+2. **Waves** by parsing `## Wave N:` headers
+3. **Tasks** by parsing `- [ ] **T00N** [USN] Description` lines
+4. **Issue sync table** at bottom of file
+
+Example parsing:
+```
+## Wave 1: Core Implementation
+- [ ] **T001** [US1] Create user model `lib/models/user.py`
+- [ ] **T002** [US1] Add validation (depends on T001)
+
+## Wave 2: Integration
+- [ ] **T003** [P] [US1] Integration tests
+```
+
+Becomes:
+```
+Wave 1:
+  - T001: Create user model
+  - T002: Add validation
+Wave 2:
+  - T003: Integration tests
+```
+
+### Step 3: Check Existing Issues
+
+For each wave, check if an issue already exists:
+
+```bash
+# Look for issues with feature-name and wave labels
+gh issue list --label "{feature-name}" --label "wave-N" --json number,title,state
+```
+
+### Step 4: Create Issues for Pending Waves
+
+For each wave without an issue, create one:
+
+**Issue Title:**
+```
+[Wave N] {Feature Name Title}: {Wave Description}
+```
+
+**Issue Body:**
+```markdown
+## Parent Spec
+
+Feature: `{feature-name}`
+Spec: `.specify/specs/{feature-name}/spec.md`
+Plan: `.specify/specs/{feature-name}/plan.md`
+
+## Tasks
+
+{List of tasks from this wave}
+
+- [ ] **T001** [US1] {Description} `{file_path}`
+- [ ] **T002** [US1] {Description} (depends on T001)
+
+## Acceptance Criteria
+
+{Extracted from spec.md for relevant user stories}
+
+## Files to Modify
+
+{List of file paths from tasks}
+
+---
+
+*Created from spec via `/spec:sync`*
+```
+
+**Issue Labels:**
+- `{feature-name}` (feature label)
+- `wave-N` (wave label)
+- `enhancement` (type)
+
+**Command:**
+```bash
+gh issue create \
+  --title "[Wave 1] {Feature}: {Description}" \
+  --body "{body}" \
+  --label "{feature-name},wave-1,enhancement"
+```
+
+### Step 5: Update tasks.md
+
+After creating issues, update the Issue Sync table in tasks.md:
+
+```markdown
+## Issue Sync
+
+| Wave | Tasks | Issue | Status |
+|------|-------|-------|--------|
+| Wave 1 | T001-T002 | #42 | open |
+| Wave 2 | T003-T004 | #43 | open |
+```
+
+### Step 6: Output Summary
+
+```
+Sync complete for: {feature-name}
+
+Issues created:
+  #42 - [Wave 1] User Auth: Core Implementation
+  #43 - [Wave 2] User Auth: Integration
+
+Issues already exist (skipped):
+  #40 - [Wave 0] User Auth: Research (closed)
+
+Updated:
+  .specify/specs/{feature-name}/tasks.md
+
+Next steps:
+1. View issues: gh issue list --label {feature-name}
+2. Start work: git worktree add -b issue-42-user-auth ../project-issue-42
+3. Check status: /spec:status
+```
+
+## Dry Run Mode
+
+Add `--dry-run` to preview without creating issues:
+
+```
+/spec:sync user-authentication --dry-run
+```
+
+Output shows what would be created without making changes.
+
+## Examples
+
+```
+# Sync specific feature
+/spec:sync user-authentication
+
+# Sync all features
+/spec:sync
+
+# Preview changes
+/spec:sync user-authentication --dry-run
+```
+
+## Issue Template Integration
+
+The created issues follow the project's micro-issue template format, compatible with Issue-Driven Development workflow.
+
+## Notes
+
+- Each wave becomes one GitHub issue
+- Tasks within a wave are tracked as checkboxes in the issue
+- Issue numbers are written back to tasks.md for traceability
+- Re-running sync skips existing issues (idempotent)

--- a/.codex/skills/spec-create/SKILL.md
+++ b/.codex/skills/spec-create/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: spec-create
+description: Trigger `/spec:create`.
+---
+
+# spec-create
+
+## Trigger
+- Primary: `/spec:create`
+- Text alias: `spec:create`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/spec/create.md`
+
+## Execution
+1. Use this skill when the user invokes `/spec:create` or explicitly asks for the spec `create` workflow.
+2. Follow the workflow steps in `.codex/prompts/spec/create.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/spec-create/agents/openai.yaml
+++ b/.codex/skills/spec-create/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "spec:create"
+  short_description: "Trigger /spec:create"
+  default_prompt: "/spec:create"

--- a/.codex/skills/spec-help/SKILL.md
+++ b/.codex/skills/spec-help/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: spec-help
+description: Trigger `/spec:help`.
+---
+
+# spec-help
+
+## Trigger
+- Primary: `/spec:help`
+- Text alias: `spec:help`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/spec/help.md`
+
+## Execution
+1. Use this skill when the user invokes `/spec:help` or explicitly asks for the spec `help` workflow.
+2. Follow the workflow steps in `.codex/prompts/spec/help.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/spec-help/agents/openai.yaml
+++ b/.codex/skills/spec-help/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "spec:help"
+  short_description: "Trigger /spec:help"
+  default_prompt: "/spec:help"

--- a/.codex/skills/spec-init/SKILL.md
+++ b/.codex/skills/spec-init/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: spec-init
+description: Trigger `/spec:init`.
+---
+
+# spec-init
+
+## Trigger
+- Primary: `/spec:init`
+- Text alias: `spec:init`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/spec/init.md`
+
+## Execution
+1. Use this skill when the user invokes `/spec:init` or explicitly asks for the spec `init` workflow.
+2. Follow the workflow steps in `.codex/prompts/spec/init.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/spec-init/agents/openai.yaml
+++ b/.codex/skills/spec-init/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "spec:init"
+  short_description: "Trigger /spec:init"
+  default_prompt: "/spec:init"

--- a/.codex/skills/spec-status/SKILL.md
+++ b/.codex/skills/spec-status/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: spec-status
+description: Trigger `/spec:status`.
+---
+
+# spec-status
+
+## Trigger
+- Primary: `/spec:status`
+- Text alias: `spec:status`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/spec/status.md`
+
+## Execution
+1. Use this skill when the user invokes `/spec:status` or explicitly asks for the spec `status` workflow.
+2. Follow the workflow steps in `.codex/prompts/spec/status.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/spec-status/agents/openai.yaml
+++ b/.codex/skills/spec-status/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "spec:status"
+  short_description: "Trigger /spec:status"
+  default_prompt: "/spec:status"

--- a/.codex/skills/spec-sync/SKILL.md
+++ b/.codex/skills/spec-sync/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: spec-sync
+description: Trigger `/spec:sync`.
+---
+
+# spec-sync
+
+## Trigger
+- Primary: `/spec:sync`
+- Text alias: `spec:sync`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/spec/sync.md`
+
+## Execution
+1. Use this skill when the user invokes `/spec:sync` or explicitly asks for the spec `sync` workflow.
+2. Follow the workflow steps in `.codex/prompts/spec/sync.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/spec-sync/agents/openai.yaml
+++ b/.codex/skills/spec-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "spec:sync"
+  short_description: "Trigger /spec:sync"
+  default_prompt: "/spec:sync"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,4 +53,5 @@ Defaults are set in each service's `src/config.py` and can be overridden via `MC
 - Second-opinion slash trigger parity is mapped in `docs/skills/second-opinion-command-skill-map.md`.
 - QA slash trigger parity is mapped in `docs/skills/qa-command-skill-map.md`.
 - Project slash trigger parity is mapped in `docs/skills/project-command-skill-map.md`.
+- Spec slash trigger parity is mapped in `docs/skills/spec-command-skill-map.md`.
 - AGENTS.md governance trigger parity is mapped in `docs/skills/agents-md-command-skill-map.md`.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ The `/project:*` namespace is available through:
 - `.codex/skills/project-*/` - backing Codex skill packages
 - `docs/skills/project-command-skill-map.md` - trigger-to-skill inventory
 
+## Spec Trigger Parity
+
+The `/spec:*` namespace is available through:
+
+- `.claude/commands/spec/*.md` - source command inventory
+- `.codex/prompts/spec/*.md` - slash-compatible entrypoints
+- `.codex/skills/spec-*/` - backing Codex skill packages
+- `docs/skills/spec-command-skill-map.md` - trigger-to-skill inventory
+
 ## AGENTS.md Trigger Parity
 
 The `/agents-md:*` namespace is available through:

--- a/docs/skills/spec-command-skill-map.md
+++ b/docs/skills/spec-command-skill-map.md
@@ -1,0 +1,13 @@
+# Spec Trigger to Skill Map
+
+This file maps spec triggers to Codex prompts and skill packages.
+
+| Trigger | Prompt Entrypoint | Skill Package |
+|---|---|---|
+| `/spec:create` | `.codex/prompts/spec/create.md` | `.codex/skills/spec-create/SKILL.md` |
+| `/spec:help` | `.codex/prompts/spec/help.md` | `.codex/skills/spec-help/SKILL.md` |
+| `/spec:init` | `.codex/prompts/spec/init.md` | `.codex/skills/spec-init/SKILL.md` |
+| `/spec:status` | `.codex/prompts/spec/status.md` | `.codex/skills/spec-status/SKILL.md` |
+| `/spec:sync` | `.codex/prompts/spec/sync.md` | `.codex/skills/spec-sync/SKILL.md` |
+
+Canonical inventory: `.claude/commands/spec/*.md`, `.codex/prompts/spec/*.md`, and `.codex/skills/spec-*/`.

--- a/tests/test_spec_skill_trigger_parity.py
+++ b/tests/test_spec_skill_trigger_parity.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_DIR = ROOT / ".claude" / "commands" / "spec"
+PROMPT_DIR = ROOT / ".codex" / "prompts" / "spec"
+SKILLS_DIR = ROOT / ".codex" / "skills"
+
+
+def _source_commands() -> set[str]:
+    return {path.stem for path in SOURCE_DIR.glob("*.md")}
+
+
+def _target_prompts() -> set[str]:
+    return {path.stem for path in PROMPT_DIR.glob("*.md")}
+
+
+def test_spec_prompt_trigger_parity_with_source_commands() -> None:
+    assert _target_prompts() == _source_commands()
+
+
+def test_every_spec_prompt_has_backing_skill_package() -> None:
+    for command in sorted(_source_commands()):
+        trigger = f"/spec:{command}"
+        skill_name = f"spec-{command}"
+
+        skill_md = SKILLS_DIR / skill_name / "SKILL.md"
+        agent_yaml = SKILLS_DIR / skill_name / "agents" / "openai.yaml"
+        prompt_md = PROMPT_DIR / f"{command}.md"
+
+        assert skill_md.exists(), f"Missing skill file for {trigger}: {skill_md}"
+        assert agent_yaml.exists(), f"Missing agents metadata for {trigger}: {agent_yaml}"
+
+        prompt_text = prompt_md.read_text()
+        skill_text = skill_md.read_text()
+
+        assert f"Backing skill: `{skill_name}`" in prompt_text
+        assert trigger in skill_text
+        assert f".codex/prompts/spec/{command}.md" in skill_text
+
+
+def test_spec_agent_metadata_points_to_expected_triggers() -> None:
+    for command in sorted(_source_commands()):
+        skill_name = f"spec-{command}"
+        trigger = f"/spec:{command}"
+        agent_yaml = SKILLS_DIR / skill_name / "agents" / "openai.yaml"
+        text = agent_yaml.read_text()
+
+        assert f'display_name: "spec:{command}"' in text
+        assert f'default_prompt: "{trigger}"' in text


### PR DESCRIPTION
## Summary
- ported `/spec:create`, `/spec:help`, `/spec:init`, `/spec:status`, and `/spec:sync` into `.codex/prompts/spec/*`
- added matching Codex skill packages and `agents/openai.yaml` metadata for each `/spec:*` trigger
- added trigger inventory mapping in `docs/skills/spec-command-skill-map.md`
- updated command discoverability in `AGENTS.md` and `README.md`
- added namespace parity coverage in `tests/test_spec_skill_trigger_parity.py`

## Test Plan
- env UV_CACHE_DIR=/tmp/uv-cache make lint
- env UV_CACHE_DIR=/tmp/uv-cache make test

Closes #15