### PR TITLE
spec: plugin marketplace modernization (full wave)

### DIFF
--- a/.specify/specs/plugin-marketplace-modernization/plan.md
+++ b/.specify/specs/plugin-marketplace-modernization/plan.md
@@ -1,0 +1,138 @@
+# Implementation Plan: Plugin Marketplace Modernization
+
+> **Spec:** `.specify/specs/plugin-marketplace-modernization/spec.md`
+> **Delivery model:** Codex builds all tasks (issues are self-contained for
+> `codex:auto`-style delegation). Claude reviews at the end (Epic F) and tunes
+> gaps. Cross-repo companion issues are filed in claude-power-pack.
+
+## Sequencing
+
+```
+Epic 0 (threat model, exit bar)        <- blocks C, D, E scaffolding
+   |
+Epic A (demolition/externalize)        <- independent of B, unblocks clean tree
+   |
+Epic B (SoT sync bridge, CPP-side)     <- feeds generated skills into C/D
+   |
+Epic C (plugin packaging)              <- distribution rails for D
+   |
+Epic D (family ports, per-family dogfood gates)
+   |
+Epic E (friction telemetry)            <- can start after 0; informs D7 woodpecker verdict
+   |
+Epic F (quality bar, E2E acceptance, Claude review)
+```
+
+## Epic 0: Threat Model and Guard Design (Phase 0, explicit exit bar)
+
+Security-first standing rule: the guard is designed before the scaffolding.
+
+- **0.1** Threat model: AWS secret-key exposure paths in Codex sessions
+  (env, `config.toml`, `history.jsonl`, session logs, CI logs); plugin
+  supply chain (git-backed source pinning policy); hooks are non-managed and
+  user-reviewed; friction telemetry egress (what leaves the box, masking
+  before write). Deliverable: `docs/security/threat-model.md`.
+- **0.2** Borrow-vs-build spike: evaluate Secret Guard (pre-commit
+  pattern+entropy scanner) and Agent Guard (real-time secret-leak guardrails
+  for Codex/Claude Code) for the secrets-masking layer. Deliverable: adopt or
+  build decision recorded in the threat model.
+
+**Exit bar:** guard designs for (a) secrets masking in Codex sessions,
+(b) ledger write path, (c) plugin pinning policy are documented and
+owner-approved before any Epic C/D/E implementation PR merges.
+
+## Epic A: Demolition - Externalize MCP, Retire Runtime (mirror CPP #469)
+
+- **A1** Delete bundled servers and runtime: `codex-second-opinion/`,
+  `codex-playwright/`, `codex-nano-banana/`, `codex-woodpecker/`,
+  `mcp-evaluate/`, `aws-secretsmanager-agent/`, `docker-compose.yml`,
+  `scripts/deploy_mcp.sh`, `scripts/deploy_doctor.py`, all `make docker-*`
+  and `deploy*` targets.
+- **A2** Wire shared external MCP: `config.toml` pointer template for the
+  shared `mcp-second-opinion` server (localhost HTTP), native
+  `@playwright/mcp` registration; write the host-managed-services doc
+  (what runs where, who owns it - the CPP HOST_MANAGED analog).
+- **A3** Purge legacy strays: root Reddit scripts, reference PDF,
+  `INSTALLATION_ISSUES.md`, stale docs; retire `lib/spec_bridge/`
+  (CPP #420 parity); delete legacy `CLAUDE.md` breadcrumb.
+- **A4** Retire `scripts/skills_install_codex.py`,
+  `scripts/mcp_install_codex.py`, and their make targets/doctor checks.
+
+## Epic B: Single-SoT Sync Bridge (hybrid model)
+
+- **B1** *(claude-power-pack issue)* Evolve `codex-prompt-sync.py` into a
+  SKILL.md generator: per-command Codex skills with progressive-disclosure
+  layout, harness transforms, trigger-word-front-loaded descriptions.
+- **B2** *(claude-power-pack issue)* Cross-repo publish: generator emits into
+  codex-power-pack via PR (eli5-gate vendoring pattern, reversed direction);
+  `--check` drift gates wired into both repos' CI.
+- **B3** Delete the frozen `.claude/commands/` fork from this repo; generated
+  skills land under `plugins/<family>/skills/` carrying GENERATED markers.
+- **B4** Harness-lint CI gate: fail any skill referencing Claude-only
+  constructs (Agent tool, native worktrees, `!` prefix, `/plugin` refs,
+  CLAUDE.md paths).
+
+## Epic C: Native Plugin Packaging and Distribution
+
+- **C1** Marketplace scaffold: `.agents/plugins/marketplace.json` + first
+  plugin (project family) with `.codex-plugin/plugin.json`; prove E2E with
+  `/plugins` install from the repo as a git-backed source.
+- **C2** Package all families as per-family plugins; per-skill
+  `agents/openai.yaml` (default `allow_implicit_invocation: false`,
+  display metadata).
+- **C3** Version pinning and release process: tagged releases, marketplace
+  entries pin ref/sha, upgrade documented.
+- **C4** `cxpp:init/update/status` thin fallback for non-plugin infra:
+  `config.toml` MCP pointers, secrets bootstrap, spec-kit install,
+  hooks/rules install.
+- **C5** Docs cutover: rewrite `README.md` + `AGENTS.md` for the new
+  architecture; quick start becomes marketplace add + `/plugins` install.
+
+## Epic D: Family Ports (each story ends with a Codex dogfood gate)
+
+- **D1** project: `$project-init` zero-to-repo orchestration (primary
+  objective); absorb #55 (project-next / project-lite inventory gap).
+- **D2** spec: official spec-kit adoption for Codex + gh-CLI issue sync;
+  no label adapter (CPP #418 decisions).
+- **D3** flow: issue lifecycle (start/finish/merge/status) adapted to Codex;
+  port layout-aware merge logic (CPP gh-pr-merge.sh lineage).
+- **D4** github: issue management family (gh CLI).
+- **D5** cicd: Makefile validation + pipeline generation; absorb #53
+  (mandatory gitleaks step in generated Woodpecker pipelines).
+- **D6** secrets: AWS Secrets Manager family with masking guardrails per the
+  Phase 0 spike outcome (borrowed guard or built hooks/rules).
+- **D7** woodpecker: skills driving Woodpecker CLI/API directly (replaces the
+  deleted MCP server); secrets strictly via D6; absorb #57 (deploy
+  guardrails). Telemetry from Epic E decides if this ever becomes an external
+  shared server.
+- **D8** security: deterministic half only (gitleaks, git-history, pip-audit,
+  gate); semantic review defers to Codex native review.
+- **D9** agents-md: lint + help (generated from CPP's agents-md family).
+- **D10** documentation: c4 diagrams + pptx (no nano-banana path).
+- **D11** qa: qa-test web testing family.
+- **D12** evaluate + second-opinion client commands against the shared server.
+
+## Epic E: Codex Friction Telemetry (shared ledger)
+
+- **E1** Spike: Codex hooks.json event surface - which lifecycle events can
+  observe approval prompts / command failures; rules interplay; design the
+  masking-before-write guard (Phase 0 dependency).
+- **E2** Capture implementation: fail-open writer to the shared Postgres
+  fleet ledger (connection via secrets, never hardcoded), rows tagged
+  `harness=codex`.
+- **E3** *(claude-power-pack issue)* Ledger feathering: harness tag in
+  schema/consumers so retros compare harnesses.
+- **E4** Retro loop: self-improvement retro skill for Codex consuming the
+  ledger; absorb #58 (propose validation gates after repeated failures) and
+  #59 (blocking reminder for admin-only bootstrap deps).
+
+## Epic F: Quality Bar and Close-Out (the 9/10)
+
+- **F1** Woodpecker CI refresh: gitleaks first, validate, image gates;
+  git-less container guard on tests.
+- **F2** Test suite + drift gates green; `make verify` meaningful
+  post-demolition.
+- **F3** E2E acceptance: Codex, from a fresh install via `/plugins`,
+  scaffolds a throwaway project AND authors+syncs a gh spec end to end.
+- **F4** Claude review-and-tune: gap analysis pass over the whole wave,
+  fixes filed/applied (owner-decided delivery model D7).

--- a/.specify/specs/plugin-marketplace-modernization/spec.md
+++ b/.specify/specs/plugin-marketplace-modernization/spec.md
@@ -1,0 +1,142 @@
+# Feature Specification: Plugin Marketplace Modernization
+
+> **Branch:** `spec/plugin-marketplace-modernization`
+> **Created:** 2026-07-07
+> **Status:** In Review
+
+---
+
+## Overview
+
+Codex Power Pack (CxPP) is a first-pass Codex replication of claude-power-pack
+(CPP), frozen in early June 2026. Since then, two things changed underneath it:
+
+1. **Codex shipped native plugins and a marketplace** (March 2026, matured
+   since): `.codex-plugin/plugin.json` bundles skills + hooks + `.mcp.json`,
+   catalogued via `.agents/plugins/marketplace.json`, installed with `/plugins`
+   from git-backed sources. CxPP's custom installers
+   (`skills_install_codex.py`, `mcp_install_codex.py`) predate all of this.
+2. **CPP retired the architecture CxPP still embodies**: bundled MCP servers
+   behind a docker-compose runtime (CPP #469 externalized second-opinion and
+   the sidecar; CPP #420 retired spec_bridge; CPP epic #417 Phase B moved
+   distribution to the native plugin marketplace).
+
+This spec modernizes CxPP into a 9/10 repo whose core objective is
+**scaffolding of GitHub specs and new projects from Codex**, with the same
+native-first philosophy CPP applies to Claude Code: defer to what the harness
+provides, ship only what adds value on top.
+
+## Ratified Decisions (owner-grilled 2026-07-07)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| D1 | Source of truth | **Hybrid.** Shared command families are authored once in CPP `.claude/commands/` and generated into CxPP via a cross-repo sync (evolution of CPP `codex-prompt-sync.py`). CxPP independently owns everything Codex-native: plugin manifests, hooks, rules, AGENTS.md tooling, marketplace catalog, `config.toml` wiring. The frozen `.claude/commands/` fork in this repo is deleted. |
+| D2 | MCP servers | **None live in CxPP.** Externalize what does not fit the marketplace distribution model; extend what adds value. Second opinion comes from the shared external `mcp-second-opinion` server (localhost HTTP pointer, serves both harnesses). Playwright goes native (`@playwright/mcp`). nano-banana is deleted (already torn down fleet-wide). The docker-compose runtime, deploy scripts, and deploy doctor are removed. |
+| D3 | Woodpecker | **Skills first.** No marketplace plugin for Woodpecker CI exists in the Codex ecosystem (verified 2026-07-07), so CxPP ships skills that drive the Woodpecker CLI/API directly, with AWS Secrets Manager access strictly through the secrets family. Friction telemetry (D6) measures whether Codex handles this reliably; promotion to an external shared MCP server is a data-driven follow-up, not a default. |
+| D4 | Distribution | **Native per-family plugins** under `plugins/<family>/` with `.codex-plugin/plugin.json`, catalogued in `.agents/plugins/marketplace.json`, installable individually (respects the ~8k-char skill-list budget). One thin `cxpp:init/update/status` fallback survives for what plugins cannot carry: `config.toml` MCP pointers, secrets bootstrap, spec-kit install, hooks/rules install. Custom skill installers are retired. |
+| D5 | Scope | **Full parity wave**, planned as epics/stories now and synced to GitHub issues in this repo. |
+| D6 | Friction telemetry | Codex needs a friction-measurement equivalent of CPP's permission census and friction ledger, writing to the **same shared Postgres fleet ledger** (Tailscale-internal; connection via secrets, never hardcoded). Cross-repo issues are posted to claude-power-pack to feather shared functionality (generator, ledger schema). |
+| D7 | Delivery | **Codex builds all tasks** (issues written self-contained for `codex:auto`-style delegation). **Claude reviews at the end and tunes gaps.** Every ported family's definition of done includes a dogfood gate: Codex itself runs the family's core skill end to end. |
+| D8 | Security first | Phase 0 threat model with an explicit exit bar precedes scaffolding. Known weak spot: Codex fumbling AWS secret keys. Borrow-vs-build spike on existing Codex secret-guard plugins (Secret Guard, Agent Guard) to reduce surface area. |
+
+## Target Architecture
+
+```
+codex-power-pack/
+├── AGENTS.md                          # canonical Codex instructions (rewritten)
+├── .agents/
+│   └── plugins/marketplace.json       # repo marketplace catalog (git-backed source)
+├── plugins/
+│   └── <family>/
+│       ├── .codex-plugin/plugin.json  # manifest: skills (+hooks/.mcp.json where needed)
+│       └── skills/<skill>/SKILL.md    # GENERATED for shared families, authored for Codex-native
+├── lib/                               # deterministic Python helpers (cicd, creds, security)
+├── scripts/                           # generators, drift guards, harness lint
+├── templates/                         # project scaffolding templates
+├── .specify/                          # spec-kit authoring
+├── .woodpecker.yml                    # CI: gitleaks -> validate -> gates
+└── tests/
+```
+
+Removed entirely: `codex-second-opinion/`, `codex-playwright/`,
+`codex-nano-banana/`, `codex-woodpecker/`, `mcp-evaluate/`,
+`aws-secretsmanager-agent/`, `docker-compose.yml`, `lib/spec_bridge/`,
+`scripts/deploy_mcp.sh`, `scripts/deploy_doctor.py`,
+`scripts/skills_install_codex.py`, `scripts/mcp_install_codex.py`,
+root-level stray scripts and reference PDFs, the frozen `.claude/commands/`
+fork, and the legacy `CLAUDE.md` breadcrumb.
+
+## User Stories
+
+### US1: Scaffold a new project from Codex [P1]
+
+**As a** Codex user,
+**I want** `$project-init` to take me from zero to a GitHub repo with
+Makefile, CI, secrets wiring, and AGENTS.md,
+**So that** new projects start at the quality bar instead of climbing to it.
+
+**Acceptance Criteria:**
+- [ ] Fresh machine: `marketplace add` + `/plugins` install of the project family works with no repo clone
+- [ ] Codex (not Claude) scaffolds a throwaway project end to end, including first commit and CI green
+- [ ] Secrets never appear in Codex output, history, or logs during the run
+
+### US2: Author and sync GitHub specs from Codex [P1]
+
+**As a** Codex user,
+**I want** spec-kit authoring plus gh-CLI issue sync as skills,
+**So that** specs and their issue waves are produced the same way CPP does it.
+
+**Acceptance Criteria:**
+- [ ] `$spec-adopt` installs official spec-kit (which supports Codex) into a target repo
+- [ ] Spec -> epics/stories sync to GitHub issues via gh CLI (no label adapter, mirroring CPP #418)
+
+### US3: Daily-driver parity [P2]
+
+**As a** CPP user working in Codex,
+**I want** the flow, github, cicd, secrets, security (deterministic),
+agents-md, documentation, qa, evaluate, and self-improvement families,
+**So that** switching harnesses does not mean losing the workflow.
+
+**Acceptance Criteria:**
+- [ ] Each family installs as its own plugin and passes its dogfood gate
+- [ ] Generated skills carry no Claude-only constructs (CI-linted)
+
+### US4: Measured friction, shared ledger [P2]
+
+**As the** fleet operator,
+**I want** Codex friction signals (approval prompts, secret fumbles, repeated
+infra failures) written to the same Postgres ledger CPP uses,
+**So that** retros compare harnesses and drive borrow/build decisions with data.
+
+**Acceptance Criteria:**
+- [ ] Fail-open capture; a down ledger never blocks work
+- [ ] Rows tagged by harness; masking guard applied before any write leaves the box
+- [ ] Retro skill consumes the ledger and proposes codified fixes
+
+## Edge Cases
+
+| Scenario | Expected Behavior |
+|----------|-------------------|
+| Shared MCP server down | Skills degrade with a clear message; nothing in CxPP starts/owns servers |
+| CPP SoT edit uses Claude-only construct | CxPP harness-lint CI gate fails the sync PR, not the installed user |
+| Skill-list budget exceeded | Per-family installs keep each user under budget; descriptions front-load trigger words |
+| Ledger unreachable | Fail-open, local buffer if cheap, never a hard dependency |
+| gitleaks CI gate vs skill fixtures | Path-allowlist fixtures in `.gitleaks.toml`, as CPP learned |
+
+## Out of Scope
+
+- Running or operating any MCP server from this repo (docker, compose, deploy targets)
+- A `claude:*` delegation family inside Codex (mirror of CPP `codex:*`); revisit after the wave
+- browser session lease-desk machinery (Claude-specific concurrency layer); native `@playwright/mcp` suffices
+- claude-md family (AGENTS.md world; agents-md family covers it)
+- Publishing to OpenAI's official public plugin directory (self-serve publishing not yet open; repo marketplace + git-backed source is the distribution path)
+
+## Existing Open Issues Absorbed
+
+| Issue | Absorbed into |
+|-------|---------------|
+| #53 mandatory gitleaks in Woodpecker pipelines | Epic D (cicd story) |
+| #55 project-next/project-lite missing from inventory | Epic D (project story) |
+| #57 Woodpecker deployment guardrails | Epic D (woodpecker story) |
+| #58 propose validation gates after repeated infra failures | Epic E (retro story) |
+| #59 blocking reminder for admin-only bootstrap deps | Epic E (retro story) |

--- a/.specify/specs/plugin-marketplace-modernization/tasks.md
+++ b/.specify/specs/plugin-marketplace-modernization/tasks.md
@@ -1,0 +1,52 @@
+# Task Breakdown: Plugin Marketplace Modernization
+
+> **Spec:** `.specify/specs/plugin-marketplace-modernization/spec.md`
+> **Sync:** epics and stories below are mirrored to GitHub issues in
+> cooneycw/codex-power-pack (companion issues B1/B2/E3 in
+> cooneycw/claude-power-pack). Issue numbers recorded after sync.
+> **Delivery:** Codex builds all tasks; Claude reviews at the end (F4).
+
+| ID  | Epic | Title | Depends on | Repo |
+|-----|------|-------|------------|------|
+| 0.1 | 0 | Threat model: secrets, supply chain, hooks, telemetry egress | - | CxPP |
+| 0.2 | 0 | Spike: borrow-vs-build secret-leak guardrails (Secret Guard / Agent Guard) | 0.1 | CxPP |
+| A1  | A | Delete bundled MCP servers, compose runtime, deploy scripts | - | CxPP |
+| A2  | A | Wire shared external MCP pointers + host-managed-services doc | A1 | CxPP |
+| A3  | A | Purge legacy strays + retire lib/spec_bridge | - | CxPP |
+| A4  | A | Retire custom skill/MCP installers and make targets | A1 | CxPP |
+| B1  | B | SKILL.md generator with harness transforms | - | CPP |
+| B2  | B | Cross-repo publish + bidirectional drift gates | B1 | CPP |
+| B3  | B | Remove frozen .claude/commands fork; receive generated skills | B2 | CxPP |
+| B4  | B | Harness-lint CI gate for Claude-only constructs | B3 | CxPP |
+| C1  | C | Marketplace scaffold + first plugin (project) proven E2E | 0.1, A1 | CxPP |
+| C2  | C | Per-family plugins for all families + openai.yaml policy | C1, B3 | CxPP |
+| C3  | C | Version pinning + tagged release process | C1 | CxPP |
+| C4  | C | cxpp:init/update/status thin infra fallback | A2, A4 | CxPP |
+| C5  | C | README/AGENTS.md rewrite, docs cutover | C2, C4 | CxPP |
+| D1  | D | project family: $project-init zero-to-repo (+#55) | C1 | CxPP |
+| D2  | D | spec family: spec-kit adopt + gh issue sync | C1 | CxPP |
+| D3  | D | flow family: issue lifecycle adapted to Codex | C2 | CxPP |
+| D4  | D | github family: issue management | C2 | CxPP |
+| D5  | D | cicd family: Makefile + pipeline gen (+#53) | C2 | CxPP |
+| D6  | D | secrets family: AWS SM + masking guardrails | 0.2, C2 | CxPP |
+| D7  | D | woodpecker skills replacing the MCP server (+#57) | D5, D6 | CxPP |
+| D8  | D | security family: deterministic half only | C2 | CxPP |
+| D9  | D | agents-md family: lint + help | C2 | CxPP |
+| D10 | D | documentation family: c4 + pptx | C2 | CxPP |
+| D11 | D | qa family: qa-test | C2 | CxPP |
+| D12 | D | evaluate + second-opinion client commands | A2, C2 | CxPP |
+| E1  | E | Spike: Codex hooks event surface + masking design | 0.1 | CxPP |
+| E2  | E | Fail-open friction writer to shared ledger (harness=codex) | E1 | CxPP |
+| E3  | E | Ledger feathering: harness tag in schema/consumers | E2 | CPP |
+| E4  | E | Codex retro loop consuming the ledger (+#58, +#59) | E2 | CxPP |
+| F1  | F | Woodpecker CI refresh (gitleaks-first, image gates) | A1 | CxPP |
+| F2  | F | Test suite + drift gates green post-demolition | B4, C2 | CxPP |
+| F3  | F | E2E acceptance: fresh-install Codex scaffolds project + spec | D1, D2 | CxPP |
+| F4  | F | Claude review-and-tune gap pass over the wave | all | CxPP |
+
+## Definition of Done (every D-story)
+
+1. Family installs as its own plugin via `/plugins` from the repo marketplace.
+2. Codex (not Claude) executes the family's core skill end to end (dogfood gate).
+3. No Claude-only constructs (harness-lint green); no secrets in output/logs.
+4. `make verify` green; docs updated.


### PR DESCRIPTION
Full modernization spec for codex-power-pack, ratified via owner grill 2026-07-07.

**Decisions:** hybrid SoT with claude-power-pack (shared families generated, Codex-native owned here); zero in-repo MCP servers (shared external mcp-second-opinion, native @playwright/mcp, delete compose runtime); native per-family plugin marketplace distribution; woodpecker skills-first with friction telemetry (shared Postgres ledger) deciding any future server promotion; Codex builds all tasks, Claude reviews at the end.

**Contents:** `.specify/specs/plugin-marketplace-modernization/` spec + plan + tasks (7 epics, 35 stories). Issue wave synced to this repo separately; companion issues filed in claude-power-pack (generator, cross-repo publish, ledger feathering).

Absorbs open issues #53, #55, #57, #58, #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)