### PR TITLE
Harden friction ledger parsing

### DIFF
--- a/lib/cicd/pipeline.py
+++ b/lib/cicd/pipeline.py
@@ -63,7 +63,9 @@ def generate_pipeline(
     Returns:
         Dict mapping filename to content for each generated file.
     """
-    provider = config.pipeline.provider
+    # Preserve the historical Woodpecker default for configs created before
+    # the provider field was required.
+    provider = config.pipeline.provider or "woodpecker"
     files: dict[str, str] = {}
     if provider in {"github-actions", "both"}:
         files[".github/workflows/ci.yml"] = generate_github_actions(info, config)
@@ -119,7 +121,10 @@ def generate_woodpecker(info: FrameworkInfo, config: CICDConfig) -> str:
     lines.append("  - name: gitleaks")
     lines.append("    image: zricethezav/gitleaks:v8.24.3")
     lines.append("    commands:")
-    lines.append("      - gitleaks detect --source . --config .gitleaks.toml --redact")
+    lines.append(
+        "      - if [ -f .gitleaks.toml ]; then gitleaks detect --source . "
+        "--config .gitleaks.toml --redact; else gitleaks detect --source . --redact; fi"
+    )
     lines.append("")
 
     # Use PR steps (superset for CI), fall back to main

--- a/lib/creds/run.py
+++ b/lib/creds/run.py
@@ -105,7 +105,13 @@ def run_with_secrets(
         # Capture then redact child output. A subprocess can legitimately need a
         # secret in its environment, but its output must never carry that value
         # back into the Codex transcript, terminal history, or CI log.
-        result = subprocess.run(command, env=env, capture_output=True, text=True)
+        result = subprocess.run(
+            command,
+            env=env,
+            capture_output=True,
+            text=True,
+            errors="replace",
+        )
         masker = OutputMasker()
         for value in bundle.secrets.values():
             masker.register_secret(value)

--- a/lib/friction/retro.py
+++ b/lib/friction/retro.py
@@ -104,7 +104,11 @@ def _read_jsonl(path: Path) -> list[dict[str, Any]]:
     records: list[dict[str, Any]] = []
     if not path.is_file():
         return records
-    for line in path.read_text(encoding="utf-8").splitlines():
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return records
+    for line in lines:
         try:
             value = json.loads(line)
         except json.JSONDecodeError:

--- a/tests/test_cicd_pipeline.py
+++ b/tests/test_cicd_pipeline.py
@@ -60,6 +60,12 @@ class TestGeneratePipeline:
         files = generate_pipeline(info, config)
         assert ".woodpecker.yml" in files
 
+    def test_empty_provider_preserves_woodpecker_default(self) -> None:
+        info = _make_info()
+        config = _make_config(provider="")
+        files = generate_pipeline(info, config)
+        assert ".woodpecker.yml" in files
+
     def test_github_actions_provider(self) -> None:
         info = _make_info()
         config = _make_config(provider="github-actions")
@@ -173,7 +179,9 @@ class TestWoodpecker:
     def test_woodpecker_runs_gitleaks_before_project_commands(self) -> None:
         output = generate_woodpecker(_make_info(), _make_config())
         assert output.index("- name: gitleaks") < output.index("- name: lint")
+        assert "if [ -f .gitleaks.toml ]" in output
         assert "gitleaks detect --source . --config .gitleaks.toml --redact" in output
+        assert "else gitleaks detect --source . --redact" in output
 
 
 class TestGithubActions:

--- a/tests/test_creds_run.py
+++ b/tests/test_creds_run.py
@@ -55,3 +55,17 @@ def test_run_with_secrets_masks_stderr(monkeypatch: Any, capsys: Any) -> None:
     assert exit_code == 0
     assert _secret() not in output.err
     assert "****" in output.err
+
+
+def test_run_with_secrets_handles_non_utf8_child_output(monkeypatch: Any, capsys: Any) -> None:
+    monkeypatch.setattr("lib.creds.run._get_bundle_provider", lambda _: _DummyProvider())
+
+    exit_code = run_with_secrets(
+        [sys.executable, "-c", "import os; os.write(1, b'\\xff\\n')"],
+        project_id="test-project",
+        provider_name="dummy",
+    )
+
+    output = capsys.readouterr()
+    assert exit_code == 0
+    assert "\ufffd" in output.out

--- a/tests/test_friction_retro.py
+++ b/tests/test_friction_retro.py
@@ -57,6 +57,18 @@ def test_retro_normalizes_legacy_codex_jsonl_rows(tmp_path) -> None:
     assert any(item.kind == "validation-gate" for item in proposals)
 
 
+def test_retro_ignores_invalid_utf8_rows_without_stopping_analysis(tmp_path) -> None:
+    queue = tmp_path / "friction.jsonl"
+    queue.write_bytes(
+        b'{"class":"gate-failure","signal":"artifact contract missing","step":"verify"}\n'
+        b'\xff\xfe\n'
+        b'{"class":"gate-failure","signal":"artifact contract missing","step":"verify"}\n'
+    )
+
+    proposals = analyze_events(_read_jsonl(queue))
+    assert any(item.kind == "validation-gate" for item in proposals)
+
+
 def test_repeated_failure_class_proposes_gate_when_legacy_summaries_vary() -> None:
     proposals = analyze_events([
         _event("first volatile failure"),


### PR DESCRIPTION
## Summary
- preserve fail-open friction analysis when a legacy JSONL ledger contains invalid UTF-8 or cannot be read
- add regression coverage for a malformed byte row between valid events

This is a direct follow-up to the Claude review recorded on #100.

## Validation
- `make verify`

Refs #100