### PR TITLE
fix(flow): resolve security scan PYTHONPATH (Closes #54)

### DIFF
--- a/.codex/cicd_tasks.yml
+++ b/.codex/cicd_tasks.yml
@@ -56,7 +56,7 @@ steps:
       [ -z "$CPP_DIR" ]; then exit 0; fi;
       PYTHON_BIN="$CPP_DIR/.venv/bin/python"; if [ ! -x "$PYTHON_BIN"
       ]; then PYTHON_BIN=python3; fi;
-      PYTHONPATH="$CPP_DIR${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN"
+      ! PYTHONPATH="$CPP_DIR${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN"
       -c 'import lib.security' 2>/dev/null
 
   deploy_security_scan:
@@ -80,7 +80,7 @@ steps:
       [ -z "$CPP_DIR" ]; then exit 0; fi;
       PYTHON_BIN="$CPP_DIR/.venv/bin/python"; if [ ! -x "$PYTHON_BIN"
       ]; then PYTHON_BIN=python3; fi;
-      PYTHONPATH="$CPP_DIR${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN"
+      ! PYTHONPATH="$CPP_DIR${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN"
       -c 'import lib.security' 2>/dev/null
 
   deploy:

--- a/.codex/cicd_tasks.yml
+++ b/.codex/cicd_tasks.yml
@@ -37,19 +37,51 @@ steps:
 
   security_scan:
     command: >-
-      PYTHONPATH="${HOME}/Projects/codex-power-pack/lib"
-      python3 -m lib.security gate flow_finish
+      CPP_DIR="" for dir in "${CODEX_POWER_PACK_DIR:-}"
+      "$HOME/Projects/codex-power-pack" /opt/codex-power-pack
+      "$HOME/.codex-power-pack"; do if [ -n "$dir" ] && [ -f
+      "$dir/AGENTS.md" ]; then CPP_DIR="$dir"; break; fi; done; if
+      [ -z "$CPP_DIR" ]; then echo "codex-power-pack not found" >&2;
+      exit 1; fi; PYTHON_BIN="$CPP_DIR/.venv/bin/python"; if [ ! -x
+      "$PYTHON_BIN" ]; then PYTHON_BIN=python3; fi;
+      PYTHONPATH="$CPP_DIR${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN"
+      -m lib.security gate flow_finish
     description: Run security quick scan
     timeout: 120
-    skip_if: "! python3 -c 'import lib.security' 2>/dev/null"
+    skip_if: >-
+      CPP_DIR="" for dir in "${CODEX_POWER_PACK_DIR:-}"
+      "$HOME/Projects/codex-power-pack" /opt/codex-power-pack
+      "$HOME/.codex-power-pack"; do if [ -n "$dir" ] && [ -f
+      "$dir/AGENTS.md" ]; then CPP_DIR="$dir"; break; fi; done; if
+      [ -z "$CPP_DIR" ]; then exit 0; fi;
+      PYTHON_BIN="$CPP_DIR/.venv/bin/python"; if [ ! -x "$PYTHON_BIN"
+      ]; then PYTHON_BIN=python3; fi;
+      PYTHONPATH="$CPP_DIR${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN"
+      -c 'import lib.security' 2>/dev/null
 
   deploy_security_scan:
     command: >-
-      PYTHONPATH="${HOME}/Projects/codex-power-pack/lib"
-      python3 -m lib.security gate flow_deploy
+      CPP_DIR="" for dir in "${CODEX_POWER_PACK_DIR:-}"
+      "$HOME/Projects/codex-power-pack" /opt/codex-power-pack
+      "$HOME/.codex-power-pack"; do if [ -n "$dir" ] && [ -f
+      "$dir/AGENTS.md" ]; then CPP_DIR="$dir"; break; fi; done; if
+      [ -z "$CPP_DIR" ]; then echo "codex-power-pack not found" >&2;
+      exit 1; fi; PYTHON_BIN="$CPP_DIR/.venv/bin/python"; if [ ! -x
+      "$PYTHON_BIN" ]; then PYTHON_BIN=python3; fi;
+      PYTHONPATH="$CPP_DIR${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN"
+      -m lib.security gate flow_deploy
     description: Run security scan before deploy
     timeout: 120
-    skip_if: "! python3 -c 'import lib.security' 2>/dev/null"
+    skip_if: >-
+      CPP_DIR="" for dir in "${CODEX_POWER_PACK_DIR:-}"
+      "$HOME/Projects/codex-power-pack" /opt/codex-power-pack
+      "$HOME/.codex-power-pack"; do if [ -n "$dir" ] && [ -f
+      "$dir/AGENTS.md" ]; then CPP_DIR="$dir"; break; fi; done; if
+      [ -z "$CPP_DIR" ]; then exit 0; fi;
+      PYTHON_BIN="$CPP_DIR/.venv/bin/python"; if [ ! -x "$PYTHON_BIN"
+      ]; then PYTHON_BIN=python3; fi;
+      PYTHONPATH="$CPP_DIR${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN"
+      -c 'import lib.security' 2>/dev/null
 
   deploy:
     command: make deploy

--- a/lib/cicd/manifest.py
+++ b/lib/cicd/manifest.py
@@ -39,6 +39,7 @@ import yaml
 
 from .detector import detect_framework
 from .makefile import parse_makefile
+from .security_scan import build_security_gate_command, build_security_gate_skip_if
 
 logger = logging.getLogger(__name__)
 
@@ -302,13 +303,10 @@ def generate_manifest(
 
     # Add security_scan step if lib.security is available
     steps["security_scan"] = StepModel(
-        command=(
-            'PYTHONPATH="${HOME}/Projects/codex-power-pack/lib" '
-            "python3 -m lib.security gate flow_finish"
-        ),
+        command=build_security_gate_command("flow_finish"),
         description="Run security quick scan",
         timeout=120,
-        skip_if="! python3 -c 'import lib.security' 2>/dev/null",
+        skip_if=build_security_gate_skip_if(),
     )
 
     # Add any extra Makefile targets not already covered

--- a/lib/cicd/security_scan.py
+++ b/lib/cicd/security_scan.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-
 CPP_DIR_DISCOVERY = """CPP_DIR=""
-for dir in "${CODEX_POWER_PACK_DIR:-}" "$HOME/Projects/codex-power-pack" /opt/codex-power-pack "$HOME/.codex-power-pack"; do
+for dir in "${CODEX_POWER_PACK_DIR:-}" \
+  "$HOME/Projects/codex-power-pack" \
+  /opt/codex-power-pack \
+  "$HOME/.codex-power-pack"; do
   if [ -n "$dir" ] && [ -f "$dir/AGENTS.md" ]; then
     CPP_DIR="$dir"
     break

--- a/lib/cicd/security_scan.py
+++ b/lib/cicd/security_scan.py
@@ -33,5 +33,5 @@ def build_security_gate_skip_if() -> str:
         + 'if [ -z "$CPP_DIR" ]; then exit 0; fi; '
         + 'PYTHON_BIN="$CPP_DIR/.venv/bin/python"; '
         + 'if [ ! -x "$PYTHON_BIN" ]; then PYTHON_BIN=python3; fi; '
-        + 'PYTHONPATH="$CPP_DIR${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" -c \'import lib.security\' 2>/dev/null'
+        + '! PYTHONPATH="$CPP_DIR${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" -c \'import lib.security\' 2>/dev/null'
     )

--- a/lib/cicd/security_scan.py
+++ b/lib/cicd/security_scan.py
@@ -1,0 +1,35 @@
+"""Helpers for invoking Codex Power Pack security gates from the runner."""
+
+from __future__ import annotations
+
+
+CPP_DIR_DISCOVERY = """CPP_DIR=""
+for dir in "${CODEX_POWER_PACK_DIR:-}" "$HOME/Projects/codex-power-pack" /opt/codex-power-pack "$HOME/.codex-power-pack"; do
+  if [ -n "$dir" ] && [ -f "$dir/AGENTS.md" ]; then
+    CPP_DIR="$dir"
+    break
+  fi
+done
+"""
+
+
+def build_security_gate_command(gate: str) -> str:
+    """Build a shell command that runs a security gate from the CPP repo root."""
+    return (
+        CPP_DIR_DISCOVERY
+        + 'if [ -z "$CPP_DIR" ]; then echo "codex-power-pack not found" >&2; exit 1; fi; '
+        + 'PYTHON_BIN="$CPP_DIR/.venv/bin/python"; '
+        + 'if [ ! -x "$PYTHON_BIN" ]; then PYTHON_BIN=python3; fi; '
+        + f'PYTHONPATH="$CPP_DIR${{PYTHONPATH:+:$PYTHONPATH}}" "$PYTHON_BIN" -m lib.security gate {gate}'
+    )
+
+
+def build_security_gate_skip_if() -> str:
+    """Build a shell expression that skips when lib.security is unavailable."""
+    return (
+        CPP_DIR_DISCOVERY
+        + 'if [ -z "$CPP_DIR" ]; then exit 0; fi; '
+        + 'PYTHON_BIN="$CPP_DIR/.venv/bin/python"; '
+        + 'if [ ! -x "$PYTHON_BIN" ]; then PYTHON_BIN=python3; fi; '
+        + 'PYTHONPATH="$CPP_DIR${PYTHONPATH:+:$PYTHONPATH}" "$PYTHON_BIN" -c \'import lib.security\' 2>/dev/null'
+    )

--- a/lib/cicd/steps.py
+++ b/lib/cicd/steps.py
@@ -11,6 +11,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Optional, Protocol
 
+from .security_scan import build_security_gate_command, build_security_gate_skip_if
 from .state import StepStatus
 
 
@@ -192,14 +193,11 @@ BUILTIN_PLANS: dict[str, list[StepDef]] = {
         ),
         StepDef(
             id="security_scan",
-            command=(
-                'PYTHONPATH="${HOME}/Projects/codex-power-pack/lib" '
-                "python3 -m lib.security gate flow_finish"
-            ),
+            command=build_security_gate_command("flow_finish"),
             description="Run security quick scan",
             timeout_seconds=120,
             max_attempts=1,
-            skip_if="! python3 -c 'import lib.security' 2>/dev/null",
+            skip_if=build_security_gate_skip_if(),
         ),
     ],
     "check": [
@@ -223,14 +221,11 @@ BUILTIN_PLANS: dict[str, list[StepDef]] = {
     "deploy": [
         StepDef(
             id="security_scan",
-            command=(
-                'PYTHONPATH="${HOME}/Projects/codex-power-pack/lib" '
-                "python3 -m lib.security gate flow_deploy"
-            ),
+            command=build_security_gate_command("flow_deploy"),
             description="Run security scan before deploy",
             timeout_seconds=120,
             max_attempts=1,
-            skip_if="! python3 -c 'import lib.security' 2>/dev/null",
+            skip_if=build_security_gate_skip_if(),
         ),
         StepDef(
             id="deploy",

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -28,6 +28,14 @@ from lib.cicd.manifest import (
 )
 from lib.cicd.steps import StepDef, get_plan_steps
 
+
+def assert_uses_cpp_root_security_command(command: str, gate: str) -> None:
+    assert "${HOME}/Projects/codex-power-pack/lib" not in command
+    assert 'PYTHONPATH="$CPP_DIR${PYTHONPATH:+:$PYTHONPATH}"' in command
+    assert f"-m lib.security gate {gate}" in command
+    assert 'PYTHON_BIN="$CPP_DIR/.venv/bin/python"' in command
+
+
 # -- StepModel validation tests --
 
 
@@ -346,6 +354,13 @@ class TestGenerateManifest:
         # Should still have security_scan at minimum
         assert "security_scan" in manifest.steps
 
+    def test_security_scan_uses_cpp_repo_root(self, tmp_path):
+        manifest = generate_manifest(tmp_path)
+        security_scan = manifest.steps["security_scan"]
+        assert_uses_cpp_root_security_command(security_scan.command, "flow_finish")
+        assert security_scan.skip_if is not None
+        assert 'PYTHONPATH="$CPP_DIR${PYTHONPATH:+:$PYTHONPATH}"' in security_scan.skip_if
+
 
 # -- write_manifest tests --
 
@@ -396,6 +411,18 @@ class TestGetPlanStepsIntegration:
         steps = get_plan_steps("finish", project_root=str(tmp_path))
         assert len(steps) > 0
         assert steps[0].id == "lint"
+
+    def test_builtin_finish_security_scan_uses_cpp_repo_root(self, tmp_path):
+        steps = get_plan_steps("finish", project_root=str(tmp_path))
+        security_scan = next(step for step in steps if step.id == "security_scan")
+        assert_uses_cpp_root_security_command(security_scan.command, "flow_finish")
+        assert security_scan.skip_if is not None
+        assert 'PYTHONPATH="$CPP_DIR${PYTHONPATH:+:$PYTHONPATH}"' in security_scan.skip_if
+
+    def test_builtin_deploy_security_scan_uses_cpp_repo_root(self, tmp_path):
+        steps = get_plan_steps("deploy", project_root=str(tmp_path))
+        security_scan = next(step for step in steps if step.id == "security_scan")
+        assert_uses_cpp_root_security_command(security_scan.command, "flow_deploy")
 
     def test_manifest_overrides_builtin(self, tmp_path):
         """With a manifest, get_plan_steps uses manifest plans."""
@@ -469,3 +496,15 @@ class TestCPPManifest:
         # Verify cross-references are valid
         errors = manifest.validate_plan_references()
         assert errors == [], f"CPP manifest has reference errors: {errors}"
+
+        assert_uses_cpp_root_security_command(
+            manifest.steps["security_scan"].command,
+            "flow_finish",
+        )
+        assert manifest.steps["security_scan"].skip_if is not None
+        assert 'PYTHONPATH="$CPP_DIR${PYTHONPATH:+:$PYTHONPATH}"' in manifest.steps["security_scan"].skip_if
+
+        assert_uses_cpp_root_security_command(
+            manifest.steps["deploy_security_scan"].command,
+            "flow_deploy",
+        )

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -36,6 +36,12 @@ def assert_uses_cpp_root_security_command(command: str, gate: str) -> None:
     assert 'PYTHON_BIN="$CPP_DIR/.venv/bin/python"' in command
 
 
+def assert_skips_only_when_security_module_is_unavailable(command: str) -> None:
+    assert 'PYTHONPATH="$CPP_DIR${PYTHONPATH:+:$PYTHONPATH}"' in command
+    assert "! PYTHONPATH=" in command
+    assert "import lib.security" in command
+
+
 # -- StepModel validation tests --
 
 
@@ -359,7 +365,7 @@ class TestGenerateManifest:
         security_scan = manifest.steps["security_scan"]
         assert_uses_cpp_root_security_command(security_scan.command, "flow_finish")
         assert security_scan.skip_if is not None
-        assert 'PYTHONPATH="$CPP_DIR${PYTHONPATH:+:$PYTHONPATH}"' in security_scan.skip_if
+        assert_skips_only_when_security_module_is_unavailable(security_scan.skip_if)
 
 
 # -- write_manifest tests --
@@ -417,7 +423,7 @@ class TestGetPlanStepsIntegration:
         security_scan = next(step for step in steps if step.id == "security_scan")
         assert_uses_cpp_root_security_command(security_scan.command, "flow_finish")
         assert security_scan.skip_if is not None
-        assert 'PYTHONPATH="$CPP_DIR${PYTHONPATH:+:$PYTHONPATH}"' in security_scan.skip_if
+        assert_skips_only_when_security_module_is_unavailable(security_scan.skip_if)
 
     def test_builtin_deploy_security_scan_uses_cpp_repo_root(self, tmp_path):
         steps = get_plan_steps("deploy", project_root=str(tmp_path))
@@ -502,7 +508,9 @@ class TestCPPManifest:
             "flow_finish",
         )
         assert manifest.steps["security_scan"].skip_if is not None
-        assert 'PYTHONPATH="$CPP_DIR${PYTHONPATH:+:$PYTHONPATH}"' in manifest.steps["security_scan"].skip_if
+        assert_skips_only_when_security_module_is_unavailable(
+            manifest.steps["security_scan"].skip_if
+        )
 
         assert_uses_cpp_root_security_command(
             manifest.steps["deploy_security_scan"].command,


### PR DESCRIPTION
## Summary
- resolve the security gate command from the codex-power-pack repo root instead of the broken lib-only PYTHONPATH
- reuse the same command builder for built-in plans and generated manifests
- update the checked-in cicd task manifest and add regression coverage for finish/deploy security scan commands

## Testing
- uv run --frozen pytest tests/test_manifest.py
- uv run --frozen pytest tests/test_security_scanners.py