### PR TITLE
fix(mcp): add install/doctor/smoke tooling and align SSE docs (Closes #32, Closes #33, Closes #34)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Defaults are set in each service's `src/config.py` and can be overridden via `MC
 - Python 3.11+
 - `uv` for dependency management
 - `make lint`, `make test`, `make typecheck`, `make verify` for quality gates
+- `make mcp-install-codex`, `make mcp-doctor`, `make mcp-smoke` for MCP setup/validation
 - Docker entrypoints go through `make docker-*`
 - prefer `rg` for repo search
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: test lint format typecheck verify build update_docs clean help \
+       mcp-install-codex mcp-doctor mcp-smoke \
        docker-build docker-check-env docker-up docker-down docker-logs docker-ps deploy
 
 ## Quality gates (used by /flow:finish)
@@ -27,6 +28,19 @@ verify: lint test typecheck
 update_docs:
 	@echo "Run /documentation:c4 to regenerate C4 architecture diagrams"
 	@echo "Review AGENTS.md and README.md for accuracy"
+
+## MCP operations
+
+CODEX_CONFIG ?= $(HOME)/.codex/config.toml
+
+mcp-install-codex:
+	python3 scripts/mcp_install_codex.py --codex-config "$(CODEX_CONFIG)"
+
+mcp-doctor:
+	python3 scripts/mcp_doctor.py --codex-config "$(CODEX_CONFIG)" --profiles "$(PROFILE)"
+
+mcp-smoke:
+	python3 scripts/mcp_smoke.py --profiles "$(PROFILE)"
 
 ## Docker (MCP server containers)
 ## Usage: make docker-up PROFILE=core
@@ -71,7 +85,7 @@ docker-ps:
 
 ## Deploy (used by Woodpecker CI and /flow:deploy)
 
-deploy: docker-build docker-up
+deploy: docker-build docker-up mcp-smoke
 	@sleep 5
 	@$(MAKE) docker-ps
 
@@ -90,6 +104,11 @@ help:
 	@echo "  make typecheck   - Run mypy"
 	@echo "  make build       - Build distribution packages"
 	@echo "  make verify      - Run all quality checks"
+	@echo ""
+	@echo "MCP:"
+	@echo "  make mcp-install-codex - Install/update Codex MCP registrations"
+	@echo "  make mcp-doctor        - Validate Codex MCP config and endpoint health"
+	@echo "  make mcp-smoke         - Run MCP initialize smoke tests for active PROFILE"
 	@echo ""
 	@echo "Docker:"
 	@echo "  make docker-up   - Start containers (PROFILE=core)"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ cd codex-power-pack
 uv sync --extra dev
 make verify
 make docker-up PROFILE=core
+make mcp-smoke PROFILE=core
 ```
 
 The default Docker profile starts:
@@ -37,6 +38,32 @@ Add the browser profile for Playwright:
 ```bash
 make docker-up PROFILE="core browser"
 ```
+
+## Codex MCP Setup
+
+Install deterministic Codex MCP registrations from this repository path:
+
+```bash
+make mcp-install-codex
+```
+
+Validate local config drift and live endpoint health:
+
+```bash
+make mcp-doctor PROFILE="core browser cicd"
+```
+
+`mcp-install-codex` automatically replaces legacy Woodpecker entries such as
+`voice-bot-acs/codex-power-pack/mcp-woodpecker-ci` with repo-local paths.
+
+Canonical transport matrix:
+
+| Server | Profile | Canonical endpoint | Alternate transport |
+|--------|---------|--------------------|---------------------|
+| `codex-second-opinion` | `core` | `http://127.0.0.1:9100/sse` | `uv run --directory .../codex-second-opinion python src/server.py --stdio` |
+| `codex-playwright` | `browser` | `http://127.0.0.1:9101/sse` | `uv run --directory .../codex-playwright python src/server.py --stdio` |
+| `codex-nano-banana` | `core` | `http://127.0.0.1:9102/sse` | `uv run --directory .../codex-nano-banana python src/server.py --stdio` |
+| `codex-woodpecker` | `cicd` | `http://127.0.0.1:9103/sse` | `uv run --directory .../codex-woodpecker python src/server.py --stdio` |
 
 ## Codex Architecture
 

--- a/codex-playwright/README.md
+++ b/codex-playwright/README.md
@@ -43,7 +43,15 @@ uv run playwright install chromium
 #   }
 # }
 #
-# Or use SSE / streamable transport for systemd or Docker deployments.
+# Or use SSE transport for systemd or Docker deployments:
+#   {
+#     "mcpServers": {
+#       "playwright-persistent": {
+#         "type": "sse",
+#         "url": "http://127.0.0.1:9101/sse"
+#       }
+#     }
+#   }
 ```
 
 ## Configuration

--- a/codex-second-opinion/README.md
+++ b/codex-second-opinion/README.md
@@ -8,7 +8,7 @@ Multi-model code review MCP server for Codex.
 - **Multi-Model Support**: Consult multiple LLMs (Gemini 3.1, Claude Sonnet/Haiku/Opus, GPT-5.3 Codex, o4-mini)
 - **Session-Based**: Interactive multi-turn conversations for deeper analysis
 - **Visual Analysis**: Support for screenshot/image analysis (Playwright integration)
-- **Streamable HTTP**: Stateless transport - no persistent connection, resilient to disconnects
+- **SSE Transport**: Remote-friendly transport for Docker and service deployments
 
 ## Quick Start
 
@@ -43,13 +43,13 @@ Register the server in your Codex MCP configuration.
 }
 ```
 
-**Streamable HTTP:**
+**SSE transport:**
 ```json
 {
   "mcpServers": {
     "second-opinion": {
-      "type": "streamable-http",
-      "url": "http://127.0.0.1:9100/mcp"
+      "type": "sse",
+      "url": "http://127.0.0.1:9100/sse"
     }
   }
 }
@@ -93,19 +93,18 @@ Recommended dedicated API-key secret: `codex_llm_apikeys`.
 
 ### Error: `-32602: Invalid request parameters`
 
-This usually means Codex cannot reach the server or the SSE session expired.
+This usually means Codex cannot reach the server or your MCP registration points to the wrong endpoint.
 
-**Fix 1: Upgrade to streamable-http transport (recommended)**
+**Fix 1: Use the canonical SSE endpoint**
 
-The streamable-http transport is stateless - each request is independent, so there are no
-session timeouts or disconnection issues. Update your `.mcp.json`:
+Update your MCP config to:
 
 ```json
 {
   "mcpServers": {
     "second-opinion": {
-      "type": "streamable-http",
-      "url": "http://127.0.0.1:9100/mcp"
+      "type": "sse",
+      "url": "http://127.0.0.1:9100/sse"
     }
   }
 }
@@ -118,7 +117,7 @@ session timeouts or disconnection issues. Update your `.mcp.json`:
 # and point it at src/server.py --stdio
 ```
 
-**If using HTTP transport:** Ensure the server is running before starting Codex:
+**If using SSE transport:** Ensure the server is running before starting Codex:
 
 ```bash
 # Check if server is running

--- a/scripts/mcp_common.py
+++ b/scripts/mcp_common.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Shared MCP utilities for Codex Power Pack operational scripts."""
+
+from __future__ import annotations
+
+import json
+import socket
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin
+from urllib.request import Request, urlopen
+
+DEFAULT_PROTOCOL_VERSION = "2024-11-05"
+
+
+@dataclass(frozen=True)
+class ServerSpec:
+    """Canonical MCP server metadata."""
+
+    config_name: str
+    profile: str
+    sse_url: str
+    repo_subdir: str
+
+    @property
+    def stdio_args(self) -> list[str]:
+        return ["run", "--directory", self.repo_subdir, "python", "src/server.py", "--stdio"]
+
+
+@dataclass
+class ProbeResult:
+    """Result of probing an MCP SSE endpoint."""
+
+    config_name: str
+    sse_url: str
+    ok: bool
+    stage: str
+    endpoint: str | None = None
+    protocol_version: str | None = None
+    server_name: str | None = None
+    server_version: str | None = None
+    error: str | None = None
+
+
+def canonical_servers() -> list[ServerSpec]:
+    """Return canonical Codex Power Pack MCP server definitions."""
+    return [
+        ServerSpec(
+            config_name="codex-second-opinion",
+            profile="core",
+            sse_url="http://127.0.0.1:9100/sse",
+            repo_subdir="codex-second-opinion",
+        ),
+        ServerSpec(
+            config_name="codex-nano-banana",
+            profile="core",
+            sse_url="http://127.0.0.1:9102/sse",
+            repo_subdir="codex-nano-banana",
+        ),
+        ServerSpec(
+            config_name="codex-playwright",
+            profile="browser",
+            sse_url="http://127.0.0.1:9101/sse",
+            repo_subdir="codex-playwright",
+        ),
+        ServerSpec(
+            config_name="codex-woodpecker",
+            profile="cicd",
+            sse_url="http://127.0.0.1:9103/sse",
+            repo_subdir="codex-woodpecker",
+        ),
+    ]
+
+
+def parse_profiles(raw: str | None) -> set[str]:
+    """Parse profile string (`core browser` or `core,browser`) into a set."""
+    if not raw:
+        return {"core"}
+    normalized = raw.replace(",", " ")
+    values = {token.strip() for token in normalized.split() if token.strip()}
+    return values or {"core"}
+
+
+def selected_servers(profiles: set[str]) -> list[ServerSpec]:
+    """Select canonical servers matching the requested profiles."""
+    return [spec for spec in canonical_servers() if spec.profile in profiles]
+
+
+def _read_sse_event(stream: Any, max_lines: int = 200) -> dict[str, str] | None:
+    """Read one SSE event from a streaming response."""
+    event_name: str | None = None
+    data_lines: list[str] = []
+    line_count = 0
+
+    while line_count < max_lines:
+        raw = stream.readline()
+        if not raw:
+            return None
+
+        try:
+            line = raw.decode("utf-8", errors="replace").rstrip("\r\n")
+        except AttributeError:
+            line = str(raw).rstrip("\r\n")
+
+        line_count += 1
+
+        if line == "":
+            if event_name is not None:
+                return {"event": event_name, "data": "\n".join(data_lines)}
+            event_name = None
+            data_lines = []
+            continue
+
+        if line.startswith(":"):
+            continue
+        if line.startswith("event:"):
+            event_name = line.split(":", 1)[1].strip()
+            continue
+        if line.startswith("data:"):
+            data_lines.append(line.split(":", 1)[1].lstrip())
+
+    return None
+
+
+def probe_sse_server(spec: ServerSpec, timeout_seconds: float = 8.0, check_tools_list: bool = False) -> ProbeResult:
+    """Probe an MCP server over SSE and validate JSON-RPC initialize."""
+    headers = {"Accept": "text/event-stream"}
+
+    try:
+        with urlopen(Request(spec.sse_url, headers=headers, method="GET"), timeout=timeout_seconds) as stream:
+            endpoint: str | None = None
+            for _ in range(30):
+                evt = _read_sse_event(stream)
+                if not evt:
+                    break
+                if evt.get("event") == "endpoint":
+                    payload = (evt.get("data") or "").strip()
+                    endpoint = payload if payload.startswith("http") else urljoin(spec.sse_url, payload)
+                    break
+
+            if not endpoint:
+                return ProbeResult(
+                    config_name=spec.config_name,
+                    sse_url=spec.sse_url,
+                    ok=False,
+                    stage="handshake",
+                    error="No endpoint event received from SSE stream",
+                )
+
+            init_payload = {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": DEFAULT_PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {"name": "codex-power-pack", "version": "1.0"},
+                },
+            }
+
+            post_data = json.dumps(init_payload).encode("utf-8")
+            with urlopen(
+                Request(endpoint, data=post_data, headers={"Content-Type": "application/json"}, method="POST"),
+                timeout=timeout_seconds,
+            ) as _:
+                pass
+
+            init_result: dict[str, Any] | None = None
+            for _ in range(60):
+                evt = _read_sse_event(stream)
+                if not evt:
+                    break
+                data = (evt.get("data") or "").strip()
+                if not data:
+                    continue
+                try:
+                    payload = json.loads(data)
+                except json.JSONDecodeError:
+                    continue
+                if payload.get("id") == 1:
+                    init_result = payload
+                    break
+
+            if not init_result or "result" not in init_result:
+                return ProbeResult(
+                    config_name=spec.config_name,
+                    sse_url=spec.sse_url,
+                    ok=False,
+                    stage="handshake",
+                    endpoint=endpoint,
+                    error="Initialize response was not received",
+                )
+
+            if check_tools_list:
+                tools_payload = {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/list",
+                    "params": {},
+                }
+                with urlopen(
+                    Request(
+                        endpoint,
+                        data=json.dumps(tools_payload).encode("utf-8"),
+                        headers={"Content-Type": "application/json"},
+                        method="POST",
+                    ),
+                    timeout=timeout_seconds,
+                ) as _:
+                    pass
+
+                tools_response: dict[str, Any] | None = None
+                for _ in range(80):
+                    evt = _read_sse_event(stream)
+                    if not evt:
+                        break
+                    data = (evt.get("data") or "").strip()
+                    if not data:
+                        continue
+                    try:
+                        payload = json.loads(data)
+                    except json.JSONDecodeError:
+                        continue
+                    if payload.get("id") == 2:
+                        tools_response = payload
+                        break
+
+                if not tools_response or ("result" not in tools_response and "error" in tools_response):
+                    return ProbeResult(
+                        config_name=spec.config_name,
+                        sse_url=spec.sse_url,
+                        ok=False,
+                        stage="tools",
+                        endpoint=endpoint,
+                        error="tools/list response was not received",
+                    )
+
+            server_info = (init_result.get("result", {}) or {}).get("serverInfo", {})
+            return ProbeResult(
+                config_name=spec.config_name,
+                sse_url=spec.sse_url,
+                ok=True,
+                stage="ok",
+                endpoint=endpoint,
+                protocol_version=(init_result.get("result", {}) or {}).get("protocolVersion"),
+                server_name=server_info.get("name"),
+                server_version=server_info.get("version"),
+            )
+
+    except HTTPError as exc:
+        return ProbeResult(
+            config_name=spec.config_name,
+            sse_url=spec.sse_url,
+            ok=False,
+            stage="endpoint",
+            error=f"HTTP {exc.code}",
+        )
+    except (URLError, TimeoutError, socket.timeout, ConnectionError) as exc:
+        return ProbeResult(
+            config_name=spec.config_name,
+            sse_url=spec.sse_url,
+            ok=False,
+            stage="endpoint",
+            error=str(exc),
+        )
+    except Exception as exc:  # pragma: no cover - last-resort guard
+        return ProbeResult(
+            config_name=spec.config_name,
+            sse_url=spec.sse_url,
+            ok=False,
+            stage="handshake",
+            error=str(exc),
+        )
+
+
+def load_mcp_servers_from_toml(config_path: Path) -> dict[str, dict[str, Any]]:
+    """Load `[mcp_servers.*]` sections from a Codex config TOML file."""
+    if not config_path.exists():
+        return {}
+
+    with config_path.open("rb") as handle:
+        parsed = tomllib.load(handle)
+
+    servers = parsed.get("mcp_servers", {})
+    if isinstance(servers, dict):
+        # narrow type for downstream usage
+        return {str(key): value for key, value in servers.items() if isinstance(value, dict)}
+    return {}
+
+
+def extract_directory_from_args(args: Any) -> str | None:
+    """Extract `--directory` path from a stdio args list."""
+    if not isinstance(args, list):
+        return None
+
+    for index, value in enumerate(args):
+        if value == "--directory" and index + 1 < len(args):
+            candidate = args[index + 1]
+            if isinstance(candidate, str):
+                return candidate
+    return None

--- a/scripts/mcp_doctor.py
+++ b/scripts/mcp_doctor.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Diagnose Codex MCP registration and endpoint health.
+
+Checks:
+1. Codex config drift (`~/.codex/config.toml`) for expected MCP server registrations.
+2. Stale stdio `--directory` paths.
+3. MCP initialize handshake against canonical SSE endpoints.
+
+Exit codes:
+- 0: all checks passed
+- 2: endpoint unavailable
+- 3: handshake/tools failure
+- 4: config drift (missing server entries, stale stdio paths)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+from mcp_common import (
+    extract_directory_from_args,
+    load_mcp_servers_from_toml,
+    parse_profiles,
+    probe_sse_server,
+    selected_servers,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Diagnose MCP registration and connectivity")
+    parser.add_argument(
+        "--codex-config",
+        default=str(Path.home() / ".codex" / "config.toml"),
+        help="Path to Codex config TOML",
+    )
+    parser.add_argument(
+        "--profiles",
+        default="core browser cicd",
+        help="Profiles to validate (space/comma separated): core browser cicd",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON output")
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    profiles = parse_profiles(args.profiles)
+    specs = selected_servers(profiles)
+    expected_names = {spec.config_name for spec in specs}
+
+    config_path = Path(args.codex_config).expanduser()
+    config_servers = load_mcp_servers_from_toml(config_path)
+
+    missing_servers: list[str] = []
+    stale_stdio_paths: list[str] = []
+    bad_stdio_paths: list[str] = []
+
+    for name in sorted(expected_names):
+        if name not in config_servers:
+            missing_servers.append(name)
+            continue
+
+        args_value = config_servers[name].get("args")
+        stdio_dir = extract_directory_from_args(args_value)
+        if not stdio_dir:
+            continue
+
+        directory_path = Path(stdio_dir).expanduser()
+        if not directory_path.exists():
+            bad_stdio_paths.append(f"{name}: {stdio_dir}")
+        if "voice-bot-acs/codex-power-pack/mcp-woodpecker-ci" in stdio_dir:
+            stale_stdio_paths.append(f"{name}: {stdio_dir}")
+
+    probe_results = [probe_sse_server(spec, check_tools_list=False) for spec in specs]
+
+    payload = {
+        "config_path": str(config_path),
+        "profiles": sorted(profiles),
+        "expected_servers": sorted(expected_names),
+        "missing_servers": missing_servers,
+        "bad_stdio_paths": bad_stdio_paths,
+        "stale_stdio_paths": stale_stdio_paths,
+        "probe_results": [asdict(result) for result in probe_results],
+    }
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print("MCP Doctor")
+        print(f"- Codex config: {config_path}")
+        print(f"- Profiles: {', '.join(sorted(profiles))}")
+
+        if missing_servers:
+            print("- Missing MCP registrations:")
+            for name in missing_servers:
+                print(f"  - {name}")
+
+        if bad_stdio_paths:
+            print("- Missing stdio directories:")
+            for row in bad_stdio_paths:
+                print(f"  - {row}")
+
+        if stale_stdio_paths:
+            print("- Legacy/stale registration paths:")
+            for row in stale_stdio_paths:
+                print(f"  - {row}")
+
+        print("- Endpoint probes:")
+        for result in probe_results:
+            status = "PASS" if result.ok else "FAIL"
+            detail = f"server={result.server_name or '-'} version={result.server_version or '-'}"
+            if not result.ok:
+                detail = f"stage={result.stage} error={result.error or 'unknown'}"
+            print(f"  - [{status}] {result.config_name} {detail}")
+
+    config_failed = bool(missing_servers or bad_stdio_paths or stale_stdio_paths)
+    failed_results = [result for result in probe_results if not result.ok]
+
+    if config_failed:
+        return 4
+    if any(result.stage == "endpoint" for result in failed_results):
+        return 2
+    if failed_results:
+        return 3
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mcp_install_codex.py
+++ b/scripts/mcp_install_codex.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Install/update Codex MCP registrations for codex-power-pack.
+
+This script writes deterministic stdio registrations in `~/.codex/config.toml`
+using repository-local service directories.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+from pathlib import Path
+
+from mcp_common import canonical_servers
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Install Codex MCP config for codex-power-pack")
+    parser.add_argument(
+        "--codex-config",
+        default=str(Path.home() / ".codex" / "config.toml"),
+        help="Path to Codex config TOML",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=str(Path(__file__).resolve().parents[1]),
+        help="Repository root path used to build --directory args",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Print planned changes without writing files")
+    return parser
+
+
+def _remove_mcp_sections(text: str, server_names: set[str]) -> str:
+    """Remove existing `[mcp_servers.<name>]` and nested sections for selected names."""
+    lines = text.splitlines(keepends=True)
+    result: list[str] = []
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        stripped = line.strip()
+
+        if stripped.startswith("[mcp_servers.") and stripped.endswith("]"):
+            section_key = stripped[len("[mcp_servers.") : -1]
+            section_base = section_key.split(".", 1)[0]
+            if section_base in server_names:
+                index += 1
+                while index < len(lines):
+                    next_stripped = lines[index].strip()
+                    if next_stripped.startswith("[") and next_stripped.endswith("]"):
+                        break
+                    index += 1
+                continue
+
+        result.append(line)
+        index += 1
+
+    return "".join(result)
+
+
+def _format_toml_array(values: list[str]) -> str:
+    quoted = [json.dumps(value) for value in values]
+    return "[" + ", ".join(quoted) + "]"
+
+
+def _render_blocks(repo_root: Path) -> str:
+    blocks: list[str] = []
+
+    for spec in canonical_servers():
+        service_dir = str((repo_root / spec.repo_subdir).resolve())
+        args = ["run", "--directory", service_dir, "python", "src/server.py", "--stdio"]
+
+        blocks.append(f"[mcp_servers.{spec.config_name}]")
+        blocks.append('command = "uv"')
+        blocks.append(f"args = {_format_toml_array(args)}")
+        blocks.append("")
+
+        if spec.config_name == "codex-woodpecker":
+            blocks.append(f"[mcp_servers.{spec.config_name}.env]")
+            blocks.append('AWS_REGION = "us-east-1"')
+            blocks.append('AWS_SECRET_NAME = "codex-power-pack"')
+            blocks.append('PYTHONUNBUFFERED = "1"')
+            blocks.append("")
+
+    return "\n".join(blocks).rstrip() + "\n"
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    config_path = Path(args.codex_config).expanduser()
+    repo_root = Path(args.repo_root).resolve()
+
+    if not repo_root.exists():
+        print(f"ERROR: repo root does not exist: {repo_root}")
+        return 1
+
+    canonical_names = {spec.config_name for spec in canonical_servers()}
+    migration_aliases = {
+        "second-opinion",
+        "playwright-persistent",
+        "nano-banana",
+        "woodpecker-ci",
+        "codex-woodpecker",  # ensures stale legacy block is replaced
+    }
+
+    names_to_replace = canonical_names | migration_aliases
+
+    original_text = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
+    base_text = _remove_mcp_sections(original_text, names_to_replace).rstrip()
+    rendered = _render_blocks(repo_root)
+
+    new_text = (base_text + "\n\n" + rendered).lstrip("\n") if base_text else rendered
+
+    print(f"Codex config target: {config_path}")
+    print(f"Repo root: {repo_root}")
+    print("Servers installed:")
+    for name in sorted(canonical_names):
+        print(f"- {name}")
+
+    if args.dry_run:
+        print("\nDRY RUN: no files written")
+        return 0
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    if config_path.exists():
+        timestamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+        backup_path = config_path.with_suffix(config_path.suffix + f".bak.{timestamp}")
+        backup_path.write_text(original_text, encoding="utf-8")
+        print(f"Backup: {backup_path}")
+
+    config_path.write_text(new_text, encoding="utf-8")
+    print("Updated Codex MCP config.")
+    print("Next step: run `make mcp-doctor`.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mcp_smoke.py
+++ b/scripts/mcp_smoke.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Run MCP initialize smoke checks against Codex Power Pack SSE endpoints.
+
+Exit codes:
+- 0: all checks passed
+- 2: endpoint unavailable (connection/HTTP failure)
+- 3: handshake or tools/list failure
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict
+
+from mcp_common import parse_profiles, probe_sse_server, selected_servers
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="MCP smoke tests (SSE initialize)")
+    parser.add_argument(
+        "--profiles",
+        default="core",
+        help="Profiles to probe (space/comma separated): core browser cicd",
+    )
+    parser.add_argument(
+        "--tools-list",
+        action="store_true",
+        help="Also run JSON-RPC tools/list after initialize",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON output")
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    profiles = parse_profiles(args.profiles)
+    specs = selected_servers(profiles)
+
+    if not specs:
+        print("No MCP servers selected for profiles:", ", ".join(sorted(profiles)))
+        return 0
+
+    results = [probe_sse_server(spec, check_tools_list=args.tools_list) for spec in specs]
+
+    if args.json:
+        print(json.dumps([asdict(result) for result in results], indent=2, sort_keys=True))
+    else:
+        print("MCP Smoke Results")
+        for result in results:
+            status = "PASS" if result.ok else "FAIL"
+            detail = f"server={result.server_name or '-'} version={result.server_version or '-'}"
+            if not result.ok:
+                detail = f"stage={result.stage} error={result.error or 'unknown'}"
+            print(f"- [{status}] {result.config_name} ({result.sse_url}) {detail}")
+
+    if all(result.ok for result in results):
+        return 0
+
+    if any(result.stage == "endpoint" for result in results if not result.ok):
+        return 2
+    return 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_mcp_common.py
+++ b/tests/test_mcp_common.py
@@ -1,0 +1,59 @@
+"""Unit tests for scripts/mcp_common.py helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Import from scripts/ to test operational helpers without packaging changes.
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from mcp_common import (  # type: ignore[import-not-found]  # noqa: E402
+    extract_directory_from_args,
+    load_mcp_servers_from_toml,
+    parse_profiles,
+    selected_servers,
+)
+
+
+def test_parse_profiles_supports_space_and_comma_delimiters() -> None:
+    assert parse_profiles("core browser") == {"core", "browser"}
+    assert parse_profiles("core,browser,cicd") == {"core", "browser", "cicd"}
+
+
+def test_parse_profiles_defaults_to_core() -> None:
+    assert parse_profiles(None) == {"core"}
+    assert parse_profiles("") == {"core"}
+
+
+def test_selected_servers_filters_by_profile() -> None:
+    core_servers = {spec.config_name for spec in selected_servers({"core"})}
+    assert core_servers == {"codex-second-opinion", "codex-nano-banana"}
+
+
+def test_extract_directory_from_args() -> None:
+    args = ["run", "--directory", "/tmp/example", "python", "src/server.py", "--stdio"]
+    assert extract_directory_from_args(args) == "/tmp/example"
+    assert extract_directory_from_args(["run", "python", "src/server.py"]) is None
+
+
+def test_load_mcp_servers_from_toml(tmp_path: Path) -> None:
+    config = tmp_path / "config.toml"
+    config.write_text(
+        """
+[mcp_servers.codex-second-opinion]
+command = "uv"
+args = ["run", "--directory", "/tmp/a", "python", "src/server.py", "--stdio"]
+
+[mcp_servers.codex-second-opinion.env]
+PYTHONUNBUFFERED = "1"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    servers = load_mcp_servers_from_toml(config)
+    assert "codex-second-opinion" in servers
+    assert servers["codex-second-opinion"]["command"] == "uv"

--- a/tests/test_mcp_docs_endpoints.py
+++ b/tests/test_mcp_docs_endpoints.py
@@ -1,0 +1,50 @@
+"""Documentation checks for MCP endpoint/transport consistency."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _load(path: str) -> str:
+    return (_repo_root() / path).read_text(encoding="utf-8")
+
+
+def test_no_910x_mcp_endpoint_examples_in_codex_docs() -> None:
+    files = [
+        "README.md",
+        "codex-second-opinion/README.md",
+        "codex-playwright/README.md",
+        "codex-nano-banana/README.md",
+        "codex-woodpecker/README.md",
+    ]
+
+    bad_pattern = re.compile(r"http://127\\.0\\.0\\.1:91\\d\\d/mcp")
+    offenders: list[str] = []
+
+    for file_path in files:
+        text = _load(file_path)
+        if bad_pattern.search(text):
+            offenders.append(file_path)
+
+    assert not offenders, f"Found stale /mcp endpoint examples in: {', '.join(offenders)}"
+
+
+def test_sse_endpoint_examples_exist_for_all_codex_mcp_servers() -> None:
+    expected_examples = {
+        "codex-second-opinion/README.md": "http://127.0.0.1:9100/sse",
+        "codex-playwright/README.md": "http://127.0.0.1:9101/sse",
+        "codex-nano-banana/README.md": "http://127.0.0.1:9102/sse",
+        "codex-woodpecker/README.md": "http://127.0.0.1:9103/sse",
+    }
+
+    missing: list[str] = []
+    for file_path, endpoint in expected_examples.items():
+        if endpoint not in _load(file_path):
+            missing.append(f"{file_path} -> {endpoint}")
+
+    assert not missing, f"Missing SSE endpoint examples: {', '.join(missing)}"


### PR DESCRIPTION
## Summary
- add `scripts/mcp_install_codex.py` to deterministically install Codex MCP stdio registrations from repo-local paths
- add `scripts/mcp_doctor.py` to detect MCP config drift (missing registrations, stale/missing stdio directories) and validate live SSE endpoint handshakes
- add `scripts/mcp_smoke.py` to run profile-aware MCP initialize smoke checks with distinct failure exit codes
- add shared operational helpers in `scripts/mcp_common.py`
- add Makefile targets: `mcp-install-codex`, `mcp-doctor`, `mcp-smoke`
- gate `make deploy` with `mcp-smoke` so deployment verifies MCP initialize readiness
- align MCP docs to canonical SSE endpoints (`/sse`) and remove stale `/mcp` examples in Codex service docs
- add tests for new MCP helper logic and docs endpoint consistency checks

## Validation
- `make update_docs`
- `env UV_CACHE_DIR=/tmp/uv-cache make verify`
- `python3 scripts/mcp_smoke.py --profiles "core browser cicd"`
- `python3 scripts/mcp_doctor.py --codex-config /home/cooneycw/.codex/config.toml --profiles "core browser cicd"` (expected non-zero on stale local config)
- migration proof:
  - `python3 scripts/mcp_install_codex.py --codex-config /tmp/codex-config-migration-test.toml --repo-root /home/cooneycw/Projects/codex-power-pack-issue-32`
  - `python3 scripts/mcp_doctor.py --codex-config /tmp/codex-config-migration-test.toml --profiles "core browser cicd"` (passes)

Closes #32
Closes #33
Closes #34
