### PR TITLE
Force UTF-8 masking input

### DIFF
--- a/lib/creds/run.py
+++ b/lib/creds/run.py
@@ -110,6 +110,7 @@ def run_with_secrets(
             env=env,
             capture_output=True,
             text=True,
+            encoding="utf-8",
             errors="replace",
         )
         masker = OutputMasker()

--- a/tests/test_creds_run.py
+++ b/tests/test_creds_run.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 import sys
 from typing import Any
 
@@ -69,3 +70,18 @@ def test_run_with_secrets_handles_non_utf8_child_output(monkeypatch: Any, capsys
     output = capsys.readouterr()
     assert exit_code == 0
     assert "\ufffd" in output.out
+
+
+def test_run_with_secrets_decodes_output_as_utf8(monkeypatch: Any) -> None:
+    monkeypatch.setattr("lib.creds.run._get_bundle_provider", lambda _: _DummyProvider())
+    captured: dict[str, object] = {}
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("lib.creds.run.subprocess.run", fake_run)
+
+    assert run_with_secrets(["echo", "ok"], project_id="test-project", provider_name="dummy") == 0
+    assert captured["encoding"] == "utf-8"
+    assert captured["errors"] == "replace"


### PR DESCRIPTION
## Summary
- explicitly decode captured child output as UTF-8 before secret masking
- retain replacement behavior for malformed bytes
- add a regression assertion for the decoding contract

Follow-up to the recorded Claude and live second-opinion review findings.

## Validation
- `make verify`

Closes #100