### PR TITLE
docs(release): document pinned marketplace process (Closes #79)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,8 @@ tool integrations, with client-side pointers documented in `docs/HOST_MANAGED.md
 - Keep marketplace entries pinned for release use. Repo marketplace entries under
   `.agents/plugins/marketplace.json` should declare pinning policy and be
   installed with `codex plugin marketplace add --ref <tag-or-sha>`.
+- Use `docs/release-process.md` for release PRs, signed tag or SHA installs,
+  upgrade transcripts, rollback refs, and changelog discipline.
 - prefer `rg` for repo search
 
 ## Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Documented the pinned marketplace release, upgrade, and rollback process for
+  Codex plugin releases (#79).
+
 ### Removed
 
 - Retired the legacy `lib/spec_bridge/` package and its dedicated tests; spec-kit remains the authoring path.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ The catalog currently exposes per-family packages for `project`, `spec`,
 `cxpp`. `spec` and `cxpp` are scaffolded package slots for the follow-up family
 implementation issues.
 
+Release installs and upgrades follow `docs/release-process.md`: use a signed
+release tag or immutable commit SHA, record the resolved SHA, and preserve
+rollback refs in the release notes.
+
 See `docs/plugin-marketplace-project-e2e.md` for the issue #77 project-plugin
 E2E transcript.
 

--- a/docs/plugin-marketplace-project-e2e.md
+++ b/docs/plugin-marketplace-project-e2e.md
@@ -209,7 +209,8 @@ skills/project-init/reference.md
 skills/project-init/scripts/speckit-tasks-to-issues.sh
 ```
 
-For release use, replace the branch ref above with a release tag or commit SHA:
+For release use, follow `docs/release-process.md` and replace the branch ref
+above with a signed release tag or immutable commit SHA:
 
 ```bash
 codex plugin marketplace add cooneycw/codex-power-pack \

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,119 @@
+# Release Process
+
+Codex Power Pack releases are distributed through the repo marketplace and
+per-family Codex plugins. Release installs must be reproducible: users install a
+reviewed release tag or immutable commit SHA, not a moving branch.
+
+## Versioning
+
+- Use semantic versioning for repository releases.
+- Bump the major version for breaking distribution or plugin-shape changes.
+- Bump the minor version for new plugin families, new skills, or new supported
+  install surfaces that are backwards compatible.
+- Bump the patch version for bug fixes, documentation corrections, and
+  non-breaking metadata updates.
+- Keep each plugin manifest version aligned with the release when the plugin's
+  installed payload or user-visible metadata changes.
+
+## Release PR Checklist
+
+Every release PR must include:
+
+1. Marketplace entry diff for `.agents/plugins/marketplace.json`.
+2. Plugin manifest diff for every changed `plugins/<family>/.codex-plugin/plugin.json`.
+3. Generated skill diff, if `.codex/skills/` or packaged `plugins/<family>/skills/`
+   changed.
+4. Hook, MCP config, and app config diff, if any plugin bundles those surfaces.
+5. `CHANGELOG.md` entries moved from `Unreleased` into the release section.
+6. The planned signed release tag and the resolved commit SHA that the tag points
+   to.
+7. A fresh Codex config upgrade transcript showing marketplace add, plugin add,
+   and installed plugin list output.
+8. Rollback notes recording the previous plugin ref, new plugin ref, and the
+   reason for the upgrade.
+
+Run `make verify` before tagging. If generated skill sources changed, run the
+repo drift gates before opening the release PR.
+
+## Tagging
+
+Create release tags from the merge commit that passed verification on `main`.
+Prefer a signed release tag:
+
+```bash
+git fetch origin main --tags
+git checkout main
+git pull origin main
+git tag -s vX.Y.Z -m "vX.Y.Z"
+git rev-parse vX.Y.Z^{commit}
+git push origin vX.Y.Z
+```
+
+Record the resolved commit SHA in the release notes and upgrade transcript.
+Branch refs are only for local development and dogfood. They do not satisfy
+release acceptance.
+
+## Installing A Release
+
+Install only the plugin families needed for the current workflow. Include
+`.agents` plus every selected `plugins/<family>` path in the sparse checkout.
+
+```bash
+codex plugin marketplace add cooneycw/codex-power-pack \
+  --ref vX.Y.Z \
+  --sparse .agents \
+  --sparse plugins/project \
+  --sparse plugins/github
+codex plugin add project@codex-power-pack
+codex plugin add github@codex-power-pack
+```
+
+For maximum reproducibility, use the resolved commit SHA instead of the tag:
+
+```bash
+codex plugin marketplace add cooneycw/codex-power-pack \
+  --ref <immutable-commit-sha> \
+  --sparse .agents \
+  --sparse plugins/project
+codex plugin add project@codex-power-pack
+```
+
+The marketplace pinning policy accepts immutable commit SHAs and signed release
+tags, resolved through `codex plugin marketplace add --ref`.
+
+## Upgrade Procedure
+
+1. Read the release notes and `CHANGELOG.md`.
+2. Record the currently installed marketplace ref and plugin versions with
+   `codex plugin list --json`.
+3. Add or update the marketplace source with `codex plugin marketplace add` and
+   the new `--ref`.
+4. Reinstall only the selected family plugins with `codex plugin add`.
+5. Confirm the installed plugin versions and marketplace source with
+   `codex plugin list --json`.
+6. Run a workflow smoke test for every upgraded family.
+7. Attach the upgrade transcript to the release PR or release notes.
+
+The transcript should be created from a fresh Codex config for release
+acceptance so cached state does not hide install defects.
+
+## Rollback
+
+Rollback is the same operation with the previous pinned ref:
+
+```bash
+codex plugin marketplace add cooneycw/codex-power-pack \
+  --ref <previous-plugin-ref> \
+  --sparse .agents \
+  --sparse plugins/project
+codex plugin add project@codex-power-pack
+```
+
+Every release note must preserve:
+
+- previous plugin ref
+- new plugin ref
+- resolved commit SHA for the new ref
+- reason for the upgrade
+- reason for rollback, if a rollback is performed
+

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -1,0 +1,77 @@
+"""Release process checks for pinned marketplace distribution."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RELEASE_DOC = REPO_ROOT / "docs" / "release-process.md"
+MARKETPLACE_PATH = REPO_ROOT / ".agents" / "plugins" / "marketplace.json"
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_release_process_documents_version_and_tag_gates() -> None:
+    text = read_text(RELEASE_DOC).lower()
+
+    for required in [
+        "semantic versioning",
+        "major version",
+        "minor version",
+        "patch version",
+        "signed release tag",
+        "resolved commit sha",
+        "git tag -s",
+        "make verify",
+        "changelog.md",
+    ]:
+        assert required in text
+
+
+def test_release_process_documents_explicit_upgrade_and_rollback() -> None:
+    text = read_text(RELEASE_DOC).lower()
+
+    for required in [
+        "codex plugin marketplace add cooneycw/codex-power-pack",
+        "--ref",
+        "codex plugin add",
+        "fresh codex config",
+        "upgrade transcript",
+        "rollback",
+        "previous plugin ref",
+        "new plugin ref",
+    ]:
+        assert required in text
+
+
+def test_release_process_matches_marketplace_pinning_policy() -> None:
+    text = read_text(RELEASE_DOC).lower()
+    marketplace = load_json(MARKETPLACE_PATH)
+
+    accepted_refs = {
+        accepted_ref
+        for entry in marketplace["plugins"]
+        for accepted_ref in entry["pinning"]["acceptedRefs"]
+    }
+
+    assert accepted_refs == {"immutable-commit-sha", "signed-release-tag"}
+    for accepted_ref in accepted_refs:
+        assert accepted_ref.replace("-", " ") in text or accepted_ref in text
+    assert "codex plugin marketplace add --ref" in text
+
+
+def test_distribution_docs_link_release_process() -> None:
+    for relative in [
+        "README.md",
+        "AGENTS.md",
+        "docs/plugin-marketplace-project-e2e.md",
+    ]:
+        assert "docs/release-process.md" in read_text(REPO_ROOT / relative)


### PR DESCRIPTION
## Summary
- Add a canonical release process for pinned Codex plugin marketplace releases.
- Link the release process from README, AGENTS, and the project marketplace E2E doc.
- Add tests that keep release docs aligned with marketplace pinning, upgrade, rollback, and changelog gates.

## Validation
- `uv run pytest tests/test_release_process.py tests/test_project_plugin_marketplace.py`
- `make update_docs`
- `make verify`

Closes #79