### PR TITLE
docs(mcp): document host-managed MCP pointers (Closes #72)

### DIFF
--- a/.claude/commands/project/help.md
+++ b/.claude/commands/project/help.md
@@ -22,7 +22,7 @@ One-command project setup that orchestrates:
 1. Creates `~/Projects/<name>` with framework scaffold (Python/Node/Go/Rust)
 2. Initializes git and pushes to a new GitHub repo
 3. Generates Makefile from detected framework (`lib/cicd`)
-4. Installs CPP commands, skills, and hooks (symlinks)
+4. Installs CxPP commands, skills, hooks, and MCP pointer templates
 5. Initializes `.specify/` for spec-driven development
 6. Optionally creates an initial feature spec
 
@@ -35,6 +35,8 @@ One-command project setup that orchestrates:
 - Idempotent - safe to re-run if interrupted (completed steps are skipped)
 - Framework-specific scaffolds with best-practice project structure
 - Integrates with `/flow`, `/spec`, `/security`, and all CPP commands
+- Future `cxpp:init` fallback scope includes host-managed MCP pointers only;
+  external servers remain owned outside the repo
 
 ## /project-next
 

--- a/.claude/commands/project/init.md
+++ b/.claude/commands/project/init.md
@@ -337,7 +337,7 @@ Report: `Step 3/6: Git initialized, pushed to github.com/{user}/{PROJECT_NAME}`
 
 ---
 
-## Step 4: CPP Setup (Orchestrate Sub-Commands)
+## Step 4: CxPP Setup (Orchestrate Sub-Commands)
 
 Run each sub-command in sequence. These are orchestrated directly - NOT by invoking `/skill` (which would require user interaction for each one). Instead, execute the same logic as each command but non-interactively with sensible defaults.
 
@@ -377,7 +377,7 @@ print(content)
 fi
 ```
 
-### 4b: CPP Init (symlinks)
+### 4b: CxPP Init (symlinks)
 
 ```bash
 if [ -n "$CPP_DIR" ]; then
@@ -403,7 +403,32 @@ if [ -n "$CPP_DIR" ]; then
 fi
 ```
 
-### 4c: Generate AGENTS.md
+### 4c: Future `cxpp:init` Host-Managed MCP Pointers
+
+Story C4 consumes this scope for the thin `cxpp:init/update/status` fallback.
+Until that command exists, use this as the target behavior:
+
+```bash
+if [ -n "$CPP_DIR" ]; then
+    mkdir -p .codex
+
+    # Record pointer examples for host-managed MCP services.
+    # Do not write global Codex config without explicit confirmation.
+    if [ -f "$CPP_DIR/templates/config.toml.example" ] && [ ! -f ".codex/config.toml.example" ]; then
+        cp "$CPP_DIR/templates/config.toml.example" .codex/config.toml.example
+        echo "Copied host-managed MCP pointer template to .codex/config.toml.example"
+    fi
+
+    echo "MCP pointers are documented in docs/HOST_MANAGED.md."
+    echo "CxPP does not start, stop, or deploy MCP servers."
+fi
+```
+
+The fallback may configure Codex-facing pointers for the shared
+`mcp-second-opinion` server and native `@playwright/mcp`. It does not start,
+stop, restart, update, or deploy either service.
+
+### 4d: Generate AGENTS.md
 
 If no AGENTS.md exists yet, generate one with CI/CD governance directives:
 
@@ -643,7 +668,7 @@ Project created: {PROJECT_NAME}
   GitHub:     github.com/{user}/{PROJECT_NAME} (private)
   Framework:  {Framework} ({PackageManager})
   Makefile:   lint, test, build, deploy, clean, verify
-  CPP:        Commands + Skills + Hooks
+  CxPP:       Commands + Skills + Hooks + MCP pointer template
   Spec:       .specify/ initialized
 
 Next steps:

--- a/.claude/commands/second-opinion/help.md
+++ b/.claude/commands/second-opinion/help.md
@@ -51,7 +51,10 @@ You can also invoke the MCP tools directly without commands:
 
 ## Requirements
 
-- MCP Second Opinion server configured (stdio recommended, or SSE on port 9100)
+- Host-managed MCP Second Opinion server configured via Codex streamable HTTP
+  at `http://127.0.0.1:8080/mcp`
+- Browser automation uses native `@playwright/mcp`, not a server wrapper from
+  this repo
 - At least one API key configured (GEMINI_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY)
 - All three recommended for cross-provider comparison
 
@@ -59,11 +62,18 @@ You can also invoke the MCP tools directly without commands:
 
 **Error `-32602: Invalid request parameters`** usually means the server isn't running, not that parameters are wrong.
 
-**Fix:** Point Claude at an externally managed second-opinion MCP server:
+**Fix:** Point Codex at an externally managed second-opinion MCP server:
 
 ```bash
-claude mcp remove second-opinion
-claude mcp add second-opinion --transport sse --url http://127.0.0.1:9100/sse
+codex mcp remove second-opinion
+codex mcp add second-opinion --url http://127.0.0.1:8080/mcp
 ```
 
-Then use your external server's health or diagnostic command.
+For browser automation, register the native Playwright MCP package:
+
+```bash
+codex mcp add playwright -- npx -y @playwright/mcp@latest
+```
+
+Then start a fresh Codex session and use the external server's health or
+diagnostic command. Codex Power Pack does not start or manage either server.

--- a/.codex/prompts/project/help.md
+++ b/.codex/prompts/project/help.md
@@ -26,7 +26,7 @@ One-command project setup that orchestrates:
 1. Creates `~/Projects/<name>` with framework scaffold (Python/Node/Go/Rust)
 2. Initializes git and pushes to a new GitHub repo
 3. Generates Makefile from detected framework (`lib/cicd`)
-4. Installs CPP commands, skills, and hooks (symlinks)
+4. Installs CxPP commands, skills, hooks, and MCP pointer templates
 5. Initializes `.specify/` for spec-driven development
 6. Optionally creates an initial feature spec
 
@@ -39,6 +39,8 @@ One-command project setup that orchestrates:
 - Idempotent - safe to re-run if interrupted (completed steps are skipped)
 - Framework-specific scaffolds with best-practice project structure
 - Integrates with `/flow`, `/spec`, `/security`, and all CPP commands
+- Future `cxpp:init` fallback scope includes host-managed MCP pointers only;
+  external servers remain owned outside the repo
 
 ## /project-next
 

--- a/.codex/prompts/project/init.md
+++ b/.codex/prompts/project/init.md
@@ -341,7 +341,7 @@ Report: `Step 3/6: Git initialized, pushed to github.com/{user}/{PROJECT_NAME}`
 
 ---
 
-## Step 4: CPP Setup (Orchestrate Sub-Commands)
+## Step 4: CxPP Setup (Orchestrate Sub-Commands)
 
 Run each sub-command in sequence. These are orchestrated directly - NOT by invoking `/skill` (which would require user interaction for each one). Instead, execute the same logic as each command but non-interactively with sensible defaults.
 
@@ -381,7 +381,7 @@ print(content)
 fi
 ```
 
-### 4b: CPP Init (symlinks)
+### 4b: CxPP Init (symlinks)
 
 ```bash
 if [ -n "$CPP_DIR" ]; then
@@ -407,7 +407,32 @@ if [ -n "$CPP_DIR" ]; then
 fi
 ```
 
-### 4c: Generate AGENTS.md
+### 4c: Future `cxpp:init` Host-Managed MCP Pointers
+
+Story C4 consumes this scope for the thin `cxpp:init/update/status` fallback.
+Until that command exists, use this as the target behavior:
+
+```bash
+if [ -n "$CPP_DIR" ]; then
+    mkdir -p .codex
+
+    # Record pointer examples for host-managed MCP services.
+    # Do not write global Codex config without explicit confirmation.
+    if [ -f "$CPP_DIR/templates/config.toml.example" ] && [ ! -f ".codex/config.toml.example" ]; then
+        cp "$CPP_DIR/templates/config.toml.example" .codex/config.toml.example
+        echo "Copied host-managed MCP pointer template to .codex/config.toml.example"
+    fi
+
+    echo "MCP pointers are documented in docs/HOST_MANAGED.md."
+    echo "CxPP does not start, stop, or deploy MCP servers."
+fi
+```
+
+The fallback may configure Codex-facing pointers for the shared
+`mcp-second-opinion` server and native `@playwright/mcp`. It does not start,
+stop, restart, update, or deploy either service.
+
+### 4d: Generate AGENTS.md
 
 If no AGENTS.md exists yet, generate one with CI/CD governance directives:
 
@@ -647,7 +672,7 @@ Project created: {PROJECT_NAME}
   GitHub:     github.com/{user}/{PROJECT_NAME} (private)
   Framework:  {Framework} ({PackageManager})
   Makefile:   lint, test, build, deploy, clean, verify
-  CPP:        Commands + Skills + Hooks
+  CxPP:       Commands + Skills + Hooks + MCP pointer template
   Spec:       .specify/ initialized
 
 Next steps:

--- a/.codex/prompts/second-opinion/help.md
+++ b/.codex/prompts/second-opinion/help.md
@@ -54,7 +54,10 @@ You can also invoke the MCP tools directly without commands:
 
 ## Requirements
 
-- MCP Second Opinion server configured (stdio recommended, or SSE on port 9100)
+- Host-managed MCP Second Opinion server configured via Codex streamable HTTP
+  at `http://127.0.0.1:8080/mcp`
+- Browser automation uses native `@playwright/mcp`, not a server wrapper from
+  this repo
 - At least one API key configured (GEMINI_API_KEY, OPENAI_API_KEY, or ANTHROPIC_API_KEY)
 - All three recommended for cross-provider comparison
 
@@ -66,7 +69,14 @@ You can also invoke the MCP tools directly without commands:
 
 ```bash
 codex mcp remove second-opinion
-codex mcp add second-opinion --transport sse --url http://127.0.0.1:9100/sse
+codex mcp add second-opinion --url http://127.0.0.1:8080/mcp
 ```
 
-Then use your external server's health or diagnostic command.
+For browser automation, register the native Playwright MCP package:
+
+```bash
+codex mcp add playwright -- npx -y @playwright/mcp@latest
+```
+
+Then start a fresh Codex session and use the external server's health or
+diagnostic command. Codex Power Pack does not start or manage either server.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@
 - `.codex/cicd_tasks.yml` - deterministic CI/CD task manifest
 - `lib/` - reusable Python libraries for creds, security, and CI/CD
 - `templates/` - starter Makefiles and workflow templates
+- `templates/config.toml.example` - Codex MCP pointers for host-managed services
+- `docs/HOST_MANAGED.md` - host-owned MCP service inventory and health checks
 - `scripts/` - shell helpers
 - `docs/skills/` - focused reference docs
 - `docs/security/` - security threat models and guard designs
@@ -25,7 +27,7 @@
 
 Codex Power Pack no longer owns MCP server code, Docker Compose runtime, or
 deployment entrypoints. Use external MCP servers and native Codex plugins for
-tool integrations.
+tool integrations, with client-side pointers documented in `docs/HOST_MANAGED.md`.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ prompt surfaces, skills, and tests for Codex-centric workflows.
 - `AGENTS.md` - the canonical repo instructions for Codex
 - `lib/creds/`, `lib/security/`, `lib/cicd/` - reusable Python libraries
 - `templates/`, `scripts/`, `docs/skills/`, `tests/` - supporting workflow assets
+- `templates/config.toml.example` and `docs/HOST_MANAGED.md` - client-side
+  pointers for externally managed MCP services
 - `docs/security/threat-model.md` - Phase 0 guard design for plugin marketplace modernization
 
 ## Quick Start
@@ -27,18 +29,31 @@ Distribution is handled by native Codex plugins. For project bootstrapping from
 the plugin, use the thin `cxpp:init` fallback rather than copying skills out of
 this checkout.
 
+For host-managed MCP tools, merge `templates/config.toml.example` into your
+Codex config or run:
+
+```bash
+codex mcp add second-opinion --url http://127.0.0.1:8080/mcp
+codex mcp add playwright -- npx -y @playwright/mcp@latest
+```
+
+`mcp-second-opinion` is an external host service; this repo only documents the
+pointer. See `docs/HOST_MANAGED.md` for owners and health checks.
+
 ## Runtime Boundary
 
 This repo does not own MCP server code, Docker Compose runtime, or deployment
 entrypoints. Configure external MCP servers and native Codex plugins outside
-this checkout.
+this checkout. The checked-in MCP config is a pointer template, not lifecycle
+management.
 
 ## Codex Architecture
 
 - Codex instructions live in `AGENTS.md`
 - Prompt entrypoints live in `.codex/prompts/`
 - Skill packages live in `.codex/skills/`
-- Runtime config targets `.codex/` paths
+- Runtime config targets `.codex/` paths and host-managed pointers in
+  `templates/config.toml.example`
 - Secrets storage uses `~/.config/codex-power-pack/`
 
 ## Distribution

--- a/docs/HOST_MANAGED.md
+++ b/docs/HOST_MANAGED.md
@@ -1,0 +1,68 @@
+# Host-Managed Services
+
+Codex Power Pack does not run MCP servers. It ships prompts, skills, templates,
+and documentation that point Codex at services owned outside this repository.
+Use `templates/config.toml.example` as the source pointer template for a fresh
+Codex install.
+
+## Codex Configuration
+
+Merge these entries into `~/.codex/config.toml`, or run the matching Codex CLI
+commands:
+
+```toml
+[mcp_servers.second-opinion]
+url = "http://127.0.0.1:8080/mcp"
+
+[mcp_servers.playwright]
+command = "npx"
+args = ["-y", "@playwright/mcp@latest"]
+```
+
+```bash
+codex mcp add second-opinion --url http://127.0.0.1:8080/mcp
+codex mcp add playwright -- npx -y @playwright/mcp@latest
+```
+
+Start a fresh Codex session after changing MCP configuration so the tool list is
+rebuilt.
+
+## Service Inventory
+
+| Service | Owner | Codex pointer | Health check |
+|---------|-------|---------------|--------------|
+| `mcp-second-opinion` | Shared external `mcp-second-opinion` service, usually installed as a host service from that repo | `http://127.0.0.1:8080/mcp` | `curl -sf http://127.0.0.1:8080/readyz` |
+| `@playwright/mcp` | Native Playwright MCP package resolved by Codex through `npx` | `npx -y @playwright/mcp@latest` | `codex mcp get playwright` |
+
+For `mcp-second-opinion`, `/` is the liveness endpoint and `/readyz` confirms the
+server has provider configuration loaded. The MCP tool-level health check is
+`health_check` after Codex has loaded the server.
+
+For browser automation, use the native `@playwright/mcp` registration above. This
+repo does not ship a Playwright server wrapper or browser lease manager.
+
+## Lifecycle Boundary
+
+No server lifecycle management exists in this repo. Codex Power Pack must not:
+
+- start, stop, restart, update, or deploy `mcp-second-opinion`
+- vendor `mcp-second-opinion`, Playwright MCP, or browser binaries
+- store API keys for the shared service in repo config
+- replace host service health checks with repo-local Docker Compose targets
+
+The host service owner manages credentials, process supervision, upgrades, and
+logs. Codex Power Pack only records the client-side connection contract.
+
+## Future `cxpp:init` Scope
+
+Story C4 owns the thin `cxpp:init/update/status` fallback. When implemented, it
+should:
+
+1. Copy or print `templates/config.toml.example` for the user's Codex config.
+2. Ask before writing any global `~/.codex/config.toml` entry.
+3. Run non-secret health checks such as `curl -sf http://127.0.0.1:8080/readyz`
+   and `codex mcp get playwright`.
+4. Report missing host services without trying to create them.
+
+That fallback may install Codex-facing pointers and hooks/rules. It still must
+not own external MCP server lifecycle.

--- a/templates/config.toml.example
+++ b/templates/config.toml.example
@@ -1,0 +1,12 @@
+# Codex MCP pointer template for host-managed services.
+#
+# Merge the entries you need into ~/.codex/config.toml or the config layer your
+# Codex install uses. Codex Power Pack documents these pointers only; it does
+# not start, stop, or deploy the referenced services.
+
+[mcp_servers.second-opinion]
+url = "http://127.0.0.1:8080/mcp"
+
+[mcp_servers.playwright]
+command = "npx"
+args = ["-y", "@playwright/mcp@latest"]

--- a/tests/test_host_managed_mcp.py
+++ b/tests/test_host_managed_mcp.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_config_template_registers_host_managed_mcp_servers() -> None:
+    text = (ROOT / "templates" / "config.toml.example").read_text()
+
+    assert "[mcp_servers.second-opinion]" in text
+    assert 'url = "http://127.0.0.1:8080/mcp"' in text
+    assert "[mcp_servers.playwright]" in text
+    assert 'command = "npx"' in text
+    assert 'args = ["-y", "@playwright/mcp@latest"]' in text
+
+
+def test_host_managed_doc_records_boundary_and_health_checks() -> None:
+    text = (ROOT / "docs" / "HOST_MANAGED.md").read_text()
+
+    for needle in [
+        "mcp-second-opinion",
+        "@playwright/mcp",
+        "curl -sf http://127.0.0.1:8080/readyz",
+        "codex mcp add second-opinion --url http://127.0.0.1:8080/mcp",
+        "No server lifecycle management exists in this repo",
+    ]:
+        assert needle in text
+
+
+def test_project_init_records_future_cxpp_init_pointer_scope() -> None:
+    text = (ROOT / ".codex" / "prompts" / "project" / "init.md").read_text()
+
+    assert "cxpp:init" in text
+    assert "templates/config.toml.example" in text
+    assert "does not start, stop, or deploy MCP servers" in text


### PR DESCRIPTION
## Summary
- Add a Codex config.toml MCP pointer template for the host-managed second-opinion server and native Playwright MCP.
- Document host-owned MCP services, lifecycle boundaries, and health-check one-liners in docs/HOST_MANAGED.md.
- Update project-init and second-opinion runbooks, plus AGENTS/README pointers, and add regression coverage.

## Verification
- uv run --extra dev python -m lib.cicd run --plan finish
- make verify

Closes #72