### PR TITLE
feat(friction): add Codex ledger writer (Closes #95)

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -2,46 +2,80 @@
   "hooks": {
     "SessionStart": [
       {
-        "type": "command",
-        "command": "bash -c 'git fetch origin --quiet 2>/dev/null && BEHIND=$(git rev-list HEAD..origin/main --count 2>/dev/null || echo 0) && if [ \"$BEHIND\" -gt 0 ]; then echo \"⚠️  codex-power-pack has $BEHIND new commit(s). Run: git pull\"; else echo \"✓ codex-power-pack is current\"; fi'"
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'git fetch origin --quiet 2>/dev/null && BEHIND=$(git rev-list HEAD..origin/main --count 2>/dev/null || echo 0) && if [ \"$BEHIND\" -gt 0 ]; then echo \"⚠️  codex-power-pack has $BEHIND new commit(s). Run: git pull\"; else echo \"✓ codex-power-pack is current\"; fi'",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 scripts/codex-friction-hook.py --event PermissionRequest",
+            "timeout": 30
+          }
+        ]
       }
     ],
     "PreToolUse": [
       {
-        "matcher": {
-          "tool_name": "Bash"
-        },
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
             "command": "~/.codex/scripts/hook-validate-command.sh",
-            "timeout": 2000
+            "timeout": 30
           }
         ]
       }
     ],
     "PostToolUse": [
       {
-        "matcher": {
-          "tool_name": "Bash"
-        },
+        "matcher": "Bash",
         "hooks": [
           {
             "type": "command",
+            "command": "python3 scripts/codex-friction-hook.py --event PostToolUse",
+            "timeout": 30
+          },
+          {
+            "type": "command",
             "command": "~/.codex/scripts/hook-mask-output.sh",
-            "timeout": 5000
+            "timeout": 30
           }
         ]
       },
       {
-        "matcher": {
-          "tool_name": "Read"
-        },
+        "matcher": "Read",
         "hooks": [
           {
             "type": "command",
+            "command": "python3 scripts/codex-friction-hook.py --event PostToolUse",
+            "timeout": 30
+          },
+          {
+            "type": "command",
             "command": "~/.codex/scripts/hook-mask-output.sh",
-            "timeout": 5000
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 scripts/codex-friction-hook.py --event UserPromptSubmit",
+            "timeout": 30
           }
         ]
       }

--- a/docs/security/codex-hooks-friction-telemetry.md
+++ b/docs/security/codex-hooks-friction-telemetry.md
@@ -224,6 +224,26 @@ Build E2 around these components:
 5. Migration cleanup for legacy `.codex/hooks.json` examples that still use
    Claude-shaped comments or outdated matcher objects.
 
+## E2 Implementation Surface
+
+Issue #95 implements the first writer path:
+
+- `lib/friction/` validates allowlisted event fields, masks every string field,
+  truncates oversized summaries, computes a post-mask fingerprint, and delegates
+  storage through the stable `cpp-memory record` contract.
+- `scripts/codex-friction-hook.py` is the thin hook adapter. It extracts only
+  derived metadata from raw Codex hook payloads; raw prompts, tool input, and
+  tool output are not copied into writer events.
+- `.codex/hooks.json` uses the current matcher-group shape and wires
+  `PermissionRequest`, `PostToolUse`, and `UserPromptSubmit` to the fail-open
+  writer while keeping the existing output masker on tool output.
+- `CXPP_CPP_MEMORY_CMD` can point at the operator-installed `cpp-memory` command
+  when it is not on `PATH`. The writer never accepts or stores a database DSN;
+  Postgres credentials remain owned by the shared CPP memory layer.
+- `CXPP_FRICTION_QUEUE` can opt into a local masked JSONL fallback for writer
+  failures. Without it, missing or unreachable ledger infrastructure is skipped
+  silently from the hook's perspective.
+
 Open uncertainty for E2 to verify with fixture hooks:
 
 - The official manual documents event names, matcher behavior, hook loading, and

--- a/lib/friction/__init__.py
+++ b/lib/friction/__init__.py
@@ -1,0 +1,12 @@
+"""Codex friction telemetry writer."""
+
+from .models import FrictionEvent, FrictionEventError
+from .writer import FrictionWriter, FrictionWriteResult, write_event
+
+__all__ = [
+    "FrictionEvent",
+    "FrictionEventError",
+    "FrictionWriteResult",
+    "FrictionWriter",
+    "write_event",
+]

--- a/lib/friction/__main__.py
+++ b/lib/friction/__main__.py
@@ -1,0 +1,6 @@
+"""Enable python -m lib.friction invocation."""
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/friction/cli.py
+++ b/lib/friction/cli.py
@@ -1,0 +1,93 @@
+"""CLI for the Codex friction writer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+from .hooks import event_from_hook_payload, load_payload
+from .models import FrictionEventError
+from .writer import FrictionWriter
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m lib.friction",
+        description="Codex friction telemetry writer",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    record = sub.add_parser("record", help="record a minimized friction event")
+    record.add_argument("--event-type", required=True)
+    record.add_argument("--summary", required=True)
+    record.add_argument("--event-source")
+    record.add_argument("--severity", default="warning")
+    record.add_argument("--repo")
+    record.add_argument("--branch")
+    record.add_argument("--issue")
+    _writer_args(record)
+
+    hook = sub.add_parser("hook", help="read a Codex hook payload from stdin")
+    hook.add_argument("--event", required=True, help="Codex hook event name")
+    hook.add_argument(
+        "--print-result",
+        action="store_true",
+        help="print the write result; hooks stay silent by default",
+    )
+    _writer_args(hook)
+
+    return parser
+
+
+def _writer_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--cpp-memory-cmd",
+        help="override cpp-memory command, e.g. 'python -m lib.cpp_memory'",
+    )
+    parser.add_argument("--queue", type=Path, help="optional masked local queue path")
+    parser.add_argument("--cwd", type=Path, help="working directory for cpp-memory")
+    parser.add_argument("--timeout", type=int, default=10)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    writer = FrictionWriter(
+        command=args.cpp_memory_cmd,
+        queue_path=args.queue,
+        cwd=args.cwd,
+        timeout=args.timeout,
+    )
+
+    try:
+        if args.command == "record":
+            result = writer.write({
+                "event_type": args.event_type,
+                "summary": args.summary,
+                "event_source": args.event_source,
+                "severity": args.severity,
+                "repo": args.repo,
+                "branch": args.branch,
+                "issue": args.issue,
+            })
+            print(json.dumps(result.public_dict(), sort_keys=True))
+            return 0
+
+        if args.command == "hook":
+            payload = load_payload(sys.stdin.read())
+            event = event_from_hook_payload(args.event, payload)
+            if event is None:
+                if args.print_result:
+                    print(json.dumps({"ok": True, "stored": "none"}))
+                return 0
+            result = writer.write(event)
+            if args.print_result:
+                print(json.dumps(result.public_dict(), sort_keys=True))
+            return 0
+    except FrictionEventError as exc:
+        print(json.dumps({"ok": False, "stored": "rejected", "reason": str(exc)}), file=sys.stderr)
+        return 2
+
+    return 1

--- a/lib/friction/hooks.py
+++ b/lib/friction/hooks.py
@@ -1,0 +1,170 @@
+"""Thin Codex hook adapters for friction telemetry."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Mapping
+
+from lib.creds.masking import OutputMasker
+
+from .models import FrictionEvent, truncate
+
+
+def load_payload(raw: str) -> dict[str, Any]:
+    """Parse hook JSON defensively."""
+
+    try:
+        payload = json.loads(raw or "{}")
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def event_from_hook_payload(
+    hook_event: str,
+    payload: Mapping[str, Any],
+    *,
+    masker: OutputMasker | None = None,
+) -> FrictionEvent | None:
+    """Extract an allowlisted event from a raw Codex hook payload.
+
+    Raw prompts, inputs, and outputs are never copied into the event. At most the
+    adapter stores derived metadata such as tool name, exit code, and whether the
+    masking layer detected a secret-shaped value.
+    """
+
+    event = hook_event.strip()
+    tool_name = _tool_name(payload)
+    repo = _optional_str(payload.get("repo") or payload.get("repository"))
+    branch = _optional_str(payload.get("branch"))
+    issue = payload.get("issue")
+
+    if event == "PermissionRequest":
+        return FrictionEvent.from_mapping({
+            "event_type": "approval_prompt",
+            "event_source": _source(event, tool_name),
+            "severity": "info",
+            "repo": repo,
+            "branch": branch,
+            "issue": issue,
+            "summary": f"Permission requested for {tool_name or 'unknown tool'}",
+        })
+
+    if event == "PostToolUse":
+        output = _tool_output(payload)
+        warnings = (masker or OutputMasker()).scan(output)
+        if warnings:
+            return FrictionEvent.from_mapping({
+                "event_type": "secret_mask_hit",
+                "event_source": _source(event, tool_name),
+                "severity": "warning",
+                "repo": repo,
+                "branch": branch,
+                "issue": issue,
+                "summary": f"Secret-shaped output detected from {tool_name or 'unknown tool'}",
+            })
+
+        if _tool_failed(payload):
+            return FrictionEvent.from_mapping({
+                "event_type": "command_failure",
+                "event_source": _source(event, tool_name),
+                "severity": "warning",
+                "repo": repo,
+                "branch": branch,
+                "issue": issue,
+                "summary": _failure_summary(payload, tool_name),
+            })
+
+    if event == "UserPromptSubmit":
+        prompt_text = _prompt_text(payload)
+        if (masker or OutputMasker()).scan(prompt_text):
+            return FrictionEvent.from_mapping({
+                "event_type": "secret_mask_hit",
+                "event_source": _source(event, None),
+                "severity": "warning",
+                "repo": repo,
+                "branch": branch,
+                "issue": issue,
+                "summary": "Secret-shaped user prompt content detected locally",
+            })
+
+    return None
+
+
+def _tool_name(payload: Mapping[str, Any]) -> str | None:
+    candidates = (
+        payload.get("tool_name"),
+        payload.get("toolName"),
+        payload.get("tool"),
+        payload.get("name"),
+    )
+    for candidate in candidates:
+        value = _optional_str(candidate)
+        if value:
+            return truncate(value, 80)
+    return None
+
+
+def _source(event: str, tool_name: str | None) -> str:
+    return f"hook:{event}:{tool_name}" if tool_name else f"hook:{event}"
+
+
+def _optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        text = str(value).strip()
+        return text or None
+    return None
+
+
+def _tool_output(payload: Mapping[str, Any]) -> str:
+    for key in ("tool_output", "output", "stdout", "stderr", "error"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+    result = payload.get("result")
+    if isinstance(result, dict):
+        parts = [result.get("stdout"), result.get("stderr"), result.get("error")]
+        return "\n".join(part for part in parts if isinstance(part, str))
+    return ""
+
+
+def _prompt_text(payload: Mapping[str, Any]) -> str:
+    for key in ("prompt", "user_prompt", "message", "text"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            return value
+    return ""
+
+
+def _tool_failed(payload: Mapping[str, Any]) -> bool:
+    for key in ("exit_code", "exitCode", "returncode", "return_code"):
+        value = payload.get(key)
+        if value not in (None, "", 0, "0"):
+            return True
+
+    status = str(payload.get("status") or payload.get("state") or "").lower()
+    if status in {"failed", "failure", "error"}:
+        return True
+
+    success = payload.get("success")
+    if success is False:
+        return True
+
+    result = payload.get("result")
+    if isinstance(result, dict):
+        return _tool_failed(result)
+
+    return bool(payload.get("tool_error") or payload.get("error"))
+
+
+def _failure_summary(payload: Mapping[str, Any], tool_name: str | None) -> str:
+    exit_code = None
+    for key in ("exit_code", "exitCode", "returncode", "return_code"):
+        if payload.get(key) not in (None, ""):
+            exit_code = payload.get(key)
+            break
+    if exit_code is not None:
+        return f"{tool_name or 'Tool'} failed with exit code {exit_code}"
+    return f"{tool_name or 'Tool'} reported an error"

--- a/lib/friction/models.py
+++ b/lib/friction/models.py
@@ -1,0 +1,272 @@
+"""Allowed event model for Codex friction telemetry."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from lib.creds.masking import OutputMasker
+
+HARNESS = "codex"
+
+ALLOWED_EVENT_FIELDS = {
+    "harness",
+    "repo",
+    "branch",
+    "issue",
+    "event_type",
+    "event_source",
+    "severity",
+    "summary",
+    "fingerprint",
+    "created_at",
+}
+
+FORBIDDEN_EVENT_FIELDS = {
+    "prompt",
+    "raw_prompt",
+    "tool_input",
+    "raw_tool_input",
+    "tool_output",
+    "raw_tool_output",
+    "environment",
+    "env",
+    "config",
+    "raw_config",
+    "session_history",
+    "session_history_path",
+    "session_log",
+    "stack_trace",
+    "traceback",
+}
+
+EVENT_TYPES = {
+    "approval_prompt",
+    "command_failure",
+    "tool_error",
+    "secret_mask_hit",
+    "ledger_write_failure",
+    "gate_failure",
+    "manual_intervention",
+    "red_output",
+    "other",
+}
+
+SEVERITIES = {"info", "warning", "error", "critical"}
+
+FIELD_LIMITS = {
+    "repo": 160,
+    "branch": 160,
+    "event_source": 160,
+    "summary": 512,
+    "fingerprint": 64,
+}
+
+
+class FrictionEventError(ValueError):
+    """Raised when a friction event violates the allowlisted schema."""
+
+
+def utc_now() -> str:
+    """Return an RFC3339-ish UTC timestamp with second precision."""
+
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def collapse_ws(value: str) -> str:
+    """Keep JSONL and ledger fields compact and single-line."""
+
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def truncate(value: str, limit: int) -> str:
+    """Truncate a string without hiding that truncation occurred."""
+
+    if len(value) <= limit:
+        return value
+    if limit <= 3:
+        return "." * max(0, limit)
+    return value[: limit - 3] + "..."
+
+
+def _optional_str(value: object, field: str) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        return str(value)
+    raise FrictionEventError(f"{field} must be a scalar string-like value")
+
+
+def _issue(value: object) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        parsed = int(str(value))
+    except (TypeError, ValueError) as exc:
+        raise FrictionEventError("issue must be an integer") from exc
+    if parsed < 0:
+        raise FrictionEventError("issue must be non-negative")
+    return parsed
+
+
+@dataclass(frozen=True)
+class FrictionEvent:
+    """A minimized, masked-ready friction event.
+
+    `harness` is fixed to `codex`; caller-provided values are ignored so every
+    ledger sighting can be attributed reliably.
+    """
+
+    event_type: str
+    summary: str
+    event_source: str | None = None
+    repo: str | None = None
+    branch: str | None = None
+    issue: int | None = None
+    severity: str = "warning"
+    created_at: str | None = None
+    fingerprint: str | None = None
+    harness: str = HARNESS
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "FrictionEvent":
+        """Build an event from an allowlisted mapping.
+
+        Raw hook payloads must be reduced by an adapter first; this constructor
+        rejects raw prompt/tool/config fields even if they appear alongside
+        allowed fields.
+        """
+
+        keys = set(data)
+        forbidden = keys & FORBIDDEN_EVENT_FIELDS
+        if forbidden:
+            joined = ", ".join(sorted(forbidden))
+            raise FrictionEventError(f"forbidden event field(s): {joined}")
+
+        unknown = keys - ALLOWED_EVENT_FIELDS
+        if unknown:
+            joined = ", ".join(sorted(unknown))
+            raise FrictionEventError(f"unknown event field(s): {joined}")
+
+        event_type = _optional_str(data.get("event_type"), "event_type")
+        if not event_type:
+            raise FrictionEventError("event_type is required")
+        event_type = event_type.strip().lower().replace("-", "_")
+        if event_type not in EVENT_TYPES:
+            raise FrictionEventError(f"unknown event_type: {event_type!r}")
+
+        summary = _optional_str(data.get("summary"), "summary")
+        if not summary or not summary.strip():
+            raise FrictionEventError("summary is required")
+
+        severity = (_optional_str(data.get("severity"), "severity") or "warning").strip().lower()
+        if severity not in SEVERITIES:
+            raise FrictionEventError(f"unknown severity: {severity!r}")
+
+        return cls(
+            event_type=event_type,
+            summary=summary,
+            event_source=_optional_str(data.get("event_source"), "event_source"),
+            repo=_optional_str(data.get("repo"), "repo"),
+            branch=_optional_str(data.get("branch"), "branch"),
+            issue=_issue(data.get("issue")),
+            severity=severity,
+            created_at=_optional_str(data.get("created_at"), "created_at") or utc_now(),
+            fingerprint=_optional_str(data.get("fingerprint"), "fingerprint"),
+            harness=HARNESS,
+        )
+
+    def masked(self, masker: OutputMasker | None = None) -> "FrictionEvent":
+        """Return the event after exact-value/pattern masking and truncation."""
+
+        masker = masker or OutputMasker()
+
+        def clean(field: str, value: str | None) -> str | None:
+            if value is None:
+                return None
+            masked = collapse_ws(masker.mask(value))
+            return truncate(masked, FIELD_LIMITS.get(field, 512))
+
+        masked_event = replace(
+            self,
+            event_source=clean("event_source", self.event_source),
+            repo=clean("repo", self.repo),
+            branch=clean("branch", self.branch),
+            summary=clean("summary", self.summary) or "",
+            created_at=clean("created_at", self.created_at) or utc_now(),
+            fingerprint=None,
+            harness=HARNESS,
+        )
+        return replace(masked_event, fingerprint=masked_event.compute_fingerprint())
+
+    def fingerprint_material(self) -> dict[str, object]:
+        """Fields used for deduplication, after masking.
+
+        `created_at` is deliberately excluded so repeated sightings of the same
+        friction event converge.
+        """
+
+        return {
+            "harness": HARNESS,
+            "repo": self.repo or "",
+            "branch": self.branch or "",
+            "issue": self.issue,
+            "event_type": self.event_type,
+            "event_source": self.event_source or "",
+            "severity": self.severity,
+            "summary": self.summary,
+        }
+
+    def compute_fingerprint(self) -> str:
+        encoded = json.dumps(
+            self.fingerprint_material(),
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def public_dict(self) -> dict[str, object]:
+        """Serialize only allowed, already-masked event fields."""
+
+        return {
+            "harness": HARNESS,
+            "repo": self.repo,
+            "branch": self.branch,
+            "issue": self.issue,
+            "event_type": self.event_type,
+            "event_source": self.event_source,
+            "severity": self.severity,
+            "summary": self.summary,
+            "fingerprint": self.fingerprint,
+            "created_at": self.created_at,
+        }
+
+    def ledger_title(self) -> str:
+        """Stable title passed to cpp-memory for its own dedup model."""
+
+        source = f" [{self.event_source}]" if self.event_source else ""
+        return truncate(f"Codex {self.event_type}{source}: {self.summary}", 180)
+
+    def ledger_body(self) -> str:
+        """Body passed to cpp-memory, intentionally restricted to allowed fields."""
+
+        fields = self.public_dict()
+        lines = [
+            "Codex friction telemetry event.",
+            "",
+            f"- event_type: {fields['event_type']}",
+            f"- event_source: {fields['event_source'] or ''}",
+            f"- severity: {fields['severity']}",
+            f"- repo: {fields['repo'] or ''}",
+            f"- branch: {fields['branch'] or ''}",
+            f"- issue: {fields['issue'] or ''}",
+            f"- harness: {HARNESS}",
+            f"- fingerprint: {fields['fingerprint']}",
+            "",
+            fields["summary"] or "",
+        ]
+        return "\n".join(str(line) for line in lines)

--- a/lib/friction/writer.py
+++ b/lib/friction/writer.py
@@ -1,0 +1,224 @@
+"""Fail-open writer for Codex friction telemetry."""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from lib.creds.masking import OutputMasker
+
+from .models import HARNESS, FrictionEvent, FrictionEventError, truncate, utc_now
+
+CPP_MEMORY_ENV = "CXPP_CPP_MEMORY_CMD"
+QUEUE_ENV = "CXPP_FRICTION_QUEUE"
+
+Runner = Callable[
+    [Sequence[str], Path | None, Mapping[str, str], int],
+    subprocess.CompletedProcess[str],
+]
+
+
+@dataclass(frozen=True)
+class FrictionWriteResult:
+    """Result of a friction write attempt.
+
+    `ok` means the caller workflow may continue. Ledger outages and missing
+    clients are represented as `ok=True` with a non-shared `stored` value.
+    """
+
+    ok: bool
+    stored: str
+    event: dict[str, object] | None = None
+    ledger: dict[str, object] | None = None
+    reason: str | None = None
+    local_path: str | None = None
+
+    def public_dict(self) -> dict[str, object]:
+        return {
+            "ok": self.ok,
+            "stored": self.stored,
+            "event": self.event,
+            "ledger": self.ledger,
+            "reason": self.reason,
+            "local_path": self.local_path,
+        }
+
+
+def _default_runner(
+    argv: Sequence[str],
+    cwd: Path | None,
+    env: Mapping[str, str],
+    timeout: int,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(argv),
+        cwd=str(cwd) if cwd else None,
+        env=dict(env),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _resolve_command(command: Sequence[str] | str | None) -> list[str] | None:
+    if command:
+        return shlex.split(command) if isinstance(command, str) else list(command)
+
+    env_command = os.environ.get(CPP_MEMORY_ENV, "").strip()
+    if env_command:
+        return shlex.split(env_command)
+
+    found = shutil.which("cpp-memory")
+    if found:
+        return [found]
+
+    return None
+
+
+class FrictionWriter:
+    """Validate, mask, fingerprint, and write Codex friction events."""
+
+    def __init__(
+        self,
+        *,
+        command: Sequence[str] | str | None = None,
+        queue_path: Path | str | None = None,
+        cwd: Path | str | None = None,
+        timeout: int = 10,
+        masker: OutputMasker | None = None,
+        runner: Runner | None = None,
+        env: Mapping[str, str] | None = None,
+    ) -> None:
+        self.command = _resolve_command(command)
+        self.queue_path = Path(queue_path) if queue_path else self._queue_from_env()
+        self.cwd = Path(cwd) if cwd else None
+        self.timeout = timeout
+        self.masker = masker or OutputMasker()
+        self.runner = runner or _default_runner
+        self.env = dict(os.environ if env is None else env)
+        self.env["CPP_HARNESS"] = HARNESS
+
+    @staticmethod
+    def _queue_from_env() -> Path | None:
+        value = os.environ.get(QUEUE_ENV, "").strip()
+        return Path(value) if value else None
+
+    def write(self, data: Mapping[str, Any] | FrictionEvent) -> FrictionWriteResult:
+        """Write an event and never fail because the ledger is down."""
+
+        event = data if isinstance(data, FrictionEvent) else FrictionEvent.from_mapping(data)
+        event = event.masked(self.masker)
+
+        if not self.command:
+            return self._fallback(event, reason="cpp-memory unavailable")
+
+        argv = [
+            *self.command,
+            "record",
+            "--class",
+            "infra_trap",
+            "--scope",
+            "knowledge",
+            "--title",
+            event.ledger_title(),
+            "--body",
+            event.ledger_body(),
+            "--confidence",
+            "0.8",
+            "--harness",
+            HARNESS,
+        ]
+
+        try:
+            proc = self.runner(argv, self.cwd, self.env, self.timeout)
+        except (FileNotFoundError, subprocess.SubprocessError, OSError) as exc:
+            return self._fallback(event, reason=f"cpp-memory failed: {self._safe_error(str(exc))}")
+
+        stdout = self.masker.mask(proc.stdout or "").strip()
+        stderr = self.masker.mask(proc.stderr or "").strip()
+
+        if proc.returncode != 0:
+            detail = stderr or stdout or f"exit {proc.returncode}"
+            return self._fallback(event, reason=f"cpp-memory failed: {self._safe_error(detail)}")
+
+        ledger = self._parse_ledger(stdout)
+        if ledger.get("harness") != HARNESS:
+            ledger["harness"] = HARNESS
+
+        return FrictionWriteResult(
+            ok=True,
+            stored=str(ledger.get("stored") or "shared"),
+            event=event.public_dict(),
+            ledger=ledger,
+        )
+
+    def _parse_ledger(self, stdout: str) -> dict[str, object]:
+        if not stdout:
+            return {"stored": "shared", "harness": HARNESS}
+        try:
+            parsed = json.loads(stdout)
+        except json.JSONDecodeError:
+            return {
+                "stored": "shared",
+                "harness": HARNESS,
+                "raw": truncate(stdout, 512),
+            }
+        return parsed if isinstance(parsed, dict) else {"stored": "shared", "harness": HARNESS}
+
+    def _fallback(self, event: FrictionEvent, *, reason: str) -> FrictionWriteResult:
+        local_path = self._append_local(event, reason)
+        return FrictionWriteResult(
+            ok=True,
+            stored="local-buffer" if local_path else "skipped",
+            event=event.public_dict(),
+            reason=reason,
+            local_path=str(local_path) if local_path else None,
+        )
+
+    def _append_local(self, event: FrictionEvent, reason: str) -> Path | None:
+        if not self.queue_path:
+            return None
+
+        record = {
+            "created_at": utc_now(),
+            "event_type": "ledger_write_failure",
+            "harness": HARNESS,
+            "reason": self._safe_error(reason),
+            "event": event.public_dict(),
+        }
+        line = json.dumps(record, sort_keys=True, separators=(",", ":"))
+
+        try:
+            self.queue_path.parent.mkdir(parents=True, exist_ok=True)
+            fd = os.open(self.queue_path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+            with os.fdopen(fd, "a", encoding="utf-8") as handle:
+                handle.write(line + "\n")
+        except OSError:
+            return None
+        return self.queue_path
+
+    def _safe_error(self, value: str) -> str:
+        return truncate(self.masker.mask(value).replace("\n", " "), 512)
+
+
+def write_event(data: Mapping[str, Any] | FrictionEvent, **kwargs: Any) -> FrictionWriteResult:
+    """Convenience wrapper around :class:`FrictionWriter`."""
+
+    return FrictionWriter(**kwargs).write(data)
+
+
+def reject_event(data: Mapping[str, Any]) -> FrictionWriteResult:
+    """Return a structured rejection for CLI callers."""
+
+    try:
+        FrictionEvent.from_mapping(data)
+    except FrictionEventError as exc:
+        return FrictionWriteResult(ok=False, stored="rejected", reason=str(exc))
+    return FrictionWriteResult(ok=False, stored="rejected", reason="event was not rejected")

--- a/scripts/codex-friction-hook.py
+++ b/scripts/codex-friction-hook.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""Codex hook entrypoint for fail-open friction telemetry."""
+
+from __future__ import annotations
+
+import sys
+
+from lib.friction.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main(["hook", *sys.argv[1:]]))

--- a/tests/test_friction_writer.py
+++ b/tests/test_friction_writer.py
@@ -1,0 +1,167 @@
+"""Tests for the Codex friction telemetry writer."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Mapping, Sequence
+
+import pytest
+
+from lib.creds.masking import OutputMasker
+from lib.friction.hooks import event_from_hook_payload
+from lib.friction.models import FrictionEvent, FrictionEventError
+from lib.friction.writer import FrictionWriter
+
+
+class FakeRunner:
+    def __init__(
+        self,
+        *,
+        returncode: int = 0,
+        stdout: str = '{"stored":"shared","harness":"codex","fingerprint":"cpp-fp"}',
+        stderr: str = "",
+    ) -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+        self.calls: list[Sequence[str]] = []
+        self.env: Mapping[str, str] | None = None
+
+    def __call__(
+        self,
+        argv: Sequence[str],
+        cwd: Path | None,
+        env: Mapping[str, str],
+        timeout: int,
+    ) -> subprocess.CompletedProcess[str]:
+        self.calls.append(list(argv))
+        self.env = dict(env)
+        return subprocess.CompletedProcess(list(argv), self.returncode, self.stdout, self.stderr)
+
+
+def _event(summary: str = "psql failed with password=supersecret") -> dict[str, object]:
+    return {
+        "event_type": "command_failure",
+        "event_source": "hook:PostToolUse:Bash",
+        "severity": "warning",
+        "repo": "cooneycw/codex-power-pack",
+        "branch": "issue-95-test",
+        "issue": 95,
+        "summary": summary,
+    }
+
+
+def test_writer_masks_event_before_cpp_memory_call() -> None:
+    runner = FakeRunner()
+    writer = FrictionWriter(command=["cpp-memory"], runner=runner, env={})
+
+    result = writer.write(_event())
+
+    assert result.ok is True
+    assert result.stored == "shared"
+    assert runner.env is not None
+    assert runner.env["CPP_HARNESS"] == "codex"
+    argv_text = "\n".join(runner.calls[0])
+    assert "supersecret" not in argv_text
+    assert "password=****" in argv_text
+    assert "--harness" in runner.calls[0]
+    assert "codex" in runner.calls[0]
+
+
+def test_writer_overrides_caller_harness() -> None:
+    runner = FakeRunner(stdout='{"stored":"shared","harness":"claude"}')
+    writer = FrictionWriter(command=["cpp-memory"], runner=runner, env={})
+
+    result = writer.write({**_event(), "harness": "claude"})
+
+    assert result.event is not None
+    assert result.event["harness"] == "codex"
+    assert result.ledger is not None
+    assert result.ledger["harness"] == "codex"
+
+
+def test_forbidden_raw_fields_are_rejected() -> None:
+    with pytest.raises(FrictionEventError, match="forbidden event field"):
+        FrictionEvent.from_mapping({
+            "event_type": "command_failure",
+            "summary": "bad",
+            "tool_output": "raw password=supersecret",
+        })
+
+
+def test_oversized_summary_is_truncated_after_masking() -> None:
+    runner = FakeRunner()
+    writer = FrictionWriter(command=["cpp-memory"], runner=runner, env={})
+    long_secret = "password=supersecret " + "x" * 800
+
+    result = writer.write(_event(long_secret))
+
+    assert result.event is not None
+    summary = str(result.event["summary"])
+    assert len(summary) <= 512
+    assert "supersecret" not in summary
+    assert "..." in summary
+
+
+def test_ledger_down_fails_open_and_writes_masked_local_buffer(tmp_path: Path) -> None:
+    runner = FakeRunner(returncode=1, stderr="dial postgres://user:secret@db/internal failed")
+    queue = tmp_path / "friction-failures.jsonl"
+    writer = FrictionWriter(command=["cpp-memory"], runner=runner, queue_path=queue, env={})
+
+    result = writer.write(_event())
+
+    assert result.ok is True
+    assert result.stored == "local-buffer"
+    assert result.local_path == str(queue)
+    line = queue.read_text().strip()
+    assert "supersecret" not in line
+    assert "secret@db" not in line
+    assert "postgres://user:****@db" in line
+    record = json.loads(line)
+    assert record["event_type"] == "ledger_write_failure"
+    assert record["harness"] == "codex"
+
+
+def test_missing_cpp_memory_is_skipped_without_error(tmp_path: Path) -> None:
+    writer = FrictionWriter(command=["definitely-not-cpp-memory"], queue_path=tmp_path / "q.jsonl", env={})
+    # Simulate post-resolution failure from the OS path, not test process PATH.
+    writer.command = None
+
+    result = writer.write(_event())
+
+    assert result.ok is True
+    assert result.stored == "local-buffer"
+
+
+def test_permission_hook_extracts_minimized_event() -> None:
+    event = event_from_hook_payload(
+        "PermissionRequest",
+        {
+            "tool_name": "Bash",
+            "tool_input": {"command": "echo password=supersecret"},
+            "repo": "cooneycw/codex-power-pack",
+            "branch": "issue-95-test",
+        },
+    )
+
+    assert event is not None
+    masked = event.masked(OutputMasker())
+    assert masked.event_type == "approval_prompt"
+    assert masked.summary == "Permission requested for Bash"
+    assert "supersecret" not in json.dumps(masked.public_dict())
+
+
+def test_post_tool_secret_hit_does_not_copy_raw_output() -> None:
+    event = event_from_hook_payload(
+        "PostToolUse",
+        {
+            "tool_name": "Bash",
+            "tool_output": "connecting with postgresql://user:secretpass@db/app",
+        },
+    )
+
+    assert event is not None
+    assert event.event_type == "secret_mask_hit"
+    assert "secretpass" not in event.summary


### PR DESCRIPTION
## Summary
- Add `lib/friction` with allowlisted Codex friction events, masking, fingerprinting, and fail-open delegation to `cpp-memory record --harness codex`.
- Add a Codex hook entrypoint and update `.codex/hooks.json` to current matcher-group syntax for PermissionRequest, PostToolUse, and UserPromptSubmit capture.
- Document the E2 writer surface and environment knobs.

## Validation
- `make verify`

Closes #95