### PR TITLE
fix(skills): add deterministic Codex skill install/doctor workflow (Closes #36)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Defaults are set in each service's `src/config.py` and can be overridden via `MC
 - Python 3.11+
 - `uv` for dependency management
 - `make lint`, `make test`, `make typecheck`, `make verify` for quality gates
+- `make skills-install-codex`, `make skills-doctor` for Codex skill registration
 - `make mcp-install-codex`, `make mcp-doctor`, `make mcp-smoke` for MCP setup/validation
 - Docker entrypoints go through `make docker-*`
 - prefer `rg` for repo search

--- a/INSTALLATION_ISSUES.md
+++ b/INSTALLATION_ISSUES.md
@@ -45,5 +45,27 @@ cp .env.example .env
 
 ---
 
+## Issue 3: Skills Not Found Outside Repository Root
+
+**Problem**: Codex cannot resolve slash-style workflows from unrelated directories.
+
+**Symptoms**:
+- First-run command invocations fail with "skill not found"
+- Running from `~/Projects/<some-other-repo>/` does not see codex-power-pack workflows
+
+**Solution**: Install repository skill packages into `~/.codex/skills` and run doctor checks:
+```bash
+cd codex-power-pack
+make skills-install-codex
+make skills-doctor
+```
+
+If doctor reports drift/conflicts:
+```bash
+make skills-install-codex SKILLS_OVERWRITE=1
+```
+
+---
+
 *Generated: 2025-12-20*
-*Updated: 2026-02-16 - Modernized for uv-first workflow*
+*Updated: 2026-03-13 - Added Codex skill discovery/install troubleshooting*

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: test lint format typecheck verify build update_docs clean help \
+       skills-install-codex skills-doctor \
        mcp-install-codex mcp-doctor mcp-smoke \
        docker-build docker-check-env docker-up docker-down docker-logs docker-ps deploy
 
@@ -32,6 +33,14 @@ update_docs:
 ## MCP operations
 
 CODEX_CONFIG ?= $(HOME)/.codex/config.toml
+CODEX_SKILLS_DIR ?= $(HOME)/.codex/skills
+SKILLS_OVERWRITE ?= 0
+
+skills-install-codex:
+	python3 scripts/skills_install_codex.py --codex-skills-dir "$(CODEX_SKILLS_DIR)" $(if $(filter 1,$(SKILLS_OVERWRITE)),--overwrite,)
+
+skills-doctor:
+	python3 scripts/skills_install_codex.py --doctor --codex-skills-dir "$(CODEX_SKILLS_DIR)"
 
 mcp-install-codex:
 	python3 scripts/mcp_install_codex.py --codex-config "$(CODEX_CONFIG)"
@@ -104,6 +113,10 @@ help:
 	@echo "  make typecheck   - Run mypy"
 	@echo "  make build       - Build distribution packages"
 	@echo "  make verify      - Run all quality checks"
+	@echo ""
+	@echo "Skills:"
+	@echo "  make skills-install-codex - Install/update Codex skill links under ~/.codex/skills"
+	@echo "  make skills-doctor        - Validate Codex skill registration drift/missing links"
 	@echo ""
 	@echo "MCP:"
 	@echo "  make mcp-install-codex - Install/update Codex MCP registrations"

--- a/README.md
+++ b/README.md
@@ -23,9 +23,16 @@ management, templates, and tests for Codex-centric workflows.
 git clone https://github.com/cooneycw/codex-power-pack.git
 cd codex-power-pack
 uv sync --extra dev
+make skills-install-codex
 make verify
 make docker-up PROFILE=core
 make mcp-smoke PROFILE=core
+```
+
+Confirm skill registration health:
+
+```bash
+make skills-doctor
 ```
 
 The default Docker profile starts:
@@ -72,6 +79,28 @@ Canonical transport matrix:
 - Skill packages live in `.codex/skills/`
 - Runtime config targets `.codex/` paths
 - Secrets storage uses `~/.config/codex-power-pack/`
+
+## Workspace-Wide Skill Discovery
+
+Codex command discovery is driven by installed skill packages under
+`~/.codex/skills`, not by walking parent `.claude/commands` symlinks.
+
+Use the deterministic installer to register this repository's skills globally:
+
+```bash
+make skills-install-codex
+make skills-doctor
+```
+
+If `skills-doctor` reports drift, replace conflicting registrations:
+
+```bash
+make skills-install-codex SKILLS_OVERWRITE=1
+```
+
+The `/project:*` namespace in this repository currently includes:
+- `/project:help`
+- `/project:init`
 
 ## CI/CD Trigger Parity
 

--- a/scripts/skills_install_codex.py
+++ b/scripts/skills_install_codex.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Install and diagnose Codex skill registrations for codex-power-pack.
+
+Codex discovers reusable skills from ~/.codex/skills. This script links
+repo-local skill packages from .codex/skills into that directory so workflows
+resolve consistently from any working directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class SkillTargetStatus:
+    name: str
+    source: Path
+    target: Path
+    status: str
+    detail: str
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Install or diagnose Codex skill links for codex-power-pack"
+    )
+    parser.add_argument(
+        "--repo-skills-dir",
+        default=str(Path(__file__).resolve().parents[1] / ".codex" / "skills"),
+        help="Path to repository-managed skill packages",
+    )
+    parser.add_argument(
+        "--codex-skills-dir",
+        default=str(Path.home() / ".codex" / "skills"),
+        help="Target Codex skills directory",
+    )
+    parser.add_argument(
+        "--doctor",
+        action="store_true",
+        help="Only report skill registration status; do not write files",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace conflicting existing targets after writing a timestamped backup",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned install actions without writing files",
+    )
+    return parser
+
+
+def discover_repo_skills(repo_skills_dir: Path) -> list[Path]:
+    if not repo_skills_dir.is_dir():
+        return []
+    return sorted(path for path in repo_skills_dir.iterdir() if (path / "SKILL.md").is_file())
+
+
+def inspect_target(source: Path, target: Path) -> SkillTargetStatus:
+    if not target.exists() and not target.is_symlink():
+        return SkillTargetStatus(
+            name=source.name,
+            source=source,
+            target=target,
+            status="missing",
+            detail="target does not exist",
+        )
+
+    if target.is_symlink():
+        try:
+            resolved = target.resolve()
+        except OSError:
+            return SkillTargetStatus(
+                name=source.name,
+                source=source,
+                target=target,
+                status="broken",
+                detail="target is a broken symlink",
+            )
+
+        if resolved == source.resolve():
+            return SkillTargetStatus(
+                name=source.name,
+                source=source,
+                target=target,
+                status="ok",
+                detail="symlink points to repository skill package",
+            )
+        return SkillTargetStatus(
+            name=source.name,
+            source=source,
+            target=target,
+            status="drift",
+            detail=f"symlink points elsewhere: {resolved}",
+        )
+
+    target_skill_file = target / "SKILL.md"
+    if target_skill_file.is_file():
+        if target_skill_file.read_text(encoding="utf-8") == (source / "SKILL.md").read_text(encoding="utf-8"):
+            return SkillTargetStatus(
+                name=source.name,
+                source=source,
+                target=target,
+                status="copied",
+                detail="directory exists with matching SKILL.md (not symlinked)",
+            )
+        return SkillTargetStatus(
+            name=source.name,
+            source=source,
+            target=target,
+            status="drift",
+            detail="directory exists but SKILL.md content differs",
+        )
+
+    return SkillTargetStatus(
+        name=source.name,
+        source=source,
+        target=target,
+        status="drift",
+        detail="target exists but is not a valid skill directory",
+    )
+
+
+def _backup_name(path: Path) -> Path:
+    stamp = dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+    return path.with_name(f"{path.name}.bak.{stamp}")
+
+
+def _install_one(
+    source: Path,
+    target: Path,
+    *,
+    overwrite: bool,
+    dry_run: bool,
+) -> SkillTargetStatus:
+    current = inspect_target(source, target)
+    if current.status in {"ok", "copied"}:
+        return current
+
+    if current.status in {"missing", "broken"}:
+        if not dry_run:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if target.is_symlink():
+                target.unlink()
+            target.symlink_to(source)
+        return SkillTargetStatus(
+            name=source.name,
+            source=source,
+            target=target,
+            status="installed",
+            detail="created symlink to repository skill package",
+        )
+
+    if not overwrite:
+        return SkillTargetStatus(
+            name=source.name,
+            source=source,
+            target=target,
+            status="conflict",
+            detail=current.detail,
+        )
+
+    backup_target = _backup_name(target)
+    if not dry_run:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.rename(backup_target)
+        target.symlink_to(source)
+    return SkillTargetStatus(
+        name=source.name,
+        source=source,
+        target=target,
+        status="replaced",
+        detail=f"conflicting target backed up to {backup_target}",
+    )
+
+
+def run_doctor(repo_skills_dir: Path, codex_skills_dir: Path) -> int:
+    repo_skills = discover_repo_skills(repo_skills_dir)
+    if not repo_skills:
+        print(f"ERROR: no skill packages found in {repo_skills_dir}")
+        return 1
+
+    print(f"Repository skills: {repo_skills_dir}")
+    print(f"Codex skills dir:  {codex_skills_dir}")
+    print("")
+
+    statuses = [inspect_target(source, codex_skills_dir / source.name) for source in repo_skills]
+    grouped: dict[str, list[SkillTargetStatus]] = {}
+    for item in statuses:
+        grouped.setdefault(item.status, []).append(item)
+
+    for key in ("ok", "copied", "missing", "drift", "broken", "conflict"):
+        if key not in grouped:
+            continue
+        print(f"{key.upper()} ({len(grouped[key])})")
+        for item in grouped[key]:
+            print(f"- {item.name}: {item.detail}")
+        print("")
+
+    unhealthy = {"missing", "drift", "broken", "conflict"}
+    if any(grouped.get(state) for state in unhealthy):
+        print("Doctor result: FAIL")
+        print("Run: make skills-install-codex SKILLS_OVERWRITE=1")
+        return 1
+
+    print("Doctor result: PASS")
+    return 0
+
+
+def run_install(repo_skills_dir: Path, codex_skills_dir: Path, *, overwrite: bool, dry_run: bool) -> int:
+    repo_skills = discover_repo_skills(repo_skills_dir)
+    if not repo_skills:
+        print(f"ERROR: no skill packages found in {repo_skills_dir}")
+        return 1
+
+    print(f"Repository skills: {repo_skills_dir}")
+    print(f"Codex skills dir:  {codex_skills_dir}")
+    print("")
+
+    results: list[SkillTargetStatus] = []
+    for source in repo_skills:
+        target = codex_skills_dir / source.name
+        result = _install_one(source, target, overwrite=overwrite, dry_run=dry_run)
+        results.append(result)
+        print(f"- {source.name}: {result.status} ({result.detail})")
+
+    conflicts = [entry for entry in results if entry.status == "conflict"]
+    if conflicts:
+        print("")
+        print("Install result: PARTIAL")
+        print("Conflicts were left in place to avoid destructive changes.")
+        print("Re-run with --overwrite to replace conflicting targets.")
+        return 2
+
+    print("")
+    print("Install result: OK (dry run)" if dry_run else "Install result: OK")
+    print("Next step: make skills-doctor")
+    return 0
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+
+    repo_skills_dir = Path(args.repo_skills_dir).expanduser().resolve()
+    codex_skills_dir = Path(args.codex_skills_dir).expanduser()
+
+    if args.doctor:
+        return run_doctor(repo_skills_dir, codex_skills_dir)
+    return run_install(
+        repo_skills_dir,
+        codex_skills_dir,
+        overwrite=args.overwrite,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_skills_install_codex.py
+++ b/tests/test_skills_install_codex.py
@@ -1,0 +1,72 @@
+"""Unit tests for scripts/skills_install_codex.py."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from skills_install_codex import (  # type: ignore[import-not-found]  # noqa: E402
+    _install_one,
+    discover_repo_skills,
+    inspect_target,
+)
+
+
+def _write_skill(root: Path, name: str, body: str = "name: test\n") -> Path:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(body, encoding="utf-8")
+    return skill_dir
+
+
+def test_discover_repo_skills_filters_to_directories_with_skill_md(tmp_path: Path) -> None:
+    skills_root = tmp_path / ".codex" / "skills"
+    _write_skill(skills_root, "flow-help")
+    (skills_root / "not-a-skill").mkdir(parents=True, exist_ok=True)
+
+    discovered = discover_repo_skills(skills_root)
+    assert [path.name for path in discovered] == ["flow-help"]
+
+
+def test_install_one_creates_symlink_for_missing_target(tmp_path: Path) -> None:
+    source = _write_skill(tmp_path / "repo", "flow-help")
+    target = tmp_path / "codex" / "skills" / "flow-help"
+
+    result = _install_one(source, target, overwrite=False, dry_run=False)
+    assert result.status == "installed"
+    assert target.is_symlink()
+    assert target.resolve() == source.resolve()
+
+
+def test_install_one_reports_conflict_without_overwrite(tmp_path: Path) -> None:
+    source = _write_skill(tmp_path / "repo", "flow-help", body="source\n")
+    target = _write_skill(tmp_path / "codex" / "skills", "flow-help", body="different\n")
+
+    result = _install_one(source, target, overwrite=False, dry_run=False)
+    assert result.status == "conflict"
+    assert target.is_dir()
+
+
+def test_install_one_replaces_conflict_with_overwrite(tmp_path: Path) -> None:
+    source = _write_skill(tmp_path / "repo", "flow-help", body="source\n")
+    target = _write_skill(tmp_path / "codex" / "skills", "flow-help", body="different\n")
+
+    result = _install_one(source, target, overwrite=True, dry_run=False)
+    assert result.status == "replaced"
+    assert target.is_symlink()
+    assert target.resolve() == source.resolve()
+
+    backups = list((tmp_path / "codex" / "skills").glob("flow-help.bak.*"))
+    assert backups
+
+
+def test_inspect_target_reports_copied_for_matching_directory(tmp_path: Path) -> None:
+    source = _write_skill(tmp_path / "repo", "flow-help", body="same\n")
+    target = _write_skill(tmp_path / "codex" / "skills", "flow-help", body="same\n")
+
+    status = inspect_target(source, target)
+    assert status.status == "copied"


### PR DESCRIPTION
## Summary
- added `scripts/skills_install_codex.py` to install and diagnose repository skills under `~/.codex/skills`
- added `make skills-install-codex` and `make skills-doctor` targets for deterministic first-run setup and drift detection
- updated README/AGENTS/INSTALLATION_ISSUES to document Codex skill discovery behavior and valid `/project:*` trigger coverage
- added unit tests for installer and target-state detection in `tests/test_skills_install_codex.py`

## Test Plan
- env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev pytest tests/test_skills_install_codex.py tests/test_project_skill_trigger_parity.py
- env UV_CACHE_DIR=/tmp/uv-cache make lint
- env UV_CACHE_DIR=/tmp/uv-cache make test

Closes #36