### PR TITLE
fix(cicd): isolate runner step environment

### DIFF
--- a/lib/cicd/manifest.py
+++ b/lib/cicd/manifest.py
@@ -59,6 +59,7 @@ class StepModel(BaseModel):
     idempotent: bool = True
     skip_if: Optional[str] = None
     depends_on: list[str] = Field(default_factory=list)
+    env: dict[str, str] = Field(default_factory=dict)
     artifacts: list[str] = Field(default_factory=list)
     rollback: Optional[str] = None
 
@@ -222,6 +223,7 @@ def step_model_to_step_def(step_id: str, model: StepModel) -> Any:
         idempotent=model.idempotent,
         skip_if=model.skip_if,
         depends_on=list(model.depends_on),
+        env=dict(model.env),
     )
 
 
@@ -377,6 +379,7 @@ def write_manifest(manifest: TaskManifest, project_root: str | Path) -> Path:
         "#   steps.<name>.max_attempts - Retry count (default: 1)\n"
         "#   steps.<name>.idempotent  - Safe to retry? (default: true)\n"
         "#   steps.<name>.skip_if     - Shell expression; skip if exits 0\n"
+        "#   steps.<name>.env         - Extra env vars (merged on top of sanitized base)\n"
         "#   steps.<name>.artifacts   - Output files to preserve\n"
         "#   steps.<name>.rollback    - Command to run on failure\n"
         "#   plans.<name>.steps       - Ordered list of step names\n"

--- a/lib/cicd/runner.py
+++ b/lib/cicd/runner.py
@@ -17,6 +17,7 @@ Usage:
 from __future__ import annotations
 
 import json
+import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -24,6 +25,15 @@ from typing import Any, Optional, TextIO
 
 from .state import RunState
 from .steps import ShellStep, StepDef, get_plan_steps
+
+RUNNER_STRIP_VARS = frozenset({"PYTHONPATH"})
+
+
+def _build_step_env() -> dict[str, str]:
+    """Build a sanitized environment for child step processes."""
+    env = {k: v for k, v in os.environ.items() if k not in RUNNER_STRIP_VARS}
+    env.setdefault("UV_CACHE_DIR", "/tmp/uv-cache")
+    return env
 
 
 @dataclass
@@ -136,6 +146,7 @@ class DeterministicRunner:
             "project_root": str(self.project_root),
             "run_id": state.run_id,
             "plan": state.plan_name,
+            "env": _build_step_env(),
         }
 
         completed = state.current_index

--- a/lib/cicd/steps.py
+++ b/lib/cicd/steps.py
@@ -6,6 +6,7 @@ Each step type knows how to execute a specific kind of operation
 
 from __future__ import annotations
 
+import os
 import subprocess
 import time
 from dataclasses import dataclass, field
@@ -56,9 +57,10 @@ class StepDef:
     idempotent: bool = True
     skip_if: Optional[str] = None  # shell expression; step skipped if exits 0
     depends_on: list[str] = field(default_factory=list)
+    env: dict[str, str] = field(default_factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d: dict[str, Any] = {
             "id": self.id,
             "command": self.command,
             "description": self.description,
@@ -66,6 +68,9 @@ class StepDef:
             "max_attempts": self.max_attempts,
             "idempotent": self.idempotent,
         }
+        if self.env:
+            d["env"] = self.env
+        return d
 
 
 class ShellStep:
@@ -84,6 +89,7 @@ class ShellStep:
         self.idempotent = step_def.idempotent
         self.skip_if = step_def.skip_if
         self.description = step_def.description
+        self.env = step_def.env
 
     def should_skip(self, context: dict[str, Any]) -> bool:
         """Check if this step should be skipped."""
@@ -105,6 +111,10 @@ class ShellStep:
         """Execute the shell command with timeout."""
         cwd = context.get("project_root")
         env = context.get("env")
+
+        if self.env:
+            env = dict(os.environ) if env is None else dict(env)
+            env.update(self.env)
 
         try:
             proc = subprocess.run(

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -66,13 +66,19 @@ class TestStepModel:
             idempotent=True,
             skip_if='! grep -q "^test:" Makefile 2>/dev/null',
             depends_on=["lint"],
+            env={"DJANGO_SETTINGS_MODULE": "config.settings.test"},
             artifacts=["coverage.xml", "htmlcov/"],
             rollback="make clean",
         )
         assert step.timeout == 300
         assert step.max_attempts == 3
+        assert step.env == {"DJANGO_SETTINGS_MODULE": "config.settings.test"}
         assert step.artifacts == ["coverage.xml", "htmlcov/"]
         assert step.rollback == "make clean"
+
+    def test_env_default_empty(self):
+        step = StepModel(command="make lint")
+        assert step.env == {}
 
     def test_timeout_bounds(self):
         with pytest.raises(Exception):
@@ -234,6 +240,25 @@ class TestStepModelToStepDef:
         assert step_def.skip_if == '! grep -q "^test:" Makefile 2>/dev/null'
         assert step_def.depends_on == ["lint"]
 
+    def test_env_field_conversion(self):
+        model = StepModel(
+            command="make test",
+            env={
+                "UV_CACHE_DIR": "/tmp/uv-cache",
+                "DJANGO_SETTINGS_MODULE": "config.settings.test",
+            },
+        )
+        step_def = step_model_to_step_def("test", model)
+        assert step_def.env == {
+            "UV_CACHE_DIR": "/tmp/uv-cache",
+            "DJANGO_SETTINGS_MODULE": "config.settings.test",
+        }
+
+    def test_env_field_default_empty(self):
+        model = StepModel(command="make lint")
+        step_def = step_model_to_step_def("lint", model)
+        assert step_def.env == {}
+
 
 # -- load_manifest tests --
 
@@ -305,6 +330,30 @@ class TestLoadManifest:
 
         with pytest.raises(ValueError, match="nonexistent"):
             load_manifest(tmp_path)
+
+    def test_manifest_with_env(self, tmp_path):
+        manifest_dir = tmp_path / ".codex"
+        manifest_dir.mkdir()
+        manifest_file = manifest_dir / "cicd_tasks.yml"
+        manifest_file.write_text(textwrap.dedent("""\
+            version: "1"
+            steps:
+              test:
+                command: make test
+                env:
+                  UV_CACHE_DIR: /tmp/uv-cache
+                  DJANGO_SETTINGS_MODULE: config.settings.test
+            plans:
+              check:
+                steps: [test]
+        """))
+
+        manifest = load_manifest(tmp_path)
+        assert manifest is not None
+        assert manifest.steps["test"].env == {
+            "UV_CACHE_DIR": "/tmp/uv-cache",
+            "DJANGO_SETTINGS_MODULE": "config.settings.test",
+        }
 
     def test_empty_file_returns_none(self, tmp_path):
         manifest_dir = tmp_path / ".codex"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,11 +1,13 @@
 """Tests for the deterministic CI/CD runner."""
 
+import os
 from io import StringIO
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
-from lib.cicd.runner import DeterministicRunner, RunResult
+from lib.cicd.runner import DeterministicRunner, RunResult, _build_step_env
 from lib.cicd.state import RunState
 from lib.cicd.steps import StepDef
 
@@ -189,3 +191,75 @@ class TestDeterministicRunner:
         log = output.getvalue()
         assert "echo" in log
         assert "SUCCESS" in log
+
+    def test_env_sanitized_in_child(self, tmp_project: Path):
+        """Runner strips PYTHONPATH so child steps don't inherit runner imports."""
+        env_file = tmp_project / "captured_env.txt"
+        steps = [
+            StepDef(
+                id="capture_env",
+                command=f'echo "PYTHONPATH=${{PYTHONPATH:-UNSET}}" > {env_file}',
+                timeout_seconds=30,
+            ),
+        ]
+        with patch.dict(os.environ, {"PYTHONPATH": "/fake/runner/lib"}):
+            runner = DeterministicRunner(project_root=tmp_project, output=StringIO())
+            result = runner.run("check", step_defs=steps)
+
+        assert result.success
+        content = env_file.read_text()
+        assert "PYTHONPATH=UNSET" in content
+
+    def test_uv_cache_dir_defaulted(self, tmp_project: Path):
+        """Runner defaults UV_CACHE_DIR when not already set."""
+        env_file = tmp_project / "uv_cache.txt"
+        steps = [
+            StepDef(
+                id="capture_uv",
+                command=f'echo "$UV_CACHE_DIR" > {env_file}',
+                timeout_seconds=30,
+            ),
+        ]
+        env_without_uv = {k: v for k, v in os.environ.items() if k != "UV_CACHE_DIR"}
+        with patch.dict(os.environ, env_without_uv, clear=True):
+            runner = DeterministicRunner(project_root=tmp_project, output=StringIO())
+            result = runner.run("check", step_defs=steps)
+
+        assert result.success
+        assert env_file.read_text().strip() == "/tmp/uv-cache"
+
+    def test_step_level_env_override(self, tmp_project: Path):
+        """Step-level env vars merge on top of context env."""
+        env_file = tmp_project / "step_env.txt"
+        steps = [
+            StepDef(
+                id="with_env",
+                command=f'echo "$MY_STEP_VAR" > {env_file}',
+                timeout_seconds=30,
+                env={"MY_STEP_VAR": "from_step"},
+            ),
+        ]
+        runner = DeterministicRunner(project_root=tmp_project, output=StringIO())
+        result = runner.run("check", step_defs=steps)
+
+        assert result.success
+        assert env_file.read_text().strip() == "from_step"
+
+
+class TestBuildStepEnv:
+    def test_strips_pythonpath(self):
+        with patch.dict(os.environ, {"PYTHONPATH": "/runner/lib", "HOME": "/home/test"}):
+            env = _build_step_env()
+            assert "PYTHONPATH" not in env
+            assert env["HOME"] == "/home/test"
+
+    def test_defaults_uv_cache_dir(self):
+        env_without_uv = {k: v for k, v in os.environ.items() if k != "UV_CACHE_DIR"}
+        with patch.dict(os.environ, env_without_uv, clear=True):
+            env = _build_step_env()
+            assert env["UV_CACHE_DIR"] == "/tmp/uv-cache"
+
+    def test_preserves_explicit_uv_cache_dir(self):
+        with patch.dict(os.environ, {"UV_CACHE_DIR": "/custom/cache"}):
+            env = _build_step_env()
+            assert env["UV_CACHE_DIR"] == "/custom/cache"


### PR DESCRIPTION
## Summary
- strip runner launcher PYTHONPATH from child CI/CD steps
- default UV_CACHE_DIR for runner-mediated commands
- allow manifest steps to layer explicit env vars onto the sanitized base

## Tests
- UV_PROJECT_ENVIRONMENT=/home/cooneycw/Projects/codex-power-pack/.venv UV_CACHE_DIR=/tmp/uv-cache make test
- UV_PROJECT_ENVIRONMENT=/home/cooneycw/Projects/codex-power-pack/.venv UV_CACHE_DIR=/tmp/uv-cache make lint