### PR TITLE
fix(deploy): run CI smoke inside compose network

### DIFF
--- a/scripts/deploy_mcp.sh
+++ b/scripts/deploy_mcp.sh
@@ -16,6 +16,7 @@ Environment:
   PROFILE          Space-delimited profile list (default: "core")
   MAX_ATTEMPTS     Retry count for mcp-smoke (default: 10)
   SLEEP_SECONDS    Delay between smoke retries (default: 1)
+  MCP_SMOKE_MODE   host|docker|auto (default: "auto")
 EOF
 }
 
@@ -24,6 +25,10 @@ profile_spec="${PROFILE:-core}"
 max_attempts="${MAX_ATTEMPTS:-10}"
 sleep_seconds="${SLEEP_SECONDS:-1}"
 sidecar_grace_seconds="${SIDECAR_GRACE_SECONDS:-3}"
+smoke_mode="${MCP_SMOKE_MODE:-auto}"
+smoke_helper_image="${MCP_SMOKE_HELPER_IMAGE:-python:3.11-alpine}"
+smoke_network="${MCP_SMOKE_NETWORK:-codex-mcp-net}"
+smoke_workdir="${MCP_SMOKE_WORKDIR:-/workspace}"
 skip_smoke=0
 
 while [ "$#" -gt 0 ]; do
@@ -127,6 +132,14 @@ done
     exit 1
 }
 
+case "$smoke_mode" in
+    auto|host|docker) ;;
+    *)
+        echo "ERROR: MCP_SMOKE_MODE must be one of: auto, host, docker" >&2
+        exit 1
+        ;;
+esac
+
 log() {
     printf '[deploy_mcp] %s\n' "$*"
 }
@@ -134,6 +147,48 @@ log() {
 run_compose() {
     # shellcheck disable=SC2086
     docker compose $compose_args "$@"
+}
+
+is_ci_runtime() {
+    [ -n "${CI:-}" ] || [ -n "${CI_WORKSPACE:-}" ] || [ -n "${CI_PIPELINE_NUMBER:-}" ] || [ -n "${WOODPECKER_REPO:-}" ]
+}
+
+use_docker_smoke() {
+    case "$smoke_mode" in
+        docker) return 0 ;;
+        host) return 1 ;;
+        auto)
+            is_ci_runtime
+            return $?
+            ;;
+    esac
+    return 1
+}
+
+run_host_smoke() {
+    command -v make >/dev/null 2>&1 || {
+        echo "ERROR: make is required for host mcp-smoke checks" >&2
+        exit 1
+    }
+    make mcp-smoke PROFILE="$profile_spec"
+}
+
+run_docker_smoke() {
+    docker run --rm \
+        --network "$smoke_network" \
+        -v "$repo_root:$smoke_workdir:ro" \
+        -w "$smoke_workdir" \
+        -e MCP_SSE_HOST_MODE=service \
+        "$smoke_helper_image" \
+        python3 scripts/mcp_smoke.py --profiles "$profile_spec"
+}
+
+run_smoke() {
+    if use_docker_smoke; then
+        run_docker_smoke
+    else
+        run_host_smoke
+    fi
 }
 
 expected_sidecars() {
@@ -175,13 +230,6 @@ if [ "$mode" = "check" ]; then
     exit 0
 fi
 
-if [ "$skip_smoke" -ne 1 ]; then
-    command -v make >/dev/null 2>&1 || {
-        echo "ERROR: make is required for deploy_mcp.sh when smoke checks are enabled" >&2
-        exit 1
-    }
-fi
-
 log "Deploying MCP services from repo-owned entrypoint"
 docker compose version
 run_compose up -d --build --wait
@@ -189,9 +237,14 @@ run_compose ps
 assert_sidecars_running
 
 if [ "$skip_smoke" -ne 1 ]; then
+    if use_docker_smoke; then
+        log "Running mcp-smoke via Docker helper on network: $smoke_network"
+    else
+        log "Running mcp-smoke from the host workspace"
+    fi
     attempt=1
     while :; do
-        if make mcp-smoke PROFILE="$profile_spec"; then
+        if run_smoke; then
             break
         fi
 

--- a/scripts/mcp_common.py
+++ b/scripts/mcp_common.py
@@ -48,31 +48,52 @@ class ProbeResult:
     error: str | None = None
 
 
+def resolve_sse_host(config_name: str) -> str:
+    """Resolve the target host for SSE smoke checks.
+
+    `loopback` is the default for local host-driven probes.
+    `service` uses compose service DNS names for smoke checks running inside the
+    compose network from a helper container.
+    """
+
+    mode = os.getenv("MCP_SSE_HOST_MODE", "loopback").strip().lower()
+    if mode in {"", "loopback", "host", "published"}:
+        return "127.0.0.1"
+    if mode in {"service", "compose", "docker"}:
+        return config_name
+    return "127.0.0.1"
+
+
+def build_sse_url(config_name: str, port: int) -> str:
+    """Build an SSE URL for the configured smoke host mode."""
+    return f"http://{resolve_sse_host(config_name)}:{port}/sse"
+
+
 def canonical_servers() -> list[ServerSpec]:
     """Return canonical Codex Power Pack MCP server definitions."""
     return [
         ServerSpec(
             config_name="codex-second-opinion",
             profile="core",
-            sse_url="http://127.0.0.1:9100/sse",
+            sse_url=build_sse_url("codex-second-opinion", 9100),
             repo_subdir="codex-second-opinion",
         ),
         ServerSpec(
             config_name="codex-nano-banana",
             profile="core",
-            sse_url="http://127.0.0.1:9102/sse",
+            sse_url=build_sse_url("codex-nano-banana", 9102),
             repo_subdir="codex-nano-banana",
         ),
         ServerSpec(
             config_name="codex-playwright",
             profile="browser",
-            sse_url="http://127.0.0.1:9101/sse",
+            sse_url=build_sse_url("codex-playwright", 9101),
             repo_subdir="codex-playwright",
         ),
         ServerSpec(
             config_name="codex-woodpecker",
             profile="cicd",
-            sse_url="http://127.0.0.1:9103/sse",
+            sse_url=build_sse_url("codex-woodpecker", 9103),
             repo_subdir="codex-woodpecker",
         ),
     ]

--- a/tests/test_deploy_mcp.py
+++ b/tests/test_deploy_mcp.py
@@ -60,6 +60,9 @@ case "$1" in
     logs)
         printf '%s\\n' "${FAKE_DOCKER_LOG_OUTPUT:-CredentialsNotLoaded}"
         ;;
+    run)
+        exit "${FAKE_DOCKER_RUN_EXIT:-0}"
+        ;;
     image)
         exit 0
         ;;
@@ -150,3 +153,35 @@ def test_deploy_mcp_uses_script_dir_when_git_is_unavailable(tmp_path: Path) -> N
 
     assert result.returncode == 0
     assert "Deploy complete." in result.stdout
+
+
+def test_deploy_mcp_can_run_smoke_via_docker_helper(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_log = tmp_path / "docker.log"
+
+    _write_executable(fake_bin / "docker", _fake_docker_script())
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["PROFILE"] = "core browser"
+    env["SIDECAR_GRACE_SECONDS"] = "0"
+    env["FAKE_DOCKER_LOG"] = str(fake_log)
+    env["FAKE_SECOND_OPINION_STATUS"] = "running"
+    env["MCP_SMOKE_MODE"] = "docker"
+
+    result = subprocess.run(
+        [str(SCRIPT)],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Running mcp-smoke via Docker helper" in result.stdout
+    log_output = fake_log.read_text(encoding="utf-8")
+    assert "run --rm --network codex-mcp-net" in log_output
+    assert "MCP_SSE_HOST_MODE=service" in log_output
+    assert "python3 scripts/mcp_smoke.py --profiles core browser" in log_output

--- a/tests/test_mcp_common.py
+++ b/tests/test_mcp_common.py
@@ -36,6 +36,23 @@ def test_selected_servers_filters_by_profile() -> None:
     assert core_servers == {"codex-second-opinion", "codex-nano-banana"}
 
 
+def test_selected_servers_default_to_loopback_urls() -> None:
+    urls = {spec.config_name: spec.sse_url for spec in selected_servers({"core", "browser", "cicd"})}
+    assert urls["codex-second-opinion"] == "http://127.0.0.1:9100/sse"
+    assert urls["codex-playwright"] == "http://127.0.0.1:9101/sse"
+    assert urls["codex-nano-banana"] == "http://127.0.0.1:9102/sse"
+    assert urls["codex-woodpecker"] == "http://127.0.0.1:9103/sse"
+
+
+def test_selected_servers_support_service_dns_urls(monkeypatch) -> None:
+    monkeypatch.setenv("MCP_SSE_HOST_MODE", "service")
+    urls = {spec.config_name: spec.sse_url for spec in selected_servers({"core", "browser", "cicd"})}
+    assert urls["codex-second-opinion"] == "http://codex-second-opinion:9100/sse"
+    assert urls["codex-playwright"] == "http://codex-playwright:9101/sse"
+    assert urls["codex-nano-banana"] == "http://codex-nano-banana:9102/sse"
+    assert urls["codex-woodpecker"] == "http://codex-woodpecker:9103/sse"
+
+
 def test_extract_directory_from_args() -> None:
     args = ["run", "--directory", "/tmp/example", "python", "src/server.py", "--stdio"]
     assert extract_directory_from_args(args) == "/tmp/example"


### PR DESCRIPTION
## Summary
- add a CI-safe smoke path that runs from a helper container on the compose network
- teach MCP smoke helpers to target compose service DNS names when requested
- cover the docker-helper deploy path and service-DNS URL resolution with unit tests

## Validation
- env UV_CACHE_DIR=/tmp/uv-cache uv run --extra dev pytest tests/test_mcp_common.py tests/test_deploy_mcp.py tests/test_mcp_secret_contract.py
- docker run --rm --network codex-mcp-net -v /home/cooneycw/Projects/codex-power-pack:/workspace:ro -w /workspace -e MCP_SSE_HOST_MODE=service python:3.11-alpine python3 scripts/mcp_smoke.py --profiles "core browser legacy-cicd"
- CI=1 AWS_SECRETSMANAGER_TOKEN=codex-local-sidecar-token PROFILE="core browser legacy-cicd" ./scripts/deploy_mcp.sh --max-attempts 2