### PR TITLE
feat(documentation): port trigger parity namespace (Closes #5)

### DIFF
--- a/.codex/prompts/documentation/c4.md
+++ b/.codex/prompts/documentation/c4.md
@@ -1,0 +1,574 @@
+---
+description: Generate C4 architecture diagrams for the current project (all 4 levels, one per container/component)
+allowed-tools: mcp__nano-banana__list_diagram_types, mcp__nano-banana__generate_diagram, mcp__nano-banana__validate_diagram, mcp__nano-banana__split_diagram, mcp__playwright-persistent__create_session, mcp__playwright-persistent__browser_navigate, mcp__playwright-persistent__browser_screenshot, mcp__playwright-persistent__close_session, AskUserQuestion
+---
+
+> Trigger parity entrypoint for `/documentation:c4`.
+> Backing skill: `documentation-c4` (`.codex/skills/documentation-c4/SKILL.md`).
+
+
+# C4 Architecture Diagram Generation
+
+## Arguments
+
+- `LEVEL` (optional): Generate only a specific level - `L1`, `L2`, `L3`, or `L4`. Default: all 4 levels.
+- When `L3` is specified alone, generates L3 for ALL containers found in an existing L2 diagram or by analyzing the project.
+- When `L4` is specified alone, generates L4 for top 3 components per container from existing L3 diagrams.
+
+## Instructions
+
+When the user invokes `/documentation:c4 [LEVEL]`, analyze the current project and generate C4 architecture diagrams.
+
+### Step 1: Analyze the Project
+
+Read the project's key files to understand its architecture:
+
+1. **AGENTS.md** - Project overview, components, structure
+2. **README.md** - High-level description
+3. **Directory structure** - `ls` the top-level directories
+4. **Key config files** - `pyproject.toml`, `package.json`, `docker-compose.yml`, etc.
+5. **Existing docs** - Check `docs/architecture/` for previous C4 outputs
+
+Build a mental model of:
+- Who uses the system (actors/personas)
+- What external systems it integrates with
+- What containers (apps, DBs, services) make up the system
+- What components exist within each container
+- What key code elements (classes, modules) implement each component
+
+### Step 2: Determine Output Path
+
+```bash
+# Default output directory
+DOCS_DIR="docs/architecture"
+mkdir -p "$DOCS_DIR"
+```
+
+### Step 3: Generate L1 and L2 Diagrams
+
+Generate using the `generate_diagram` MCP tool with `diagram_type: "c4"`.
+
+**IMPORTANT:** Do NOT pass `save_path` to `generate_diagram`. The MCP tool runs in Docker and cannot write to host paths. Instead, capture the returned `html` string and save it using the `Write` tool.
+
+**C4 Node Types:**
+
+| Node Type | C4 Concept | When to Use |
+|-----------|-----------|-------------|
+| `person` | Actor / User | External users, admins, operators |
+| `system` | External System | Third-party APIs, services not owned by team |
+| `system-focus` | System of Interest | The system being documented |
+| `container` | Container | Applications, databases, message queues, file stores |
+| `component` | Component | Modules, services, controllers within a container |
+| `code` | Code Element | Classes, interfaces, functions, data models |
+
+#### Initialize Diagram Tracking
+
+Before generating any diagrams, initialize a list to track all outputs for the manifest:
+
+```
+# Track ALL generated diagrams for the manifest (c4-manifest.json)
+generated_diagrams = []
+```
+
+#### Level 1: System Context
+
+Focus on: actors + external systems + the system of interest. Keep it high-level (5-10 nodes max).
+
+```
+result = generate_diagram(
+    diagram_type="c4",
+    title="L1 System Context - {Project Name}",
+    description="Who uses the system and what it connects to",
+    nodes=[
+        {"id": "user", "label": "User", "type": "person", "description": "End user"},
+        {"id": "system", "label": "{Project}", "type": "system-focus", "description": "Main system"},
+        {"id": "ext1", "label": "External API", "type": "system", "description": "Third-party service"},
+    ],
+    edges=[
+        {"source": "user", "target": "system", "label": "Uses"},
+        {"source": "system", "target": "ext1", "label": "Calls API"},
+    ],
+)
+# Save HTML using Write tool
+Write(file_path="{DOCS_DIR}/c4-l1-context.html", content=result.html)
+generated_diagrams.append({
+    "id": "l1-context",
+    "level": "L1",
+    "title": result.title,
+    "file": "c4-l1-context.html",
+    "node_count": len(nodes),
+    "edge_count": len(edges),
+    "parent": null
+})
+```
+
+#### Level 2: Container
+
+Focus on: applications, databases, services within the system boundary. Show technology choices.
+
+```
+result = generate_diagram(
+    diagram_type="c4",
+    title="L2 Container - {Project Name}",
+    description="Applications, data stores, and services",
+    nodes=[
+        {"id": "web", "label": "Web App", "type": "container", "description": "React / TypeScript"},
+        {"id": "api", "label": "API Server", "type": "container", "description": "Python / FastAPI"},
+        {"id": "db", "label": "Database", "type": "container", "description": "PostgreSQL"},
+    ],
+    edges=[...],
+)
+Write(file_path="{DOCS_DIR}/c4-l2-container.html", content=result.html)
+generated_diagrams.append({
+    "id": "l2-container",
+    "level": "L2",
+    "title": result.title,
+    "file": "c4-l2-container.html",
+    "node_count": len(nodes),
+    "edge_count": len(edges),
+    "parent": "l1-context"
+})
+```
+
+### Step 3b: Plan L3/L4 Expansion
+
+After generating L2, plan the iterative L3 and L4 generation:
+
+1. **Build containers list** - Extract ALL nodes of type `container` from the L2 diagram you just generated:
+   ```
+   containers_for_l3 = [node for node in l2_nodes if node.type == "container"]
+   ```
+
+2. **Scope check** - If more than 5 containers are found, ask the user:
+   > "Found {N} containers. Generate L3 for all {N}, or select the most important ones?"
+
+   If the user selects a subset, use only those. Otherwise generate for all.
+
+3. **Plan L4 targets** - After generating each L3, you will pick the top 3 most architecturally significant components per container for L4 expansion. Significance criteria:
+   - Components with the most edges (highest connectivity)
+   - Components implementing core business logic
+   - Components with external integrations
+
+### Step 4: Generate L3 Diagrams (One Per Container)
+
+For EACH container identified in Step 3b, generate a separate L3 Component diagram.
+
+**Naming convention:** `c4-l3-{container-slug}.html` where `container-slug` is the container label lowercased with spaces/special chars replaced by hyphens.
+
+```
+for container in containers_for_l3:
+    # Analyze the codebase to identify components within this container
+    # Read source files, configs, and modules belonging to this container
+
+    slug = slugify(container.label)  # e.g., "API Server" -> "api-server"
+
+    result = generate_diagram(
+        diagram_type="c4",
+        title="L3 Component - {container.label}",
+        description="Components within {container.label}",
+        nodes=[
+            # Components discovered by analyzing this container's code
+            {"id": "{container_slug}-comp1", "label": "Component Name", "type": "component", "description": "Purpose / tech"},
+            # ... more components
+        ],
+        edges=[
+            # Internal edges between components + edges to external containers
+        ],
+    )
+    Write(file_path="{DOCS_DIR}/c4-l3-{slug}.html", content=result.html)
+    generated_diagrams.append({
+        "id": "l3-{slug}",
+        "level": "L3",
+        "title": result.title,
+        "file": "c4-l3-{slug}.html",
+        "node_count": len(nodes),
+        "edge_count": len(edges),
+        "parent": "l2-container",
+        "container_id": container.id
+    })
+```
+
+**Guidelines for L3 diagrams:**
+- Each L3 should have 5-15 nodes (components within one container)
+- Include edges to components in OTHER containers as external references (use `system` type for external container nodes)
+- Use descriptive IDs prefixed with the container slug to avoid collisions across diagrams
+
+#### QA Gating After Every `generate_diagram` Call
+
+After EVERY `generate_diagram` call (L1, L2, L3, L4), inspect the response for QA signals and react. Track all QA events for the final report.
+
+```
+# Initialize QA tracking at the start (alongside generated_diagrams)
+qa_events = []  # {"level": "L3", "diagram": "c4-l3-api.html", "action": "split", "details": "..."}
+
+# After each generate_diagram call:
+def handle_qa_gating(result, level, slug, nodes, edges):
+    retries = 0
+    MAX_RETRIES = 2
+
+    while retries < MAX_RETRIES:
+        # 1. Check for warnings in the response
+        if not result.get("warnings"):
+            break  # No QA issues - proceed
+
+        for warning in result.warnings:
+            if warning.check == "edge_validity" and warning.severity == "high":
+                # EDGE_INVALID: fix the bad edge reference and retry
+                # Find the edge with invalid source/target and correct it
+                # (remove or remap to a valid node ID)
+                fix_invalid_edges(nodes, edges, warning)
+                qa_events.append({
+                    "level": level, "diagram": slug,
+                    "action": "edge_fix_retry",
+                    "details": warning.message
+                })
+                retries += 1
+                result = generate_diagram(...)  # retry with fixed edges
+                continue  # re-check warnings after retry
+
+            if warning.check == "orphan_nodes" and warning.severity == "medium":
+                # ORPHAN_NODES: warn the user but continue
+                qa_events.append({
+                    "level": level, "diagram": slug,
+                    "action": "orphan_warning",
+                    "details": warning.message
+                })
+                # Do NOT retry - just note it
+
+            if warning.check == "long_labels" and warning.severity == "low":
+                # LONG_LABELS: note but continue
+                qa_events.append({
+                    "level": level, "diagram": slug,
+                    "action": "long_label_warning",
+                    "details": warning.message
+                })
+
+        break  # Exit retry loop after processing non-retryable warnings
+
+    # 2. Check density for overflow
+    if result.density.status in ("overflow", "critical"):
+        qa_events.append({
+            "level": level, "diagram": slug,
+            "action": "split",
+            "details": f"density {result.density.density:.2f} ({result.density.status})"
+        })
+        return "SPLIT_NEEDED"
+
+    return result
+```
+
+#### Handling OVERFLOW: Split Strategy
+
+When QA gating returns `SPLIT_NEEDED`, use `split_diagram` to produce summary + detail sub-diagrams:
+
+```
+if qa_result == "SPLIT_NEEDED":
+    split_result = split_diagram(
+        diagram_type="c4",
+        title="L3 Component - {container.label}",
+        description="Components within {container.label}",
+        nodes=[...],  # same nodes
+        edges=[...],  # same edges (after any edge fixes)
+        max_nodes_per_page=15,
+        strategy="c4_boundary",  # groups by C4 node type
+    )
+
+    # split_diagram returns HTML in each diagram entry
+    # Save each using the Write tool with naming convention:
+    #   c4-l3-{slug}.html           (summary)
+    #   c4-l3-{slug}-detail-1.html  (detail page 1)
+    #   c4-l3-{slug}-detail-2.html  (detail page 2)
+
+    for i, diagram in enumerate(split_result.diagrams):
+        if diagram.role == "summary":
+            file_name = f"c4-l3-{slug}.html"
+        else:
+            file_name = f"c4-l3-{slug}-detail-{diagram.index}.html"
+
+        Write(file_path=f"{DOCS_DIR}/{file_name}", content=diagram.html)
+        generated_diagrams.append({
+            "id": f"l3-{slug}" if diagram.role == "summary" else f"l3-{slug}-detail-{diagram.index}",
+            "level": "L3",
+            "title": diagram.title,
+            "file": file_name,
+            "node_count": diagram.node_count,
+            "edge_count": diagram.edge_count,
+            "parent": "l2-container",
+            "container_id": container.id,
+            "split_role": diagram.role,  # "summary" or "detail"
+        })
+```
+
+Available clustering strategies:
+- `c4_boundary` - groups by C4 node type (best for C4 diagrams)
+- `connectivity` - groups by graph connectivity (connected components)
+- `type_group` - groups by generic node type
+
+#### Retry Rules
+
+- **EDGE_INVALID** (high severity): Fix the invalid edge references (remove or remap to a valid node ID), then retry `generate_diagram`. Maximum 2 retries per diagram.
+- **OVERFLOW** (viewport_fit, high severity): Do NOT retry `generate_diagram`. Instead, call `split_diagram` to produce summary + detail views.
+- **ORPHAN_NODES** (medium): Log warning, continue. Do not retry.
+- **LONG_LABELS** (low): Log warning, continue. Do not retry.
+- **CONTRAST** (medium): Log warning, continue. Theme tokens handle contrast.
+
+### Step 5: Generate L4 Diagrams (Top 3 Components Per Container)
+
+For each L3 diagram, select the top 3 most architecturally significant components and generate an L4 Code diagram for each.
+
+**Naming convention:** `c4-l4-{container-slug}-{component-slug}.html`
+
+```
+for container in containers_for_l3:
+    container_slug = slugify(container.label)
+
+    # From the L3 we just generated, pick top 3 components by significance
+    top_components = select_top_3_components(l3_nodes_for_container)
+
+    for component in top_components:
+        comp_slug = slugify(component.label)
+
+        # Analyze the source code for this component
+        # Identify classes, interfaces, functions, data models
+
+        result = generate_diagram(
+            diagram_type="c4",
+            title="L4 Code - {component.label} ({container.label})",
+            description="Classes and modules in {component.label}",
+            nodes=[
+                {"id": "{container_slug}-{comp_slug}-cls1", "label": "ClassName", "type": "code", "description": "class / interface / module"},
+                # ... more code elements
+            ],
+            edges=[...],
+        )
+        Write(file_path="{DOCS_DIR}/c4-l4-{container_slug}-{comp_slug}.html", content=result.html)
+        generated_diagrams.append({
+            "id": "l4-{container_slug}-{comp_slug}",
+            "level": "L4",
+            "title": result.title,
+            "file": "c4-l4-{container_slug}-{comp_slug}.html",
+            "node_count": len(nodes),
+            "edge_count": len(edges),
+            "parent": "l3-{container_slug}",
+            "container_id": container.id,
+            "component_id": component.id
+        })
+```
+
+**Guidelines for L4 diagrams:**
+- Each L4 should have 5-12 nodes (classes/modules within one component)
+- Per Simon Brown: "Show the core, not the whole" - focus on the most important code elements
+- Skip L4 for simple components with fewer than 3 code elements
+
+### Step 6: Screenshot (if Playwright available)
+
+Use ONE Playwright session for all screenshots:
+
+1. Create a single Playwright session (headless)
+2. For EACH generated HTML file (L1, L2, all L3s, all L4s):
+   a. Navigate to `file://{absolute_path}`
+   b. Screenshot at 1920x1080
+   c. Save PNG alongside HTML (same name with .png extension)
+3. Close session (once, at end)
+
+If Playwright is not available, skip screenshots and note the user can open HTML files in a browser.
+
+### Step 6b: Generate Manifest
+
+After all diagrams are generated (and optionally screenshotted), write the `c4-manifest.json` file to track what was produced:
+
+```json
+{
+  "project": "{project-name}",
+  "generated_at": "{ISO 8601 timestamp}",
+  "theme_id": "c4-default-dark-v1",
+  "diagrams": [
+    // ... all entries from generated_diagrams list
+  ]
+}
+```
+
+Use the Write tool to create the manifest:
+
+```
+import json
+from datetime import datetime, timezone
+
+manifest = {
+    "project": project_name,
+    "generated_at": datetime.now(timezone.utc).isoformat(),
+    "theme_id": "c4-default-dark-v1",
+    "diagrams": generated_diagrams
+}
+
+Write(file_path="{DOCS_DIR}/c4-manifest.json", content=json.dumps(manifest, indent=2))
+```
+
+**Manifest rules:**
+- Each diagram entry MUST have: `id`, `level`, `title`, `file`, `node_count`, `edge_count`, `parent`
+- L1 diagrams have `parent: null`
+- L2 diagrams have `parent: "l1-context"`
+- L3 diagrams have `parent: "l2-container"` and `container_id`
+- L4 diagrams have `parent: "l3-{container_slug}"`, `container_id`, and `component_id`
+- The `file` field is a relative path within the output directory (not absolute)
+
+### Step 6c: Generate Index Page
+
+After writing the manifest, generate `index.html` for hierarchical diagram navigation. Build the page from the `generated_diagrams` list using this template:
+
+```
+# Build parent-child tree from generated_diagrams
+# L1 entries (parent == null) are roots
+# L2 entries have parent == "l1-context"
+# L3 entries have parent == "l2-container"
+# L4 entries have parent == "l3-{container_slug}"
+
+index_html = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>C4 Architecture - {project_name}</title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+    font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+    background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+    color: #e2e8f0;
+    min-height: 100vh;
+    padding: 40px;
+}
+h1 { font-size: 32px; font-weight: 700; color: #f8fafc; margin-bottom: 8px; }
+.subtitle { font-size: 16px; color: #94a3b8; margin-bottom: 32px; }
+details { margin-left: 24px; margin-bottom: 8px; }
+details:first-child { margin-left: 0; }
+summary {
+    cursor: pointer; list-style: none; padding: 8px 0;
+    font-size: 15px; color: #cbd5e1; user-select: none;
+}
+summary::-webkit-details-marker { display: none; }
+summary::before { content: '+ '; color: #64748b; font-family: monospace; }
+details[open] > summary::before { content: '- '; }
+.card {
+    display: inline-flex; align-items: center; gap: 12px;
+    background: rgba(255,255,255,0.04); border: 1px solid #334155;
+    border-radius: 8px; padding: 12px 20px; margin: 4px 0;
+    text-decoration: none; color: inherit; transition: background 0.15s;
+}
+.card:hover { background: rgba(255,255,255,0.08); }
+.badge {
+    font-size: 11px; font-weight: 700; padding: 2px 8px;
+    border-radius: 4px; text-transform: uppercase; letter-spacing: 0.5px;
+}
+.badge-l1 { background: #1d4ed8; color: #fff; }
+.badge-l2 { background: #15803d; color: #fff; }
+.badge-l3 { background: #7e22ce; color: #fff; }
+.badge-l4 { background: #92400e; color: #fff; }
+.card-title { font-weight: 600; }
+.card-meta { font-size: 12px; color: #94a3b8; }
+a.card { display: inline-flex; }
+.generated { font-size: 12px; color: #475569; margin-top: 32px; }
+</style>
+</head>
+<body>
+<h1>C4 Architecture Diagrams</h1>
+<div class="subtitle">{project_name}</div>
+"""
+
+# For each L1 diagram, create root <details open>
+# Nest L2 inside L1, L3 inside L2, L4 inside matching L3
+# Each leaf is an <a class="card"> linking to the HTML file
+
+# Example for one L3 with L4 children:
+# <details open>
+#   <summary>
+#     <a class="card" href="c4-l3-api-server.html">
+#       <span class="badge badge-l3">L3</span>
+#       <span class="card-title">L3 Component - API Server</span>
+#       <span class="card-meta">8 nodes, 10 edges</span>
+#     </a>
+#   </summary>
+#   <a class="card" href="c4-l4-api-server-auth.html">
+#     <span class="badge badge-l4">L4</span>
+#     <span class="card-title">L4 Code - Auth Module</span>
+#     <span class="card-meta">5 nodes, 3 edges</span>
+#   </a>
+# </details>
+
+# After building the tree, close with:
+index_html += '<div class="generated">Generated {timestamp}</div>'
+index_html += "</body></html>"
+
+Write(file_path="{DOCS_DIR}/index.html", content=index_html)
+```
+
+**Index page rules:**
+- L1 and L2 sections are always `<details open>` (expanded by default)
+- L3 sections are `<details open>` only if they have L4 children
+- Each diagram entry is an `<a class="card">` linking to its HTML file
+- Level badges use the same colors as the C4 diagram palette
+- Show node_count and edge_count in the card metadata
+- Include generation timestamp at the bottom
+- The page must work when opened directly from the filesystem (`file://`)
+
+### Step 7: Review AGENTS.md and README.md
+
+After generating diagrams, review these files for accuracy:
+
+1. **AGENTS.md** - Check that the repository structure section matches the current directory layout. Flag any stale references.
+2. **README.md** - Check that the project description matches the architecture shown in the C4 diagrams. Flag discrepancies.
+
+Report any issues found but do NOT auto-edit these files. Ask the user for confirmation before making changes.
+
+### Step 8: Report
+
+```
+C4 Architecture Diagrams Generated
+
+  Output:  {DOCS_DIR}/
+
+  L1 Context:    c4-l1-context.html           ({node_count} nodes, {edge_count} edges)
+  L2 Container:  c4-l2-container.html         ({node_count} nodes, {edge_count} edges)
+
+  L3 Component diagrams ({N} containers):
+    c4-l3-{slug-1}.html  ({node_count} nodes, {edge_count} edges)
+    c4-l3-{slug-2}.html  ({node_count} nodes, {edge_count} edges)
+    ...
+
+  L4 Code diagrams ({M} components):
+    c4-l4-{slug-1}-{comp-1}.html  ({node_count} nodes, {edge_count} edges)
+    c4-l4-{slug-1}-{comp-2}.html  ({node_count} nodes, {edge_count} edges)
+    ...
+
+  Manifest:       c4-manifest.json ({2 + N + M} diagrams tracked)
+  Index:          index.html (hierarchical navigation page)
+  Total diagrams: {2 + N + M}
+  Screenshots:    {count} PNG files (or "Playwright not available")
+
+  QA Summary:
+    Diagrams validated: {total}
+    Splits performed:   {split_count} (overflow/critical density)
+    Edge fixes:         {edge_fix_count} retries
+    Warnings:           {orphan_count} orphan nodes, {label_count} long labels
+    All diagrams passed QA: {yes/no}
+
+  Doc Review:
+    AGENTS.md:  {OK | {N} issues found}
+    README.md:  {OK | {N} issues found}
+
+  Open HTML files in a browser to view diagrams.
+```
+
+Build the QA Summary from the `qa_events` list collected during generation. Count events by `action` type: `split`, `edge_fix_retry`, `orphan_warning`, `long_label_warning`.
+
+## Notes
+
+- The C4 model was created by Simon Brown - see https://c4model.com
+- L1 and L2 are always single diagrams; L3 generates one per container; L4 generates up to 3 per container
+- L3/L4 diagrams use slugified container/component names in filenames to avoid collisions
+- Node IDs are prefixed with container/component slugs to stay unique across diagrams
+- Regenerate after major architectural changes
+- `c4-manifest.json` tracks all generated diagrams with parent-child relationships for downstream tools
+- `index.html` provides hierarchical navigation across all generated diagrams
+- Diagrams are gitignored by default (*.html in docs/architecture/ should be committed)
+- Use `/documentation:pptx` to embed C4 diagrams into a presentation

--- a/.codex/prompts/documentation/help.md
+++ b/.codex/prompts/documentation/help.md
@@ -1,0 +1,79 @@
+---
+description: Overview of documentation and diagram commands
+---
+
+> Trigger parity entrypoint for `/documentation:help`.
+> Backing skill: `documentation-help` (`.codex/skills/documentation-help/SKILL.md`).
+
+
+# Documentation & Diagram Commands
+
+Generate architecture documentation and professional presentations using the Nano-Banana MCP server.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `/documentation:c4` | Generate C4 architecture diagrams (all 4 levels) |
+| `/documentation:pptx` | Create PowerPoint presentations with optional diagrams |
+| `/documentation:help` | This help overview |
+
+## MCP Server: Nano-Banana
+
+The Nano-Banana MCP server (`codex-nano-banana/`, port 9102) provides diagram generation and PPTX creation tools.
+
+### Setup
+
+```bash
+# stdio (recommended)
+codex mcp add nano-banana --transport stdio -- uv run --directory ~/Projects/codex-power-pack/codex-nano-banana python src/server.py --stdio
+
+# SSE
+cd ~/Projects/codex-power-pack/codex-nano-banana && ./start-server.sh
+codex mcp add nano-banana --transport sse --url http://127.0.0.1:9102/sse
+```
+
+### Available MCP Tools
+
+| Tool | Purpose |
+|------|---------|
+| `list_diagram_types` | List supported diagram types |
+| `generate_diagram` | Generate HTML diagram at 1920x1080 |
+| `create_pptx` | Create PowerPoint from slide definitions |
+| `diagram_to_pptx` | Combined: diagram + PPTX in one step |
+
+### Diagram Types
+
+- **architecture** - System component grid layout
+- **c4** - C4 model with boundary groupings (Context, Container, Component, Code)
+- **flowchart** - Sequential process steps with arrows
+- **sequence** - Participant message exchange (UML-style)
+- **orgchart** - Tree hierarchy visualization
+- **timeline** - Milestone roadmap on horizontal track
+- **mindmap** - Central topic with radiating branches
+
+### C4 Node Types
+
+| Type | C4 Concept | Color |
+|------|-----------|-------|
+| `person` | Actor / User | Dark blue (pill shape) |
+| `system` | External System | Grey |
+| `system-focus` | System of Interest | Blue |
+| `container` | Container (app, DB, service) | Green |
+| `component` | Component within container | Purple |
+| `code` | Class / module / interface | Amber |
+
+### End-to-End Best Quality
+
+1. `generate_diagram` -> save HTML file
+2. Playwright screenshot at 1920x1080
+3. `create_pptx` with image_base64 on "diagram" layout
+
+### Makefile Integration
+
+Add an `update_docs` target to your Makefile to run C4 diagram generation and doc review as part of `/flow:auto` and `/flow:finish`.
+
+### Related
+
+- `/load-mcp-docs` - Load all MCP server documentation
+- MCP Playwright - Browser automation for screenshots

--- a/.codex/prompts/documentation/pptx.md
+++ b/.codex/prompts/documentation/pptx.md
@@ -1,0 +1,217 @@
+---
+description: Create a PowerPoint presentation with optional diagrams
+allowed-tools: mcp__nano-banana__list_diagram_types, mcp__nano-banana__generate_diagram, mcp__nano-banana__validate_diagram, mcp__nano-banana__split_diagram, mcp__nano-banana__create_pptx, mcp__nano-banana__validate_pptx_slides, mcp__nano-banana__diagram_to_pptx, mcp__playwright-persistent__create_session, mcp__playwright-persistent__browser_navigate, mcp__playwright-persistent__browser_screenshot, mcp__playwright-persistent__close_session, AskUserQuestion
+---
+
+> Trigger parity entrypoint for `/documentation:pptx`.
+> Backing skill: `documentation-pptx` (`.codex/skills/documentation-pptx/SKILL.md`).
+
+
+# PowerPoint Creation
+
+## Arguments
+
+- `TOPIC` (optional): The topic or subject for the presentation
+
+## Instructions
+
+When the user invokes `/documentation:pptx [TOPIC]`, guide them through creating a professional presentation.
+
+### Step 1: Gather Requirements
+
+If no topic is provided, ask the user:
+
+```
+What would you like to create a presentation about?
+```
+
+Then ask for preferences:
+
+1. **Slide count** - How many slides? (default: 5-8)
+2. **Diagrams** - Include diagrams? Which types? (architecture, c4, flowchart, sequence, orgchart, timeline, mindmap)
+3. **Output path** - Where to save the .pptx file? (default: current directory)
+4. **Communication framework** - How should the narrative be structured? (default: auto-select based on topic)
+5. **Organization ethos** - Does the user have a file or URL describing organizational values/culture? (optional)
+
+### Step 1b: Framework Selection
+
+If the user wants to choose a communication framework, present these options:
+
+| Framework | Structure | Description | Best For |
+|-----------|-----------|-------------|----------|
+| **GAME** | Goal / Audience / Message / Expression | Developed at McKinsey. Forces clarity on what you want (Goal), who decides (Audience), the single key takeaway (Message), and how to deliver it (Expression). One message per deck principle. | Strategic proposals, board presentations, stakeholder alignment |
+| **Pyramid** | Answer / Supporting Arguments / Evidence | Barbara Minto's Pyramid Principle. Lead with the answer, then group supporting arguments, then evidence. Top-down structure so executives get the point immediately. | Executive summaries, recommendation decks, consulting deliverables |
+| **SCQA** | Situation / Complication / Question / Answer | A storytelling variant of the Pyramid. Establishes shared context (Situation), introduces tension (Complication), frames the decision (Question), then delivers the recommendation (Answer). | Problem-solving, analytical presentations, strategy pivots |
+| **STAR** | Situation / Task / Action / Result | Behavioral narrative structure. Describes the starting context, the specific challenge, what was done, and measurable outcomes. Concrete and evidence-based. | Case studies, project retrospectives, interview prep, performance reviews |
+| **Monroe** | Attention / Need / Satisfaction / Visualization / Action | Alan Monroe's Motivated Sequence. Grabs attention, establishes urgency, presents the solution, paints the future state, then calls for action. Designed to persuade. | Persuasive pitches, change management, fundraising, policy proposals |
+| **PSB** | Problem / Solution / Benefit | The simplest persuasive structure. Name the pain, show the fix, quantify the win. No wasted slides. | Product demos, feature announcements, sales decks, internal tool adoption |
+| **Narrative** | Setup / Conflict / Journey / Resolution | Classic storytelling arc. Establishes the world, introduces a challenge, follows the journey through it, and arrives at resolution. Emotional engagement over logic. | Vision presentations, company all-hands, transformation stories, keynotes |
+
+If the user provides an org ethos file (PDF, DOCX, URL, or pasted text):
+- Read and extract key principles, values, mission, strategic pillars
+- Strip corporate names and identifiers (anonymize by default)
+- Weave organizational values into the slide narrative and speaker notes
+
+If no framework is specified, auto-select based on the topic:
+- Technical architecture -> Pyramid
+- Project updates -> STAR
+- Proposals -> GAME or Monroe
+- Problem analysis -> SCQA
+- Product features -> PSB
+
+### Step 2: Plan the Presentation
+
+Structure the deck according to the selected framework. Apply the framework implicitly through headings and flow - NEVER name the framework in the output.
+
+Example structures:
+
+**GAME-structured deck:**
+```
+Slide 1: Title
+Slide 2: The Objective (Goal)
+Slide 3: Who This Is For (Audience)
+Slide 4-N: Key Points (Message)
+Slide N+1: Recommended Actions (Expression)
+```
+
+**Pyramid-structured deck:**
+```
+Slide 1: Title
+Slide 2: Executive Summary (answer first)
+Slide 3: Current Situation
+Slide 4: The Challenge
+Slide 5-N: Supporting Evidence
+Slide N+1: Recommendation
+```
+
+**SCQA-structured deck:**
+```
+Slide 1: Title
+Slide 2: Where We Are (Situation)
+Slide 3: What Changed (Complication)
+Slide 4: The Key Question
+Slide 5-N: The Answer + Evidence
+Slide N+1: Next Steps
+```
+
+Report the plan and ask for confirmation.
+
+### Step 3: Generate Diagrams (if requested)
+
+For each diagram requested:
+
+1. Use `generate_diagram` to create the HTML diagram
+2. **QA gate the result** before proceeding (see QA Gating below)
+3. Save the validated HTML to a temp file
+4. If Playwright MCP is available:
+   - Create ONE Playwright session for ALL diagrams (do not create/close per diagram)
+   - For EACH diagram: navigate to the HTML file, screenshot at 1920x1080
+   - Close session ONCE at the end, after all diagrams are captured
+   - Use each screenshot as `image_base64` in the PPTX
+5. If Playwright is not available:
+   - Use `diagram_to_pptx` for text-based embedding
+   - Note that the user can manually screenshot the HTML for better quality
+
+#### Diagram QA Gating
+
+After each `generate_diagram` call, check the response for warnings before embedding:
+
+```
+qa_events = []
+
+for each diagram:
+    result = generate_diagram(...)
+
+    # Check for warnings
+    if result.get("warnings"):
+        high_issues = [w for w in result.warnings if w.severity == "high"]
+        medium_issues = [w for w in result.warnings if w.severity == "medium"]
+
+        # HIGH severity: block embedding and fix
+        for warning in high_issues:
+            if warning.check == "edge_validity":
+                # Fix invalid edge references and retry (max 2 retries)
+                fix edges, retry generate_diagram
+                qa_events.append({"action": "edge_fix_retry", "details": warning.message})
+
+            if warning.check == "viewport_fit":
+                # Diagram overflows viewport - split or regenerate at higher dimensions
+                if result.density.status in ("overflow", "critical"):
+                    split_result = split_diagram(
+                        diagram_type=..., title=..., nodes=..., edges=...,
+                        max_nodes_per_page=15,
+                        strategy="c4_boundary",
+                    )
+                    # Use split summary diagram for PPTX (detail pages saved separately)
+                    result = split_result.diagrams[0]  # summary
+                    qa_events.append({"action": "split", "details": "overflow"})
+
+        # MEDIUM severity: warn but allow embedding
+        for warning in medium_issues:
+            qa_events.append({"action": "warning", "details": warning.message})
+
+    # Proceed with validated/fixed diagram HTML
+```
+
+#### Playwright Session Optimization
+
+Use ONE browser session for all diagram screenshots to reduce overhead:
+
+```
+# Create ONE session before the diagram loop
+session = create_session(headless=true, viewport={"width": 1920, "height": 1080})
+
+for each diagram_html in generated_diagrams:
+    browser_navigate(session_id=session.id, url="file://{absolute_path}")
+    screenshot = browser_screenshot(session_id=session.id, full_page=true)
+    # Store screenshot for PPTX embedding
+
+# Close session ONCE after all diagrams
+close_session(session_id=session.id)
+```
+
+### Step 4: Create the PPTX
+
+Use `create_pptx` with all the slide definitions. The tool runs QC validation automatically before building - if high-severity issues are found (framework names, placeholder text), it will return an error with the issues list. Fix them and retry.
+
+You can also run `validate_pptx_slides` manually before `create_pptx` to preview issues.
+
+Report:
+
+```
+Presentation created!
+
+  File:      {path}
+  Slides:    {count}
+  Size:      {size} KB
+  Framework: {framework} (applied implicitly)
+  QC:        Passed ({issue_count} checks)
+
+  Diagrams generated:
+  - {type}: {html_path}
+  - ...
+
+  Diagram QA:
+    Validated:  {total} diagrams
+    Splits:     {split_count} (overflow diagrams split into summary + detail)
+    Retries:    {retry_count} (edge fixes)
+    Warnings:   {warning_count} (orphan nodes, long labels)
+
+  Open the .pptx file to review.
+```
+
+### Content Rules
+
+- **No framework attribution** - Apply communication framework structures implicitly through headings, flow, and narrative. NEVER name the framework in slide titles, content, footers, or speaker notes unless the user explicitly requests attribution.
+- **No corporate name references** - Do not reference consulting firms (McKinsey, BCG, Bain, etc.) or their proprietary methods. The frameworks are public domain tools for structuring communication.
+- **Anonymize by default** - If the user provides organizational documents, strip corporate names and identifiers unless told otherwise.
+- **QC gate** - The `create_pptx` tool blocks on high-severity QC issues. Fix flagged content before finalizing.
+
+### Tips
+
+- Use dark theme (built-in) for modern, professional look
+- Diagrams work best as full-width on "diagram" layout slides
+- Speaker notes can be added to any slide
+- Two-column layout works well for comparisons
+- Keep bullet points concise (3-5 per slide)
+- If org ethos is provided, reference values in speaker notes for presenter context

--- a/.codex/skills/documentation-c4/SKILL.md
+++ b/.codex/skills/documentation-c4/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: documentation-c4
+description: Trigger `/documentation:c4`.
+---
+
+# documentation-c4
+
+## Trigger
+- Primary: `/documentation:c4`
+- Text alias: `documentation:c4`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/documentation/c4.md`
+
+## Execution
+1. Use this skill when the user invokes `/documentation:c4` or explicitly asks for the documentation `c4` workflow.
+2. Follow the workflow steps in `.codex/prompts/documentation/c4.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/documentation-c4/agents/openai.yaml
+++ b/.codex/skills/documentation-c4/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "documentation:c4"
+  short_description: "Trigger /documentation:c4"
+  default_prompt: "/documentation:c4"

--- a/.codex/skills/documentation-help/SKILL.md
+++ b/.codex/skills/documentation-help/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: documentation-help
+description: Trigger `/documentation:help`.
+---
+
+# documentation-help
+
+## Trigger
+- Primary: `/documentation:help`
+- Text alias: `documentation:help`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/documentation/help.md`
+
+## Execution
+1. Use this skill when the user invokes `/documentation:help` or explicitly asks for the documentation `help` workflow.
+2. Follow the workflow steps in `.codex/prompts/documentation/help.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/documentation-help/agents/openai.yaml
+++ b/.codex/skills/documentation-help/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "documentation:help"
+  short_description: "Trigger /documentation:help"
+  default_prompt: "/documentation:help"

--- a/.codex/skills/documentation-pptx/SKILL.md
+++ b/.codex/skills/documentation-pptx/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: documentation-pptx
+description: Trigger `/documentation:pptx`.
+---
+
+# documentation-pptx
+
+## Trigger
+- Primary: `/documentation:pptx`
+- Text alias: `documentation:pptx`
+
+## Source Mapping
+- Prompt entrypoint: `.codex/prompts/documentation/pptx.md`
+
+## Execution
+1. Use this skill when the user invokes `/documentation:pptx` or explicitly asks for the documentation `pptx` workflow.
+2. Follow the workflow steps in `.codex/prompts/documentation/pptx.md` as the authoritative runbook.
+3. Keep Codex-native paths and wording (`AGENTS.md`, `.codex/*`) when presenting or adapting instructions.
+4. Preserve confirmation steps before any overwrite or destructive action.

--- a/.codex/skills/documentation-pptx/agents/openai.yaml
+++ b/.codex/skills/documentation-pptx/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "documentation:pptx"
+  short_description: "Trigger /documentation:pptx"
+  default_prompt: "/documentation:pptx"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ Defaults are set in each service's `src/config.py` and can be overridden via `MC
 - CI/CD slash trigger parity is mapped in `docs/skills/cicd-command-skill-map.md`.
 - Flow slash trigger parity is mapped in `docs/skills/flow-command-skill-map.md`.
 - GitHub slash trigger parity is mapped in `docs/skills/github-command-skill-map.md`.
+- Documentation slash trigger parity is mapped in `docs/skills/documentation-command-skill-map.md`.
 - Second-opinion slash trigger parity is mapped in `docs/skills/second-opinion-command-skill-map.md`.
 - QA slash trigger parity is mapped in `docs/skills/qa-command-skill-map.md`.
 - Project slash trigger parity is mapped in `docs/skills/project-command-skill-map.md`.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ The `/github:*` namespace is available through:
 - `.codex/skills/github-*/` - backing Codex skill packages
 - `docs/skills/github-command-skill-map.md` - trigger-to-skill inventory
 
+## Documentation Trigger Parity
+
+The `/documentation:*` namespace is available through:
+
+- `.claude/commands/documentation/*.md` - source command inventory
+- `.codex/prompts/documentation/*.md` - slash-compatible entrypoints
+- `.codex/skills/documentation-*/` - backing Codex skill packages
+- `docs/skills/documentation-command-skill-map.md` - trigger-to-skill inventory
+
 ## Second-Opinion Trigger Parity
 
 The `/second-opinion:*` namespace is available through:

--- a/docs/skills/documentation-command-skill-map.md
+++ b/docs/skills/documentation-command-skill-map.md
@@ -1,0 +1,11 @@
+# Documentation Trigger to Skill Map
+
+This file maps documentation triggers to Codex prompts and skill packages.
+
+| Trigger | Prompt Entrypoint | Skill Package |
+|---|---|---|
+| `/documentation:c4` | `.codex/prompts/documentation/c4.md` | `.codex/skills/documentation-c4/SKILL.md` |
+| `/documentation:help` | `.codex/prompts/documentation/help.md` | `.codex/skills/documentation-help/SKILL.md` |
+| `/documentation:pptx` | `.codex/prompts/documentation/pptx.md` | `.codex/skills/documentation-pptx/SKILL.md` |
+
+Canonical inventory: `.claude/commands/documentation/*.md`, `.codex/prompts/documentation/*.md`, and `.codex/skills/documentation-*/`.

--- a/tests/test_documentation_skill_trigger_parity.py
+++ b/tests/test_documentation_skill_trigger_parity.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_DIR = ROOT / ".claude" / "commands" / "documentation"
+PROMPT_DIR = ROOT / ".codex" / "prompts" / "documentation"
+SKILLS_DIR = ROOT / ".codex" / "skills"
+
+
+def _source_commands() -> set[str]:
+    return {path.stem for path in SOURCE_DIR.glob("*.md")}
+
+
+def _target_prompts() -> set[str]:
+    return {path.stem for path in PROMPT_DIR.glob("*.md")}
+
+
+def test_documentation_prompt_trigger_parity_with_source_commands() -> None:
+    assert _target_prompts() == _source_commands()
+
+
+def test_every_documentation_prompt_has_backing_skill_package() -> None:
+    for command in sorted(_source_commands()):
+        trigger = f"/documentation:{command}"
+        skill_name = f"documentation-{command}"
+
+        skill_md = SKILLS_DIR / skill_name / "SKILL.md"
+        agent_yaml = SKILLS_DIR / skill_name / "agents" / "openai.yaml"
+        prompt_md = PROMPT_DIR / f"{command}.md"
+
+        assert skill_md.exists(), f"Missing skill file for {trigger}: {skill_md}"
+        assert agent_yaml.exists(), f"Missing agents metadata for {trigger}: {agent_yaml}"
+
+        prompt_text = prompt_md.read_text()
+        skill_text = skill_md.read_text()
+
+        assert f"Backing skill: `{skill_name}`" in prompt_text
+        assert trigger in skill_text
+        assert f".codex/prompts/documentation/{command}.md" in skill_text
+
+
+def test_documentation_agent_metadata_points_to_expected_triggers() -> None:
+    for command in sorted(_source_commands()):
+        skill_name = f"documentation-{command}"
+        trigger = f"/documentation:{command}"
+        agent_yaml = SKILLS_DIR / skill_name / "agents" / "openai.yaml"
+        text = agent_yaml.read_text()
+
+        assert f'display_name: "documentation:{command}"' in text
+        assert f'default_prompt: "{trigger}"' in text


### PR DESCRIPTION
## Summary
- ported `/documentation:c4`, `/documentation:help`, and `/documentation:pptx` to `.codex/prompts/documentation/*`
- added matching Codex skill packages and `agents/openai.yaml` metadata for each documentation trigger
- added documentation trigger inventory in `docs/skills/documentation-command-skill-map.md`
- updated trigger discoverability in `AGENTS.md` and `README.md`
- added parity test coverage in `tests/test_documentation_skill_trigger_parity.py`

## Test Plan
- env UV_CACHE_DIR=/tmp/uv-cache make lint
- env UV_CACHE_DIR=/tmp/uv-cache make test

Closes #5