### PR TITLE
fix(deploy): propagate host aws auth to sidecars (Closes #47)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,5 @@ AWS_SECRETSMANAGER_TOKEN=change-me-sidecar-token
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_SESSION_TOKEN=
+# Optional when the host uses a non-default profile in ~/.aws/{config,credentials}
+AWS_PROFILE=

--- a/codex-second-opinion/README.md
+++ b/codex-second-opinion/README.md
@@ -79,6 +79,11 @@ Manager agent sidecar. The app container uses:
 - `AWS_SECRETSMANAGER_AGENT_ENDPOINT=http://127.0.0.1:2773`
 - `AWS_SECRETSMANAGER_TOKEN` for the sidecar authorization header
 
+The sidecar can authenticate with either direct `AWS_ACCESS_KEY_ID` /
+`AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` environment variables or the
+host's shared AWS files mounted from `~/.aws` using `AWS_PROFILE` (default:
+`default`).
+
 Native `uv run` usage still supports direct `boto3` resolution with AWS
 credentials when the sidecar is not present.
 

--- a/codex-second-opinion/deploy/docker-compose.yml
+++ b/codex-second-opinion/deploy/docker-compose.yml
@@ -42,8 +42,12 @@ services:
     environment:
       - AWS_REGION=${AWS_REGION:-us-east-1}
       - AWS_DEFAULT_REGION=${AWS_REGION:-us-east-1}
+      - AWS_PROFILE=${AWS_PROFILE:-default}
+      - AWS_SDK_LOAD_CONFIG=1
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
       - AWS_TOKEN=${AWS_SECRETSMANAGER_TOKEN:-codex-local-sidecar-token}
+    volumes:
+      - ${HOME}/.aws:/root/.aws:ro
     restart: unless-stopped

--- a/codex-woodpecker/README.md
+++ b/codex-woodpecker/README.md
@@ -57,10 +57,12 @@ The server resolves credentials in this order:
    - `AWS_SECRET_NAME` - Secret name (default: `codex-power-pack`)
    - `AWS_REGION` - Region (default: `us-east-1`)
    - Reads `WOODPECKER_HOST` and `WOODPECKER_API_TOKEN` keys from the secret
-   - Docker deployments prefer the AWS Secrets Manager agent sidecar with
-     `AWS_SECRET_SOURCE=aws-secretsmanager-agent`,
-     `AWS_SECRETSMANAGER_AGENT_ENDPOINT=http://127.0.0.1:2773`, and
-     `AWS_SECRETSMANAGER_TOKEN`
+- Docker deployments prefer the AWS Secrets Manager agent sidecar with
+  `AWS_SECRET_SOURCE=aws-secretsmanager-agent`,
+  `AWS_SECRETSMANAGER_AGENT_ENDPOINT=http://127.0.0.1:2773`, and
+  `AWS_SECRETSMANAGER_TOKEN`
+- The sidecar can authenticate through direct `AWS_*` credential env vars or a
+  mounted host `~/.aws` directory with `AWS_PROFILE` (default: `default`)
 
 Upstream Go defaults differ:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,10 @@
 #   AWS_API_KEYS_SECRET_NAME=codex_llm_apikeys
 #   AWS_REGION=us-east-1
 #   AWS_SECRETSMANAGER_TOKEN=change-me-sidecar-token
-#   AWS_ACCESS_KEY_ID=...       (if no IAM role/profile is available)
+#   AWS_ACCESS_KEY_ID=...       (if no IAM role/profile or ~/.aws credentials are available)
 #   AWS_SECRET_ACCESS_KEY=...
 #   AWS_SESSION_TOKEN=...
+#   AWS_PROFILE=default         (optional; defaults to "default" when ~/.aws is mounted)
 #
 # Optional native/local overrides:
 #   GEMINI_API_KEY=...
@@ -72,10 +73,14 @@ services:
     environment:
       - AWS_REGION=${AWS_REGION:-us-east-1}
       - AWS_DEFAULT_REGION=${AWS_REGION:-us-east-1}
+      - AWS_PROFILE=${AWS_PROFILE:-default}
+      - AWS_SDK_LOAD_CONFIG=1
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
       - AWS_TOKEN=${AWS_SECRETSMANAGER_TOKEN:-codex-local-sidecar-token}
+    volumes:
+      - ${HOME}/.aws:/root/.aws:ro
     restart: unless-stopped
     profiles: ["core"]
 
@@ -155,10 +160,14 @@ services:
     environment:
       - AWS_REGION=${AWS_REGION:-us-east-1}
       - AWS_DEFAULT_REGION=${AWS_REGION:-us-east-1}
+      - AWS_PROFILE=${AWS_PROFILE:-default}
+      - AWS_SDK_LOAD_CONFIG=1
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
       - AWS_TOKEN=${AWS_SECRETSMANAGER_TOKEN:-codex-local-sidecar-token}
+    volumes:
+      - ${HOME}/.aws:/root/.aws:ro
     restart: unless-stopped
     # Legacy-only container profile. Primary Codex usage is stdio transport.
     profiles: ["legacy-cicd"]

--- a/docs/skills/cicd-verification.md
+++ b/docs/skills/cicd-verification.md
@@ -201,7 +201,9 @@ injection.
 For dockerized MCP services in this repo, the runtime path is tighter: the
 containerized servers consume secrets through a local AWS Secrets Manager agent
 sidecar on `127.0.0.1:2773`, and the sidecar owns the AWS credentials and
-session token. The contract tests for that runtime boundary live in
+session token. The sidecar may authenticate from direct `AWS_*` environment
+variables or the host's shared `~/.aws` credentials/config via `AWS_PROFILE`.
+The contract tests for that runtime boundary live in
 `tests/test_mcp_secret_contract.py`.
 
 ### Template Selection

--- a/scripts/deploy_mcp.sh
+++ b/scripts/deploy_mcp.sh
@@ -23,6 +23,7 @@ mode="deploy"
 profile_spec="${PROFILE:-core}"
 max_attempts="${MAX_ATTEMPTS:-10}"
 sleep_seconds="${SLEEP_SECONDS:-1}"
+sidecar_grace_seconds="${SIDECAR_GRACE_SECONDS:-3}"
 skip_smoke=0
 
 while [ "$#" -gt 0 ]; do
@@ -123,6 +124,37 @@ run_compose() {
     docker compose $compose_args "$@"
 }
 
+expected_sidecars() {
+    case " $profile_spec " in
+        *" core "*) printf '%s\n' "codex-second-opinion-secrets" ;;
+    esac
+    case " $profile_spec " in
+        *" legacy-cicd "*) printf '%s\n' "codex-woodpecker-secrets" ;;
+    esac
+}
+
+sidecar_status() {
+    docker inspect -f '{{.State.Status}}' "$1" 2>/dev/null || printf '%s\n' "missing"
+}
+
+assert_sidecars_running() {
+    sidecars="$(expected_sidecars)"
+    [ -n "$sidecars" ] || return 0
+
+    if [ "${sidecar_grace_seconds}" -gt 0 ] 2>/dev/null; then
+        sleep "${sidecar_grace_seconds}"
+    fi
+
+    for sidecar in $sidecars; do
+        status="$(sidecar_status "$sidecar")"
+        if [ "$status" != "running" ]; then
+            log "Sidecar '$sidecar' is not running (status: $status)"
+            docker logs --tail 20 "$sidecar" || true
+            return 3
+        fi
+    done
+}
+
 if [ "$mode" = "check" ]; then
     log "Validating deploy entrypoint from repo checkout: $repo_root"
     docker compose version >/dev/null
@@ -142,6 +174,7 @@ log "Deploying MCP services from repo-owned entrypoint"
 docker compose version
 run_compose up -d --build --wait
 run_compose ps
+assert_sidecars_running
 
 if [ "$skip_smoke" -ne 1 ]; then
     attempt=1
@@ -160,6 +193,8 @@ if [ "$skip_smoke" -ne 1 ]; then
         sleep "$sleep_seconds"
     done
 fi
+
+assert_sidecars_running
 
 docker image prune -f
 log "Deploy complete."

--- a/tests/test_deploy_mcp.py
+++ b/tests/test_deploy_mcp.py
@@ -1,0 +1,124 @@
+"""Unit tests for scripts/deploy_mcp.sh."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "deploy_mcp.sh"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _fake_docker_script() -> str:
+    return """#!/bin/sh
+set -eu
+
+if [ "$#" -eq 0 ]; then
+    exit 1
+fi
+
+printf '%s\\n' "$*" >> "${FAKE_DOCKER_LOG:?}"
+
+case "$1" in
+    compose)
+        shift
+        while [ "$#" -gt 0 ]; do
+            case "$1" in
+                --profile)
+                    shift 2
+                    ;;
+                version|config|up|ps)
+                    exit 0
+                    ;;
+                *)
+                    shift
+                    ;;
+            esac
+        done
+        exit 0
+        ;;
+    inspect)
+        service="${4:-}"
+        case "$service" in
+            codex-second-opinion-secrets)
+                printf '%s\\n' "${FAKE_SECOND_OPINION_STATUS:-running}"
+                ;;
+            codex-woodpecker-secrets)
+                printf '%s\\n' "${FAKE_WOODPECKER_STATUS:-running}"
+                ;;
+            *)
+                printf '%s\\n' "running"
+                ;;
+        esac
+        ;;
+    logs)
+        printf '%s\\n' "${FAKE_DOCKER_LOG_OUTPUT:-CredentialsNotLoaded}"
+        ;;
+    image)
+        exit 0
+        ;;
+esac
+"""
+
+
+def test_deploy_mcp_fails_when_selected_sidecar_restarts(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_log = tmp_path / "docker.log"
+
+    _write_executable(fake_bin / "docker", _fake_docker_script())
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["PROFILE"] = "core"
+    env["SIDECAR_GRACE_SECONDS"] = "0"
+    env["FAKE_DOCKER_LOG"] = str(fake_log)
+    env["FAKE_SECOND_OPINION_STATUS"] = "restarting"
+    env["FAKE_DOCKER_LOG_OUTPUT"] = "CredentialsNotLoaded"
+
+    result = subprocess.run(
+        [str(SCRIPT), "--skip-smoke"],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 3
+    assert "not running" in result.stdout
+    assert "CredentialsNotLoaded" in result.stdout
+
+
+def test_deploy_mcp_succeeds_when_selected_sidecars_are_running(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_log = tmp_path / "docker.log"
+
+    _write_executable(fake_bin / "docker", _fake_docker_script())
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["PROFILE"] = "core legacy-cicd"
+    env["SIDECAR_GRACE_SECONDS"] = "0"
+    env["FAKE_DOCKER_LOG"] = str(fake_log)
+    env["FAKE_SECOND_OPINION_STATUS"] = "running"
+    env["FAKE_WOODPECKER_STATUS"] = "running"
+
+    result = subprocess.run(
+        [str(SCRIPT), "--skip-smoke"],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Deploy complete." in result.stdout

--- a/tests/test_mcp_secret_contract.py
+++ b/tests/test_mcp_secret_contract.py
@@ -36,6 +36,11 @@ def _load_module(module_name: str, path: Path):
     return module
 
 
+def _service_volumes(service: dict) -> list[str]:
+    raw = service.get("volumes", [])
+    return [str(entry) for entry in raw]
+
+
 class _FakeResponse:
     def __init__(self, payload: str) -> None:
         self._payload = payload.encode("utf-8")
@@ -77,8 +82,16 @@ def test_root_compose_uses_agent_sidecars_for_secret_consumers() -> None:
     woodpecker_sidecar = services["codex-woodpecker-secrets"]
     assert second_sidecar["network_mode"] == "service:codex-second-opinion"
     assert woodpecker_sidecar["network_mode"] == "service:codex-woodpecker"
-    assert _compose_env(second_sidecar)["AWS_TOKEN"].startswith("${AWS_SECRETSMANAGER_TOKEN:")
-    assert _compose_env(woodpecker_sidecar)["AWS_TOKEN"].startswith("${AWS_SECRETSMANAGER_TOKEN:")
+    second_sidecar_env = _compose_env(second_sidecar)
+    woodpecker_sidecar_env = _compose_env(woodpecker_sidecar)
+    assert second_sidecar_env["AWS_TOKEN"].startswith("${AWS_SECRETSMANAGER_TOKEN:")
+    assert second_sidecar_env["AWS_PROFILE"] == "${AWS_PROFILE:-default}"
+    assert second_sidecar_env["AWS_SDK_LOAD_CONFIG"] == "1"
+    assert "${HOME}/.aws:/root/.aws:ro" in _service_volumes(second_sidecar)
+    assert woodpecker_sidecar_env["AWS_TOKEN"].startswith("${AWS_SECRETSMANAGER_TOKEN:")
+    assert woodpecker_sidecar_env["AWS_PROFILE"] == "${AWS_PROFILE:-default}"
+    assert woodpecker_sidecar_env["AWS_SDK_LOAD_CONFIG"] == "1"
+    assert "${HOME}/.aws:/root/.aws:ro" in _service_volumes(woodpecker_sidecar)
 
 
 def test_second_opinion_service_compose_uses_agent_sidecar() -> None:
@@ -92,6 +105,9 @@ def test_second_opinion_service_compose_uses_agent_sidecar() -> None:
     assert app_env["AWS_SECRETSMANAGER_AGENT_ENDPOINT"] == "http://127.0.0.1:2773"
     assert services["second-opinion-secrets"]["network_mode"] == "service:second-opinion-mcp"
     assert sidecar_env["AWS_TOKEN"].startswith("${AWS_SECRETSMANAGER_TOKEN:")
+    assert sidecar_env["AWS_PROFILE"] == "${AWS_PROFILE:-default}"
+    assert sidecar_env["AWS_SDK_LOAD_CONFIG"] == "1"
+    assert "${HOME}/.aws:/root/.aws:ro" in _service_volumes(services["second-opinion-secrets"])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- mount the host shared AWS config into Secrets Manager sidecars and default them to `AWS_PROFILE=default`
- fail `scripts/deploy_mcp.sh` when a selected sidecar is not actually running instead of reporting a false-green deploy
- document the sidecar auth contract and add tests for both compose wiring and deploy failure behavior

## Test Plan
- env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev pytest tests/test_mcp_secret_contract.py tests/test_deploy_mcp.py tests/test_deploy_doctor.py tests/test_config_validation.py
- env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev python -m lib.cicd run --plan finish

Closes #47