### PR TITLE
fix(deploy): expose shared aws file paths to sidecars (Closes #47)

### DIFF
--- a/codex-second-opinion/deploy/docker-compose.yml
+++ b/codex-second-opinion/deploy/docker-compose.yml
@@ -40,10 +40,13 @@ services:
     depends_on:
       - second-opinion-mcp
     environment:
+      - HOME=/root
       - AWS_REGION=${AWS_REGION:-us-east-1}
       - AWS_DEFAULT_REGION=${AWS_REGION:-us-east-1}
       - AWS_PROFILE=${AWS_PROFILE:-default}
       - AWS_SDK_LOAD_CONFIG=1
+      - AWS_SHARED_CREDENTIALS_FILE=/root/.aws/credentials
+      - AWS_CONFIG_FILE=/root/.aws/config
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,10 +71,13 @@ services:
     depends_on:
       - codex-second-opinion
     environment:
+      - HOME=/root
       - AWS_REGION=${AWS_REGION:-us-east-1}
       - AWS_DEFAULT_REGION=${AWS_REGION:-us-east-1}
       - AWS_PROFILE=${AWS_PROFILE:-default}
       - AWS_SDK_LOAD_CONFIG=1
+      - AWS_SHARED_CREDENTIALS_FILE=/root/.aws/credentials
+      - AWS_CONFIG_FILE=/root/.aws/config
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
@@ -158,10 +161,13 @@ services:
     depends_on:
       - codex-woodpecker
     environment:
+      - HOME=/root
       - AWS_REGION=${AWS_REGION:-us-east-1}
       - AWS_DEFAULT_REGION=${AWS_REGION:-us-east-1}
       - AWS_PROFILE=${AWS_PROFILE:-default}
       - AWS_SDK_LOAD_CONFIG=1
+      - AWS_SHARED_CREDENTIALS_FILE=/root/.aws/credentials
+      - AWS_CONFIG_FILE=/root/.aws/config
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}

--- a/tests/test_mcp_secret_contract.py
+++ b/tests/test_mcp_secret_contract.py
@@ -85,12 +85,18 @@ def test_root_compose_uses_agent_sidecars_for_secret_consumers() -> None:
     second_sidecar_env = _compose_env(second_sidecar)
     woodpecker_sidecar_env = _compose_env(woodpecker_sidecar)
     assert second_sidecar_env["AWS_TOKEN"].startswith("${AWS_SECRETSMANAGER_TOKEN:")
+    assert second_sidecar_env["HOME"] == "/root"
     assert second_sidecar_env["AWS_PROFILE"] == "${AWS_PROFILE:-default}"
     assert second_sidecar_env["AWS_SDK_LOAD_CONFIG"] == "1"
+    assert second_sidecar_env["AWS_SHARED_CREDENTIALS_FILE"] == "/root/.aws/credentials"
+    assert second_sidecar_env["AWS_CONFIG_FILE"] == "/root/.aws/config"
     assert "${HOME}/.aws:/root/.aws:ro" in _service_volumes(second_sidecar)
     assert woodpecker_sidecar_env["AWS_TOKEN"].startswith("${AWS_SECRETSMANAGER_TOKEN:")
+    assert woodpecker_sidecar_env["HOME"] == "/root"
     assert woodpecker_sidecar_env["AWS_PROFILE"] == "${AWS_PROFILE:-default}"
     assert woodpecker_sidecar_env["AWS_SDK_LOAD_CONFIG"] == "1"
+    assert woodpecker_sidecar_env["AWS_SHARED_CREDENTIALS_FILE"] == "/root/.aws/credentials"
+    assert woodpecker_sidecar_env["AWS_CONFIG_FILE"] == "/root/.aws/config"
     assert "${HOME}/.aws:/root/.aws:ro" in _service_volumes(woodpecker_sidecar)
 
 
@@ -105,8 +111,11 @@ def test_second_opinion_service_compose_uses_agent_sidecar() -> None:
     assert app_env["AWS_SECRETSMANAGER_AGENT_ENDPOINT"] == "http://127.0.0.1:2773"
     assert services["second-opinion-secrets"]["network_mode"] == "service:second-opinion-mcp"
     assert sidecar_env["AWS_TOKEN"].startswith("${AWS_SECRETSMANAGER_TOKEN:")
+    assert sidecar_env["HOME"] == "/root"
     assert sidecar_env["AWS_PROFILE"] == "${AWS_PROFILE:-default}"
     assert sidecar_env["AWS_SDK_LOAD_CONFIG"] == "1"
+    assert sidecar_env["AWS_SHARED_CREDENTIALS_FILE"] == "/root/.aws/credentials"
+    assert sidecar_env["AWS_CONFIG_FILE"] == "/root/.aws/config"
     assert "${HOME}/.aws:/root/.aws:ro" in _service_volumes(services["second-opinion-secrets"])
 
 


### PR DESCRIPTION
## Summary
- set `HOME=/root` in the scratch-based AWS sidecar containers so the SDK can resolve the mounted shared config directory
- set explicit `AWS_SHARED_CREDENTIALS_FILE` and `AWS_CONFIG_FILE` paths for the mounted host `~/.aws` files
- extend the sidecar contract tests to cover the explicit shared-file environment

## Test Plan
- env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev pytest tests/test_mcp_secret_contract.py tests/test_deploy_mcp.py
- env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev python -m lib.cicd run --plan finish

Closes #47