### PR TITLE
fix(codex-woodpecker): align go parity + stdio smoke (Closes #40)

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -61,21 +61,6 @@ steps:
           - "docker-compose.yml"
           - ".woodpecker.yml"
 
-  build-woodpecker-ci:
-    image: woodpeckerci/plugin-docker-buildx
-    settings:
-      repo: codex-woodpecker
-      dockerfile: codex-woodpecker/deploy/Dockerfile
-      context: codex-woodpecker
-      tags: latest
-      dry_run: true
-    when:
-      - event: [push, pull_request]
-        path:
-          - "codex-woodpecker/**"
-          - "docker-compose.yml"
-          - ".woodpecker.yml"
-
   # mcp-evaluate removed - deprecated, absorbed into /evaluate:issue skill
 
   deploy-mcp:
@@ -83,8 +68,8 @@ steps:
     commands:
       - echo "Deploying MCP containers from main..."
       - docker compose version
-      - docker compose --profile core --profile browser --profile cicd up -d --build --wait
-      - docker compose --profile core --profile browser --profile cicd ps
+      - docker compose --profile core --profile browser up -d --build --wait
+      - docker compose --profile core --profile browser ps
       - docker image prune -f
       - echo "Deploy complete."
     volumes:
@@ -96,6 +81,5 @@ steps:
           - "codex-second-opinion/**"
           - "codex-playwright/**"
           - "codex-nano-banana/**"
-          - "codex-woodpecker/**"
           - "docker-compose.yml"
           - ".woodpecker.yml"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ All MCP servers bind to the `9100-9199` range to avoid conflicts with applicatio
 | `codex-woodpecker` | 9103 | cicd |
 
 Defaults are set in each service's `src/config.py` and can be overridden via `MCP_SERVER_PORT` env var.
+For Docker Compose, the Woodpecker container is intentionally legacy-only under profile `legacy-cicd`; primary usage is stdio.
 
 ## Conventions
 

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ mcp-smoke:
 ## Docker (MCP server containers)
 ## Usage: make docker-up PROFILE=core
 ##        make docker-up PROFILE="core browser"
-## Profiles: core (codex-second-opinion + codex-nano-banana), browser, cicd
+## Profiles: core (codex-second-opinion + codex-nano-banana), browser, legacy-cicd
 
 PROFILE ?= core
 
@@ -84,13 +84,13 @@ docker-up: docker-check-env
 	$(foreach p,$(PROFILE),docker compose --profile $(p) up -d;)
 
 docker-down:
-	docker compose --profile core --profile browser --profile cicd down
+	docker compose --profile core --profile browser --profile legacy-cicd down
 
 docker-logs:
-	docker compose --profile core --profile browser --profile cicd logs -f
+	docker compose --profile core --profile browser --profile legacy-cicd logs -f
 
 docker-ps:
-	docker compose --profile core --profile browser --profile cicd ps
+	docker compose --profile core --profile browser --profile legacy-cicd ps
 
 ## Deploy (used by Woodpecker CI and /flow:deploy)
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Canonical transport matrix:
 | `codex-nano-banana` | `core` | `http://127.0.0.1:9102/sse` | `uv run --directory .../codex-nano-banana python src/server.py --stdio` |
 | `codex-woodpecker` | `cicd` | `http://127.0.0.1:9103/sse` | `uv run --directory .../codex-woodpecker python src/server.py --stdio` |
 
+The Woodpecker Docker container remains available only as a legacy profile:
+`make docker-up PROFILE=legacy-cicd`. Primary usage is stdio transport.
+
 ## Codex Architecture
 
 - Codex instructions live in `AGENTS.md`

--- a/codex-woodpecker/README.md
+++ b/codex-woodpecker/README.md
@@ -2,6 +2,25 @@
 
 Woodpecker CI pipeline management and monitoring MCP server for Codex.
 
+## Provenance and Strategy
+
+`codex-woodpecker` is a Python reimplementation of the upstream Go binary
+[`woodpecker-mcp`](https://github.com/denysvitali/woodpecker-ci-mcp). This
+repository keeps the Python variant because it integrates with Codex Power Pack
+runtime conventions (dotenv loading, AWS Secrets Manager fallback, repo-local
+packaging, and test/lint workflows).
+
+If you prefer to run the upstream Go binary directly, Codex supports that:
+
+```toml
+[mcp_servers.codex-woodpecker]
+command = "/home/$USER/go/bin/woodpecker-mcp"
+args = ["serve"]
+```
+
+`scripts/setup-go-binary.sh` bootstraps the Go binary and writes the upstream
+`~/.config/woodpecker-mcp/config.yaml` format.
+
 ## Tools
 
 | Tool | Description |
@@ -16,6 +35,16 @@ Woodpecker CI pipeline management and monitoring MCP server for Codex.
 | `approve_pipeline` | Approve a blocked pipeline |
 | `get_pipeline_logs` | Get decoded logs for a pipeline step |
 
+Go-compatibility aliases are also exposed for migration parity:
+
+- `get_pipeline_status` (supports `latest`)
+- `start_pipeline`
+- `stop_pipeline`
+- `get_repository`
+- `list_repositories`
+- `get_logs` (supports `format`, `lines`, `tail`)
+- `lint_config`
+
 ## Configuration
 
 The server resolves credentials in this order:
@@ -24,10 +53,15 @@ The server resolves credentials in this order:
    - `WOODPECKER_URL` - Woodpecker server URL (e.g. `https://woodpecker.example.com`)
    - `WOODPECKER_API_TOKEN` - API token from Woodpecker UI
 
-2. **AWS Secrets Manager** (auto-fetch):
+2. **AWS Secrets Manager** (auto-fetch, Codex Power Pack default):
    - `AWS_SECRET_NAME` - Secret name (default: `codex-power-pack`)
    - `AWS_REGION` - Region (default: `us-east-1`)
    - Reads `WOODPECKER_HOST` and `WOODPECKER_API_TOKEN` keys from the secret
+
+Upstream Go defaults differ:
+
+- Go binary default credentials: `~/.config/woodpecker-mcp/config.yaml`
+- Python server default credentials: env vars or AWS Secrets Manager
 
 Recommended setup:
 
@@ -40,8 +74,11 @@ Recommended setup:
 
 ```bash
 # From codex-power-pack root:
-make docker-up PROFILE=cicd
+make docker-up PROFILE=legacy-cicd
 ```
+
+Note: the Woodpecker Docker container is intentionally in a legacy profile
+because Codex/Claude primary usage is stdio transport.
 
 ### Native
 

--- a/codex-woodpecker/src/server.py
+++ b/codex-woodpecker/src/server.py
@@ -1,16 +1,13 @@
-"""
-MCP Woodpecker CI - Pipeline management and monitoring server.
+"""MCP Woodpecker CI server.
 
-Provides Codex with native access to Woodpecker CI:
-list repos, trigger/cancel/approve pipelines, view logs.
-
-Port: 9103 (default)
-Transport: SSE or stdio
+Provides Codex-facing pipeline controls and a Go-compatible compatibility layer
+for users migrating from the upstream `woodpecker-mcp` binary.
 """
 
 import argparse
 import logging
-from typing import Optional
+from pathlib import Path
+from typing import Any, Optional
 
 from fastmcp import FastMCP
 from starlette.requests import Request
@@ -37,6 +34,48 @@ def _get_client() -> WoodpeckerClient:
             "auto-fetch from AWS Secrets Manager."
         )
     return WoodpeckerClient(Config.WOODPECKER_URL, Config.WOODPECKER_API_TOKEN)
+
+
+def _extract_pipeline_steps(pipeline: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract flattened workflow step metadata from a pipeline payload."""
+    steps: list[dict[str, Any]] = []
+    for wf in pipeline.get("workflows", []):
+        for child in wf.get("children", []):
+            steps.append({
+                "id": child.get("id"),
+                "name": child.get("name"),
+                "state": child.get("state"),
+                "exit_code": child.get("exit_code"),
+            })
+    return steps
+
+
+def _pipeline_payload(pipeline: dict[str, Any]) -> dict[str, Any]:
+    """Normalize Woodpecker pipeline details for MCP responses."""
+    return {
+        "number": pipeline.get("number"),
+        "status": pipeline.get("status"),
+        "event": pipeline.get("event"),
+        "branch": pipeline.get("branch"),
+        "commit": pipeline.get("commit", "")[:12],
+        "message": (pipeline.get("message") or "")[:120],
+        "author": pipeline.get("author"),
+        "started_at": pipeline.get("started_at"),
+        "finished_at": pipeline.get("finished_at"),
+        "steps": _extract_pipeline_steps(pipeline),
+    }
+
+
+def _default_config_candidates() -> list[Path]:
+    """Return likely locations for .woodpecker.yml when lint_config is called."""
+    cwd = Path.cwd()
+    repo_root = Path(__file__).resolve().parents[2]
+    service_root = Path(__file__).resolve().parents[1]
+    return [
+        cwd / ".woodpecker.yml",
+        repo_root / ".woodpecker.yml",
+        service_root / ".woodpecker.yml",
+    ]
 
 
 @mcp.custom_route("/", methods=["GET"])
@@ -183,29 +222,8 @@ async def get_pipeline(repo_id: int, pipeline_number: int) -> dict:
     """
     try:
         client = _get_client()
-        p = await client.get_pipeline(repo_id, pipeline_number)
-        # Extract step info from workflows
-        steps = []
-        for wf in p.get("workflows", []):
-            for child in wf.get("children", []):
-                steps.append({
-                    "id": child.get("id"),
-                    "name": child.get("name"),
-                    "state": child.get("state"),
-                    "exit_code": child.get("exit_code"),
-                })
-        return {
-            "number": p.get("number"),
-            "status": p.get("status"),
-            "event": p.get("event"),
-            "branch": p.get("branch"),
-            "commit": p.get("commit", "")[:12],
-            "message": (p.get("message") or "")[:120],
-            "author": p.get("author"),
-            "started_at": p.get("started_at"),
-            "finished_at": p.get("finished_at"),
-            "steps": steps,
-        }
+        pipeline = await client.get_pipeline(repo_id, pipeline_number)
+        return _pipeline_payload(pipeline)
     except Exception as exc:
         return {"error": str(exc)}
 
@@ -306,6 +324,202 @@ async def get_pipeline_logs(
         }
     except Exception as exc:
         return {"error": str(exc)}
+
+
+@mcp.tool()
+async def get_pipeline_status(
+    repo_id: int,
+    pipeline_number: Optional[int] = None,
+    latest: bool = False,
+) -> dict:
+    """Compatibility alias for the Go `get_pipeline_status` tool.
+
+    Args:
+        repo_id: Numeric repo ID.
+        pipeline_number: Pipeline number. Required unless `latest` is true.
+        latest: If true, fetch the latest pipeline for this repo.
+    """
+    try:
+        client = _get_client()
+
+        selected_number = pipeline_number
+        if latest:
+            pipelines = await client.list_pipelines(repo_id, page=1, per_page=1)
+            if not pipelines:
+                return {"error": f"No pipelines found for repo_id={repo_id}"}
+            selected_number = pipelines[0].get("number")
+
+        if selected_number is None:
+            return {"error": "pipeline_number is required when latest=false"}
+
+        pipeline = await client.get_pipeline(repo_id, int(selected_number))
+        payload = _pipeline_payload(pipeline)
+        payload["latest"] = latest
+        return payload
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+@mcp.tool()
+async def start_pipeline(
+    repo_id: int,
+    branch: str = "main",
+    variables: Optional[dict[str, str]] = None,
+) -> dict:
+    """Compatibility alias for the Go `start_pipeline` tool."""
+    return await create_pipeline(repo_id=repo_id, branch=branch, variables=variables)
+
+
+@mcp.tool()
+async def stop_pipeline(repo_id: int, pipeline_number: int) -> dict:
+    """Compatibility alias for the Go `stop_pipeline` tool."""
+    return await cancel_pipeline(repo_id=repo_id, pipeline_number=pipeline_number)
+
+
+@mcp.tool()
+async def get_repository(
+    repo_id: Optional[int] = None,
+    owner: Optional[str] = None,
+    name: Optional[str] = None,
+) -> dict:
+    """Compatibility alias for the Go `get_repository` tool.
+
+    Supports lookup by numeric `repo_id` or by `owner` + `name`.
+    """
+    try:
+        client = _get_client()
+        if repo_id is not None:
+            repo = await client.get_repo(repo_id)
+        elif owner and name:
+            repo = await client.lookup_repo(owner, name)
+        else:
+            return {"error": "Provide repo_id or owner+name"}
+
+        return {
+            "id": repo.get("id"),
+            "full_name": repo.get("full_name", f"{repo.get('owner', '?')}/{repo.get('name', '?')}"),
+            "active": repo.get("active", False),
+            "default_branch": repo.get("default_branch", "main"),
+        }
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+@mcp.tool()
+async def list_repositories() -> dict:
+    """Compatibility alias for the Go `list_repositories` tool."""
+    return await list_repos()
+
+
+@mcp.tool()
+async def get_logs(
+    repo_id: int,
+    pipeline_number: int,
+    step_id: int,
+    format: str = "text",
+    lines: Optional[int] = None,
+    tail: bool = True,
+) -> dict:
+    """Compatibility alias for the Go `get_logs` tool.
+
+    Args:
+        repo_id: Numeric repo ID.
+        pipeline_number: Pipeline number.
+        step_id: Workflow step ID.
+        format: `text` (default) or `list`.
+        lines: Optional line cap.
+        tail: If line cap is set, return last N lines when true, else first N.
+    """
+    try:
+        base = await get_pipeline_logs(repo_id=repo_id, pipeline_number=pipeline_number, step_id=step_id)
+        if "error" in base:
+            return base
+
+        log_text = base.get("log", "")
+        parts = log_text.splitlines()
+        total_lines = len(parts)
+
+        if lines is not None and lines > 0 and total_lines > lines:
+            parts = parts[-lines:] if tail else parts[:lines]
+
+        if format.lower() == "list":
+            log_value: Any = parts
+        else:
+            log_value = "\n".join(parts)
+            if log_text.endswith("\n") and log_value:
+                log_value += "\n"
+
+        return {
+            "pipeline_number": pipeline_number,
+            "step_id": step_id,
+            "format": format,
+            "tail": tail,
+            "line_count": len(parts),
+            "total_lines": total_lines,
+            "log": log_value,
+        }
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+@mcp.tool()
+async def lint_config(config: Optional[str] = None) -> dict:
+    """Compatibility shim for Go `lint_config`.
+
+    If `config` is omitted, attempts to locate `.woodpecker.yml` in common
+    repository paths.
+    """
+    raw = ""
+    source = "inline"
+    if config is not None:
+        raw = config
+    else:
+        for candidate in _default_config_candidates():
+            if candidate.exists():
+                raw = candidate.read_text(encoding="utf-8")
+                source = str(candidate)
+                break
+
+    if not raw.strip():
+        return {
+            "ok": False,
+            "source": source,
+            "errors": ["No config content provided and no .woodpecker.yml found."],
+            "warnings": [],
+        }
+
+    errors: list[str] = []
+    warnings: list[str] = []
+
+    try:
+        import yaml  # type: ignore[import-not-found]
+
+        parsed = yaml.safe_load(raw)
+        if not isinstance(parsed, dict):
+            errors.append("Config is not a YAML mapping.")
+        else:
+            if "steps" not in parsed:
+                errors.append("Missing top-level 'steps' key.")
+            elif not isinstance(parsed["steps"], dict) or not parsed["steps"]:
+                errors.append("'steps' must be a non-empty mapping.")
+            if "when" not in parsed:
+                warnings.append("No top-level 'when' condition set.")
+    except Exception:
+        # Minimal fallback when YAML parser is unavailable.
+        stripped = raw.strip()
+        if not stripped:
+            errors.append("Config is empty.")
+        if "steps:" not in raw:
+            errors.append("Missing 'steps:' block.")
+        if "when:" not in raw:
+            warnings.append("No 'when:' block found.")
+
+    return {
+        "ok": not errors,
+        "source": source,
+        "errors": errors,
+        "warnings": warnings,
+    }
 
 
 def main():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # Usage (prefer Makefile targets - see Deployment Conventions in AGENTS.md):
 #   make docker-up PROFILE=core                      # Second Opinion + Nano-Banana
 #   make docker-up PROFILE="core browser"            # + Playwright
-#   make docker-up PROFILE="core cicd"               # + Woodpecker CI
+#   make docker-up PROFILE="core legacy-cicd"        # + legacy Woodpecker CI container
 #   make docker-build PROFILE=core                   # Build images only
 #   make docker-down                                 # Stop all services
 #   make docker-ps                                   # Show container status
@@ -105,7 +105,8 @@ services:
       start_period: 10s
       retries: 3
     restart: unless-stopped
-    profiles: ["cicd"]
+    # Legacy-only container profile. Primary Codex usage is stdio transport.
+    profiles: ["legacy-cicd"]
     deploy:
       resources:
         limits:

--- a/scripts/mcp_common.py
+++ b/scripts/mcp_common.py
@@ -4,7 +4,10 @@
 from __future__ import annotations
 
 import json
+import os
 import socket
+import subprocess
+import time
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
@@ -274,6 +277,80 @@ def probe_sse_server(spec: ServerSpec, timeout_seconds: float = 8.0, check_tools
             stage="handshake",
             error=str(exc),
         )
+
+
+def probe_stdio_server(
+    spec: ServerSpec,
+    startup_seconds: float = 2.0,
+    shutdown_timeout: float = 5.0,
+) -> ProbeResult:
+    """Smoke-test stdio transport by launching and cleanly stopping the server."""
+    repo_root = Path(__file__).resolve().parents[1]
+    command = ["uv", *spec.stdio_args]
+    process: subprocess.Popen[str] | None = None
+
+    try:
+        process = subprocess.Popen(
+            command,
+            cwd=repo_root,
+            env={**os.environ, "PYTHONUNBUFFERED": "1"},
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        return ProbeResult(
+            config_name=spec.config_name,
+            sse_url=f"stdio://{spec.config_name}",
+            ok=False,
+            stage="startup",
+            error=f"Failed to launch stdio command: {exc}",
+            endpoint=" ".join(command),
+        )
+    except Exception as exc:  # pragma: no cover - defensive guard
+        return ProbeResult(
+            config_name=spec.config_name,
+            sse_url=f"stdio://{spec.config_name}",
+            ok=False,
+            stage="startup",
+            error=str(exc),
+            endpoint=" ".join(command),
+        )
+
+    time.sleep(startup_seconds)
+    return_code = process.poll()
+    if return_code is not None:
+        stderr_output = ""
+        if process.stderr is not None:
+            stderr_output = process.stderr.read().strip()
+        detail = f"stdio server exited early with code {return_code}"
+        if stderr_output:
+            detail = f"{detail}: {stderr_output[:400]}"
+        return ProbeResult(
+            config_name=spec.config_name,
+            sse_url=f"stdio://{spec.config_name}",
+            ok=False,
+            stage="startup",
+            error=detail,
+            endpoint=" ".join(command),
+        )
+
+    process.terminate()
+    try:
+        process.wait(timeout=shutdown_timeout)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=shutdown_timeout)
+
+    return ProbeResult(
+        config_name=spec.config_name,
+        sse_url=f"stdio://{spec.config_name}",
+        ok=True,
+        stage="ok",
+        endpoint=" ".join(command),
+        server_name=spec.config_name,
+    )
 
 
 def load_mcp_servers_from_toml(config_path: Path) -> dict[str, dict[str, Any]]:

--- a/scripts/mcp_smoke.py
+++ b/scripts/mcp_smoke.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Run MCP initialize smoke checks against Codex Power Pack SSE endpoints.
+"""Run MCP smoke checks against Codex Power Pack transports.
 
 Exit codes:
 - 0: all checks passed
-- 2: endpoint unavailable (connection/HTTP failure)
-- 3: handshake or tools/list failure
+- 2: transport endpoint unavailable (SSE connection or stdio launch failure)
+- 3: handshake/tools failure (SSE)
 """
 
 from __future__ import annotations
@@ -13,11 +13,11 @@ import argparse
 import json
 from dataclasses import asdict
 
-from mcp_common import parse_profiles, probe_sse_server, selected_servers
+from mcp_common import parse_profiles, probe_sse_server, probe_stdio_server, selected_servers
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="MCP smoke tests (SSE initialize)")
+    parser = argparse.ArgumentParser(description="MCP smoke tests (SSE and/or stdio)")
     parser.add_argument(
         "--profiles",
         default="core",
@@ -27,6 +27,12 @@ def build_parser() -> argparse.ArgumentParser:
         "--tools-list",
         action="store_true",
         help="Also run JSON-RPC tools/list after initialize",
+    )
+    parser.add_argument(
+        "--transport",
+        choices=["sse", "stdio", "both"],
+        default="sse",
+        help="Transport to validate (default: sse)",
     )
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON output")
     return parser
@@ -43,7 +49,11 @@ def main() -> int:
         print("No MCP servers selected for profiles:", ", ".join(sorted(profiles)))
         return 0
 
-    results = [probe_sse_server(spec, check_tools_list=args.tools_list) for spec in specs]
+    results = []
+    if args.transport in {"sse", "both"}:
+        results.extend(probe_sse_server(spec, check_tools_list=args.tools_list) for spec in specs)
+    if args.transport in {"stdio", "both"}:
+        results.extend(probe_stdio_server(spec) for spec in specs)
 
     if args.json:
         print(json.dumps([asdict(result) for result in results], indent=2, sort_keys=True))
@@ -51,10 +61,13 @@ def main() -> int:
         print("MCP Smoke Results")
         for result in results:
             status = "PASS" if result.ok else "FAIL"
+            target = result.sse_url
+            if result.sse_url.startswith("stdio://"):
+                target = result.endpoint or result.sse_url
             detail = f"server={result.server_name or '-'} version={result.server_version or '-'}"
             if not result.ok:
                 detail = f"stage={result.stage} error={result.error or 'unknown'}"
-            print(f"- [{status}] {result.config_name} ({result.sse_url}) {detail}")
+            print(f"- [{status}] {result.config_name} ({target}) {detail}")
 
     if all(result.ok for result in results):
         return 0

--- a/tests/test_mcp_common.py
+++ b/tests/test_mcp_common.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import sys
+from io import StringIO
 from pathlib import Path
 
 # Import from scripts/ to test operational helpers without packaging changes.
@@ -11,9 +12,11 @@ if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 from mcp_common import (  # type: ignore[import-not-found]  # noqa: E402
+    ServerSpec,
     extract_directory_from_args,
     load_mcp_servers_from_toml,
     parse_profiles,
+    probe_stdio_server,
     selected_servers,
 )
 
@@ -57,3 +60,77 @@ PYTHONUNBUFFERED = "1"
     servers = load_mcp_servers_from_toml(config)
     assert "codex-second-opinion" in servers
     assert servers["codex-second-opinion"]["command"] == "uv"
+
+
+def test_probe_stdio_server_success(monkeypatch) -> None:
+    class _FakeProcess:
+        def __init__(self) -> None:
+            self.stderr = StringIO("")
+            self.terminated = False
+
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+        def wait(self, timeout: float | None = None) -> int:
+            assert self.terminated is True
+            return 0
+
+    fake_process = _FakeProcess()
+
+    def _fake_popen(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return fake_process
+
+    monkeypatch.setattr("mcp_common.subprocess.Popen", _fake_popen)
+    monkeypatch.setattr("mcp_common.time.sleep", lambda _: None)
+
+    result = probe_stdio_server(
+        ServerSpec(
+            config_name="codex-woodpecker",
+            profile="cicd",
+            sse_url="http://127.0.0.1:9103/sse",
+            repo_subdir="codex-woodpecker",
+        )
+    )
+
+    assert result.ok is True
+    assert result.stage == "ok"
+    assert result.endpoint is not None
+    assert "--stdio" in result.endpoint
+
+
+def test_probe_stdio_server_early_exit(monkeypatch) -> None:
+    class _FakeProcess:
+        def __init__(self) -> None:
+            self.stderr = StringIO("boom")
+
+        def poll(self) -> int:
+            return 1
+
+        def terminate(self) -> None:
+            return None
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 1
+
+    def _fake_popen(*args, **kwargs):  # type: ignore[no-untyped-def]
+        return _FakeProcess()
+
+    monkeypatch.setattr("mcp_common.subprocess.Popen", _fake_popen)
+    monkeypatch.setattr("mcp_common.time.sleep", lambda _: None)
+
+    result = probe_stdio_server(
+        ServerSpec(
+            config_name="codex-woodpecker",
+            profile="cicd",
+            sse_url="http://127.0.0.1:9103/sse",
+            repo_subdir="codex-woodpecker",
+        )
+    )
+
+    assert result.ok is False
+    assert result.stage == "startup"
+    assert result.error is not None
+    assert "exited early" in result.error

--- a/tests/test_mcp_smoke.py
+++ b/tests/test_mcp_smoke.py
@@ -1,0 +1,23 @@
+"""Unit tests for scripts/mcp_smoke.py argument handling."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+from mcp_smoke import build_parser  # type: ignore[import-not-found]  # noqa: E402
+
+
+def test_build_parser_defaults_to_sse_transport() -> None:
+    args = build_parser().parse_args([])
+    assert args.transport == "sse"
+
+
+def test_build_parser_accepts_stdio_transport() -> None:
+    args = build_parser().parse_args(["--transport", "stdio", "--profiles", "cicd"])
+    assert args.transport == "stdio"
+    assert args.profiles == "cicd"


### PR DESCRIPTION
## Summary
- documented `codex-woodpecker` provenance as a Python reimplementation of upstream `woodpecker-mcp`, including direct-Go-binary option and credential-flow differences
- added Go-compatible MCP tool aliases (`get_pipeline_status`, `start_pipeline`, `stop_pipeline`, `get_repository`, `list_repositories`, `get_logs`, `lint_config`) while preserving existing Python tool names
- added stdio smoke coverage by extending `scripts/mcp_smoke.py` and `scripts/mcp_common.py` with stdio transport probing plus new unit tests
- disabled the unused CI-deployed Woodpecker container path by moving compose usage to `legacy-cicd` and removing automatic cicd container deploy/build steps from `.woodpecker.yml`

## Test Plan
- env UV_CACHE_DIR=/tmp/uv-cache make lint
- env UV_CACHE_DIR=/tmp/uv-cache make test
- env UV_CACHE_DIR=/tmp/uv-cache make verify

Closes #40