### PR TITLE
feat(ci): add harness lint gate (Closes #76)

### DIFF
--- a/.codex/harness-lint-allowlist.txt
+++ b/.codex/harness-lint-allowlist.txt
@@ -1,0 +1,8 @@
+# Reviewed harness-lint exceptions.
+#
+# Syntax:
+#   rule-id|relative/path/from/.codex/skills|needle-or-*|reason
+#
+# Prefer fixing the skill or adding a Codex harness adaptation. Use this file only
+# when a literal Claude-only token is intentionally retained and safe for Codex.
+claude-plugin-command|cpp-help/reference.md|Browse a marketplace|documents Codex plugin marketplace browsing command in generated CPP help

--- a/.codex/skills/README.md
+++ b/.codex/skills/README.md
@@ -17,6 +17,18 @@ A hand-edit is caught by the CI drift gate (`make codex-skills-check`,
 `scripts/codex_skills_sync.py --check`), which fails when any file here diverges from
 the pinned copy recorded in `vendor/claude-power-pack/`.
 
+## Harness lint
+
+Generated skills also run through `make harness-lint`
+(`scripts/harness_lint.py --check`) so Claude-only constructs do not reach Codex
+unadapted. A literal `AskUserQuestion`, `.claude/worktrees`, `/plugin`,
+`CLAUDE.md`, `Agent tool`, `Skill tool`, or leading `!` command is allowed only
+when the skill's `SKILL.md` contains a matching Codex harness adaptation.
+
+If a literal token must remain for documentation, add a reviewed exception to
+`.codex/harness-lint-allowlist.txt` using `rule|path|needle|reason`. Prefer
+rewriting the skill or adding an adaptation over allowlisting.
+
 ## Reconcile rule
 
 To change a generated skill, edit the **source** upstream, never the copy here:

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -17,6 +17,9 @@ steps:
       # Drift gate: .codex/skills/ must match the pinned claude-power-pack copy
       # (codex-power-pack#75). Git-free, so it runs in this container.
       - uv run python scripts/codex_skills_sync.py --check
+      # Harness gate: generated/authored skills must not carry unadapted
+      # Claude-only constructs into Codex.
+      - uv run python scripts/harness_lint.py --check
 
   secret-scan:
     image: zricethezav/gitleaks:v8.18.4

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: test lint format typecheck verify build update_docs clean help secret-scan dep-audit \
-	codex-skills codex-skills-check codex-skills-refresh
+	codex-skills codex-skills-check codex-skills-refresh harness-lint
 
 # claude-power-pack checkout the generated Codex skills are pulled from (codex-power-pack#75).
 CPP_ROOT ?= ../claude-power-pack
@@ -18,6 +18,9 @@ test:
 
 typecheck:
 	uv run --extra dev mypy .
+
+harness-lint:
+	@python3 scripts/harness_lint.py --check
 
 build:
 	uv build
@@ -40,7 +43,7 @@ codex-skills-refresh:
 
 ## Verification gate (runs all quality checks)
 
-verify: lint test typecheck codex-skills-check
+verify: lint test typecheck codex-skills-check harness-lint
 
 ## Documentation (used by /flow:auto and /flow:finish)
 
@@ -71,6 +74,7 @@ help:
 	@echo "  make format      - Run ruff formatter"
 	@echo "  make test        - Run pytest"
 	@echo "  make typecheck   - Run mypy"
+	@echo "  make harness-lint - Check skills for unadapted Claude-only constructs"
 	@echo "  make build       - Build distribution packages"
 	@echo "  make verify      - Run all quality checks"
 	@echo ""

--- a/scripts/harness_lint.py
+++ b/scripts/harness_lint.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Lint Codex skills for unadapted Claude-only constructs.
+
+Generated CxPP skills may still mention Claude-only surfaces in their source
+body. That is acceptable only when the skill's SKILL.md carries an explicit
+Codex harness adaptation for the same construct. This gate catches copied
+instructions that would otherwise break under Codex.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_SKILLS_ROOT = REPO_ROOT / ".codex" / "skills"
+DEFAULT_ALLOWLIST = REPO_ROOT / ".codex" / "harness-lint-allowlist.txt"
+
+
+@dataclass(frozen=True)
+class Rule:
+    id: str
+    description: str
+    pattern: re.Pattern[str]
+    adaptation_terms: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Finding:
+    rule_id: str
+    path: Path
+    line: int
+    text: str
+    description: str
+
+
+@dataclass(frozen=True)
+class Allow:
+    rule_id: str
+    path: str
+    needle: str
+    reason: str
+
+
+RULES = (
+    Rule(
+        id="agent-tool",
+        description="Claude Agent tool reference",
+        pattern=re.compile(r"\bAgent\s+tool\b"),
+        adaptation_terms=("Agent tool",),
+    ),
+    Rule(
+        id="skill-tool",
+        description="Claude Skill tool reference",
+        pattern=re.compile(r"\bSkill\s+tool\b"),
+        adaptation_terms=("Skill tool",),
+    ),
+    Rule(
+        id="ask-user-question",
+        description="Claude AskUserQuestion tool reference",
+        pattern=re.compile(r"\bAskUserQuestion\b"),
+        adaptation_terms=("AskUserQuestion",),
+    ),
+    Rule(
+        id="claude-worktree-path",
+        description="Claude native worktree path",
+        pattern=re.compile(r"\.claude/worktrees"),
+        adaptation_terms=(".claude/worktrees", "Native worktrees"),
+    ),
+    Rule(
+        id="bang-command-prefix",
+        description="Claude ! shell command prefix",
+        pattern=re.compile(r"^\s*!(?!\[)"),
+        adaptation_terms=("! prefix",),
+    ),
+    Rule(
+        id="claude-plugin-command",
+        description="Claude /plugin command reference",
+        pattern=re.compile(r"(?<![\w.-])/plugin\b"),
+        adaptation_terms=("/plugin",),
+    ),
+    Rule(
+        id="claude-md-reference",
+        description="CLAUDE.md reference",
+        pattern=re.compile(r"\bCLAUDE\.md\b"),
+        adaptation_terms=("CLAUDE.md",),
+    ),
+)
+
+
+def _markdown_files(skills_root: Path) -> list[Path]:
+    if not skills_root.is_dir():
+        return []
+    files: list[Path] = []
+    for skill_dir in sorted(p for p in skills_root.iterdir() if p.is_dir()):
+        files.extend(sorted(skill_dir.rglob("*.md")))
+    return files
+
+
+def _skill_dir_for(path: Path, skills_root: Path) -> Path | None:
+    rel = path.relative_to(skills_root)
+    if len(rel.parts) < 2:
+        return None
+    skill_dir = skills_root / rel.parts[0]
+    return skill_dir if skill_dir.is_dir() else None
+
+
+def _adaptation_text(skill_dir: Path) -> str:
+    skill_md = skill_dir / "SKILL.md"
+    if not skill_md.is_file():
+        return ""
+
+    lines = skill_md.read_text().splitlines()
+    start = None
+    for index, line in enumerate(lines):
+        if line.strip() == "## Codex harness adaptations":
+            start = index
+            break
+    if start is None:
+        return ""
+
+    body: list[str] = []
+    for line in lines[start + 1 :]:
+        if line.startswith("# "):
+            break
+        if line.startswith("## "):
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+def _is_inside_adaptation_block(path: Path, line_number: int, skills_root: Path) -> bool:
+    if path.name != "SKILL.md":
+        return False
+    lines = path.read_text().splitlines()
+    start = None
+    for index, line in enumerate(lines, start=1):
+        if line.strip() == "## Codex harness adaptations":
+            start = index
+            break
+    if start is None or line_number <= start:
+        return False
+    for index, line in enumerate(lines[start:], start=start + 1):
+        if line.startswith("# ") or line.startswith("## "):
+            return line_number < index
+    return True
+
+
+def _has_adaptation(path: Path, rule: Rule, skills_root: Path) -> bool:
+    skill_dir = _skill_dir_for(path, skills_root)
+    if skill_dir is None:
+        return False
+    text = _adaptation_text(skill_dir)
+    return any(term in text for term in rule.adaptation_terms)
+
+
+def read_allowlist(path: Path) -> list[Allow]:
+    if not path.is_file():
+        return []
+
+    allows: list[Allow] = []
+    errors: list[str] = []
+    for line_number, raw in enumerate(path.read_text().splitlines(), start=1):
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = [part.strip() for part in line.split("|", 3)]
+        if len(parts) != 4 or not all(parts):
+            errors.append(f"{path}:{line_number}: expected rule|path|needle|reason")
+            continue
+        rule_id, rel_path, needle, reason = parts
+        if rule_id not in {rule.id for rule in RULES}:
+            errors.append(f"{path}:{line_number}: unknown rule '{rule_id}'")
+            continue
+        allows.append(Allow(rule_id=rule_id, path=rel_path, needle=needle, reason=reason))
+
+    if errors:
+        raise ValueError("\n".join(errors))
+    return allows
+
+
+def _allowed(finding: Finding, skills_root: Path, allows: list[Allow]) -> bool:
+    rel = finding.path.relative_to(skills_root).as_posix()
+    return any(
+        allow.rule_id == finding.rule_id and allow.path == rel and (allow.needle == "*" or allow.needle in finding.text)
+        for allow in allows
+    )
+
+
+def lint_skills(skills_root: Path = DEFAULT_SKILLS_ROOT, allowlist_path: Path = DEFAULT_ALLOWLIST) -> list[Finding]:
+    skills_root = skills_root.resolve()
+    allowlist_path = allowlist_path.resolve()
+    allows = read_allowlist(allowlist_path)
+
+    findings: list[Finding] = []
+    for path in _markdown_files(skills_root):
+        text = path.read_text()
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            for rule in RULES:
+                if not rule.pattern.search(line):
+                    continue
+                finding = Finding(
+                    rule_id=rule.id,
+                    path=path,
+                    line=line_number,
+                    text=line.strip(),
+                    description=rule.description,
+                )
+                if _is_inside_adaptation_block(path, line_number, skills_root):
+                    continue
+                if _has_adaptation(path, rule, skills_root):
+                    continue
+                if _allowed(finding, skills_root, allows):
+                    continue
+                findings.append(finding)
+    return findings
+
+
+def run_check(skills_root: Path = DEFAULT_SKILLS_ROOT, allowlist_path: Path = DEFAULT_ALLOWLIST) -> int:
+    try:
+        findings = lint_skills(skills_root=skills_root, allowlist_path=allowlist_path)
+    except ValueError as exc:
+        print(f"harness-lint: invalid allowlist\n{exc}", file=sys.stderr)
+        return 2
+
+    if findings:
+        print("harness-lint: unadapted Claude-only constructs found", file=sys.stderr)
+        for finding in findings:
+            rel = finding.path.relative_to(skills_root).as_posix()
+            print(
+                f"{rel}:{finding.line}: {finding.rule_id}: {finding.description}: {finding.text}",
+                file=sys.stderr,
+            )
+        print(
+            "\nAdd a Codex harness adaptation to the skill, rewrite the copied instruction,"
+            " or add a reviewed rule|path|needle|reason entry to .codex/harness-lint-allowlist.txt.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"harness-lint: {len(_markdown_files(skills_root))} markdown file(s) passed")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Lint Codex skills for unadapted Claude-only constructs.")
+    parser.add_argument("--check", action="store_true", help="fail on findings (default)")
+    parser.add_argument("--skills-root", type=Path, default=DEFAULT_SKILLS_ROOT)
+    parser.add_argument("--allowlist", type=Path, default=DEFAULT_ALLOWLIST)
+    args = parser.parse_args(argv)
+    return run_check(skills_root=args.skills_root, allowlist_path=args.allowlist)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_harness_lint.py
+++ b/tests/test_harness_lint.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "harness_lint.py"
+_spec = importlib.util.spec_from_file_location("harness_lint", MODULE_PATH)
+assert _spec is not None and _spec.loader is not None
+harness_lint = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = harness_lint
+_spec.loader.exec_module(harness_lint)
+
+
+def _write_skill(root: Path, name: str, skill_md: str, reference_md: str = "") -> None:
+    skill_dir = root / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(skill_md)
+    if reference_md:
+        (skill_dir / "reference.md").write_text(reference_md)
+
+
+def _skill_with_adaptation(term: str) -> str:
+    return f"""---
+name: adapted
+description: adapted fixture
+---
+
+## Codex harness adaptations
+
+- {term}: Codex-safe replacement is documented here.
+
+# Adapted Skill
+"""
+
+
+def test_real_skill_tree_has_no_unadapted_claude_only_constructs() -> None:
+    assert harness_lint.lint_skills() == []
+
+
+def test_each_rule_flags_unadapted_skill_text(tmp_path: Path) -> None:
+    cases = {
+        "agent-tool": "Use the Agent tool to delegate this work.",
+        "skill-tool": "Use the Skill tool before acting.",
+        "ask-user-question": "Use AskUserQuestion to collect missing input.",
+        "claude-worktree-path": "Open .claude/worktrees/issue-1 before editing.",
+        "bang-command-prefix": "! pytest tests",
+        "claude-plugin-command": "Run /plugin install example.",
+        "claude-md-reference": "Update CLAUDE.md after changing commands.",
+    }
+
+    for rule_id, body in cases.items():
+        root = tmp_path / rule_id
+        _write_skill(
+            root,
+            "bad-skill",
+            "---\nname: bad\n---\n# Bad Skill\n",
+            body,
+        )
+        findings = harness_lint.lint_skills(root, root / "missing-allowlist.txt")
+        assert [finding.rule_id for finding in findings] == [rule_id]
+
+
+def test_matching_codex_adaptation_allows_reference_text(tmp_path: Path) -> None:
+    root = tmp_path / "skills"
+    _write_skill(
+        root,
+        "project-init",
+        _skill_with_adaptation("AskUserQuestion"),
+        "Use AskUserQuestion to ask the user directly.",
+    )
+
+    assert harness_lint.lint_skills(root, root / "missing-allowlist.txt") == []
+
+
+def test_adaptation_block_itself_is_not_a_violation(tmp_path: Path) -> None:
+    root = tmp_path / "skills"
+    _write_skill(
+        root,
+        "flow-start",
+        _skill_with_adaptation(".claude/worktrees"),
+    )
+
+    assert harness_lint.lint_skills(root, root / "missing-allowlist.txt") == []
+
+
+def test_reviewed_allowlist_requires_reason_and_allows_exact_finding(tmp_path: Path) -> None:
+    root = tmp_path / "skills"
+    allowlist = tmp_path / "allowlist.txt"
+    _write_skill(
+        root,
+        "help",
+        "---\nname: help\n---\n# Help\n",
+        "Run /plugin only when documenting the legacy Claude path.",
+    )
+
+    allowlist.write_text(
+        "claude-plugin-command|help/reference.md|legacy Claude path|documents historical migration path\n"
+    )
+    assert harness_lint.lint_skills(root, allowlist) == []
+
+    allowlist.write_text("claude-plugin-command|help/reference.md|legacy Claude path|\n")
+    try:
+        harness_lint.lint_skills(root, allowlist)
+    except ValueError as exc:
+        assert "expected rule|path|needle|reason" in str(exc)
+    else:
+        raise AssertionError("invalid allowlist entry did not fail")


### PR DESCRIPTION
Summary:
- add scripts/harness_lint.py to block unadapted Claude-only constructs in Codex skill markdown
- add reviewed allowlist support with required reasons and document the escape hatch
- wire make harness-lint into verify and Woodpecker validate
- add pytest coverage for every rule, adaptation handling, and allowlist validation

Test plan:
- make verify
- uv run --extra dev pytest tests/test_harness_lint.py
- make harness-lint

Closes #76