### PR TITLE
Dogfood friction retro proposals

### DIFF
--- a/docs/friction-retro-e2e.md
+++ b/docs/friction-retro-e2e.md
@@ -1,0 +1,33 @@
+# Friction retro dogfood
+
+This repository exercised the Codex-native friction retrospective against its
+existing, legacy `.claude/friction.jsonl` queue on 2026-07-10. The queue was
+read locally; no event content was copied into this record or sent elsewhere.
+
+## Result
+
+```text
+python3 -m lib.friction.retro --path .claude/friction.jsonl
+```
+
+returned one non-sensitive proposal:
+
+- kind: `validation-gate`
+- evidence count: `8`
+- action: add a deterministic preflight or canary check to the Makefile and CI.
+
+Legacy rows can have changing, hook-provided wording. The analyzer therefore
+uses exact fingerprints when available and falls back to a repeated allowlisted
+failure class only when no exact match is found. It never includes source summaries
+or any other raw event content in its proposal.
+
+The proposal is advisory. Applying a gate remains an explicit user decision;
+the retro command does not modify the ledger, Makefile, CI, or any workflow.
+
+## Verification
+
+```text
+make verify
+```
+
+completed successfully after the run.

--- a/lib/friction/retro.py
+++ b/lib/friction/retro.py
@@ -59,6 +59,30 @@ def analyze_events(events: Iterable[Mapping[str, Any]], repeat_threshold: int = 
             )
             break
 
+    # Exact fingerprints are the strongest same-root-cause signal. Some legacy
+    # hooks, however, attach volatile wording to every failure. When a failure
+    # class itself repeats, propose a generic preflight/triage gate without
+    # pretending the individual summaries are identical or exposing them.
+    if not any(proposal.kind == "validation-gate" for proposal in proposals):
+        type_counts: dict[str, int] = {}
+        for event in normalized:
+            if event.event_type in REPEATED_FAILURE_TYPES:
+                type_counts[event.event_type] = type_counts.get(event.event_type, 0) + 1
+        for event_type, count in type_counts.items():
+            if count >= repeat_threshold:
+                proposals.append(
+                    RetroProposal(
+                        kind="validation-gate",
+                        title=f"Add a preflight gate for repeated {event_type.replace('_', ' ')} events",
+                        action=(
+                            "Add a deterministic preflight or canary check to the Makefile and "
+                            "make CI run it before the affected workflow."
+                        ),
+                        evidence_count=count,
+                    )
+                )
+                break
+
     bootstrap_count = sum(1 for event in normalized if BOOTSTRAP_PATTERN.search(event.summary))
     if bootstrap_count:
         proposals.append(

--- a/tests/test_friction_retro.py
+++ b/tests/test_friction_retro.py
@@ -57,6 +57,16 @@ def test_retro_normalizes_legacy_codex_jsonl_rows(tmp_path) -> None:
     assert any(item.kind == "validation-gate" for item in proposals)
 
 
+def test_repeated_failure_class_proposes_gate_when_legacy_summaries_vary() -> None:
+    proposals = analyze_events([
+        _event("first volatile failure"),
+        _event("second volatile failure"),
+    ])
+
+    proposal = next(item for item in proposals if item.kind == "validation-gate")
+    assert proposal.evidence_count == 2
+
+
 def test_retro_skill_uses_codex_queue_and_requires_confirmation() -> None:
     text = (REPO_ROOT / ".codex" / "skills" / "self-improvement-retro" / "SKILL.md").read_text()
     assert ".codex/friction.jsonl" in text

--- a/tests/test_friction_retro_e2e.py
+++ b/tests/test_friction_retro_e2e.py
@@ -1,0 +1,13 @@
+"""Keep the recorded friction-retro dogfood outcome safe and actionable."""
+
+from pathlib import Path
+
+
+def test_friction_retro_dogfood_records_safe_real_ledger_result() -> None:
+    text = (Path(__file__).resolve().parents[1] / "docs" / "friction-retro-e2e.md").read_text()
+
+    assert ".claude/friction.jsonl" in text
+    assert "`8`" in text
+    assert "validation-gate" in text
+    assert "explicit user decision" in text
+    assert "source summaries" in text


### PR DESCRIPTION
## Summary
- derive a safe preflight proposal from recurring legacy failure classes when volatile summaries prevent exact fingerprint matching
- record a real local legacy-ledger dogfood result without exposing telemetry
- keep the proposal advisory and regression-tested

## Validation
- `make verify`

Closes #96