### PR TITLE
feat(cxpp): Add plugin suite profiles (Closes #132)

### DIFF
--- a/.codex/skills/cxpp-init/SKILL.md
+++ b/.codex/skills/cxpp-init/SKILL.md
@@ -19,37 +19,78 @@ machine after installing family plugins from the pinned marketplace.
   or Playwright. Missing host services are reported as prerequisites.
 - Use additive updates only. Preserve existing configuration and rules.
 
+Selecting a plugin suite consents only to the marketplace and family-plugin
+actions shown in that suite's preview. It never consents to MCP pointers,
+credentials, hooks, exec-policy rules, or external-service lifecycle changes;
+each of those remains a separate setup component with its own approval.
+
+## Plugin Suite Profiles
+
+Offer these choices when the CxPP marketplace is missing or one or more
+published family plugins are missing:
+
+- **Minimal**: `cxpp` only.
+- **Recommended**: `project`, `spec`, `flow`, `github`, `cicd`, `secrets`,
+  `security`, `agents-md`, `documentation`, `qa`, `self-improvement`, and
+  `cxpp`. This is the documented default for common development workflows.
+- **Full suite**: `project`, `spec`, `flow`, `github`, `cicd`, `secrets`,
+  `woodpecker`, `security`, `agents-md`, `documentation`, `qa`, `evaluate`,
+  `second-opinion`, `self-improvement`, and `cxpp`.
+- **Custom**: one or more individually selected names from the full-suite list.
+  Reject unknown names, de-duplicate selections in full-suite order, and treat
+  an empty selection as `skipped by user`.
+
 ## Procedure
 
 1. Confirm Codex is available with `codex --version`, then ask which components
    to configure: CxPP marketplace/plugins, host-managed MCP pointers, spec-kit,
    secrets-provider guidance, and reviewed hooks/rules. Do not assume all are
    wanted.
-2. For marketplace/plugins, require a signed release tag or immutable commit
-   SHA. Show the selected sparse paths, then, after approval, add the marketplace
-   and install only requested family plugins. Do not use a floating branch ref.
-3. For MCP pointers, show the two entries from the CxPP config pointer template
+2. For marketplace/plugins, run the read-only `/cxpp:status` checks first. If
+   the marketplace is missing or family plugins are absent, offer Minimal,
+   Recommended, Full suite, and Custom; otherwise report the suite as
+   `already current` without prompting for a reinstall.
+3. Require the requested marketplace ref to be either a confirmed signed
+   release tag or an immutable commit SHA. Resolve a signed tag to its commit
+   SHA and reject floating branch refs. Before installation, show one approval
+   preview containing:
+   - the chosen profile and selected plugins;
+   - every sparse path, exactly `.agents` plus `plugins/<family>` for each
+     selected family in full-suite order;
+   - the previous marketplace ref (`none` on a fresh setup);
+   - the requested signed tag or immutable commit SHA and its resolved SHA; and
+   - the exact additive `codex plugin marketplace add ... --ref ... --sparse
+     ...` and `codex plugin add <family>@codex-power-pack` actions.
+4. After explicit approval, add the pinned marketplace snapshot and install
+   only selected plugins that are missing. Do not use a floating ref, install an
+   unselected family, or change host configuration as a side effect. Re-run
+   `/cxpp:status` to verify the result.
+5. For MCP pointers, show the two entries from the CxPP config pointer template
    (`templates/config.toml.example` in a checkout or `config.toml.example` in
    the installed plugin): `second-opinion` at
    `http://127.0.0.1:8080/mcp` and `playwright` via
    `npx -y @playwright/mcp@latest`. After approval, use the matching `codex mcp
    add` commands. Do not edit TOML by string replacement.
-4. For spec-kit, ask whether the official tool should be installed for the
+6. For spec-kit, ask whether the official tool should be installed for the
    current user. Confirm its documented install command and version before
    executing it; do not install it as a side effect of another component.
-5. For secrets, install or enable the requested `secrets` family plugin and
+7. For secrets, install or enable the requested `secrets` family plugin and
    point to its provider setup. Do not ask for credentials or echo environment
    values.
-6. For hooks/rules, show every proposed file and destination. Run
+8. For hooks/rules, show every proposed file and destination. Run
    `codex execpolicy check` against a proposed rule before writing it. Install
    only reviewed, additive entries and wait for Codex's normal hook-trust review.
-7. Run only non-secret checks: `codex mcp get second-opinion`,
+9. Run only non-secret checks: `codex mcp get second-opinion`,
    `codex mcp get playwright`, and, when the service is expected locally,
    `curl -sf http://127.0.0.1:8080/readyz`. A failed health check is a report,
    not a reason to start the service.
 
 ## Report
 
-Report each component as `configured`, `already configured`, `skipped`, or
-`needs host prerequisite`. Include the exact non-secret follow-up needed and
-state that a new Codex session is required after MCP configuration changes.
+Separate every result into `updated`, `already current`, `skipped by user`, or
+`needs host prerequisite`. Preserve the previous ref, requested ref, and
+resolved SHA in the plugin report so rollback is possible. Include the exact
+non-secret follow-up needed and state that a new Codex session is required after
+plugin or MCP configuration changes. Re-running the same approved profile at
+the same ref must produce `already current`, not another marketplace or plugin
+write.

--- a/.codex/skills/cxpp-status/SKILL.md
+++ b/.codex/skills/cxpp-status/SKILL.md
@@ -9,26 +9,38 @@ Use this skill for `/cxpp:status` to inspect Codex Power Pack host wiring. This
 skill is read-only: it must not install, update, write, restart, or delete
 anything.
 
+## Published Plugin Families
+
+Treat the repo marketplace as authoritative for these published families, in
+this order: `project`, `spec`, `flow`, `github`, `cicd`, `secrets`,
+`woodpecker`, `security`, `agents-md`, `documentation`, `qa`, `evaluate`,
+`second-opinion`, `self-improvement`, and `cxpp`.
+
 ## Procedure
 
-1. Run `codex plugin list --json` and report installed CxPP family plugins,
-   their enabled state, marketplace source, and pinned ref when Codex exposes
-   it. Do not expose authentication data.
-2. Run `codex mcp get second-opinion` and `codex mcp get playwright`. Report
+1. Run `codex plugin marketplace list` and `codex plugin list --available
+   --json`. For every published family, report `installed` or `missing`, plus
+   enabled state, marketplace source, and pinned ref when Codex exposes them.
+   A missing marketplace means every family not otherwise visible is `missing`;
+   it is not permission to add the marketplace. Do not expose authentication
+   data.
+2. Flag a marketplace source without an immutable commit SHA or confirmed
+   signed release tag as a pinning/drift `warning`. A warning is informational
+   and must not trigger an update.
+3. Run `codex mcp get second-opinion` and `codex mcp get playwright`. Report
    each pointer as configured or missing without reading global TOML directly.
-3. When `second-opinion` is configured for localhost, run
+4. When `second-opinion` is configured for localhost, run
    `curl -sf http://127.0.0.1:8080/readyz`; otherwise label its health as not
    checked. Run no process-management command.
-4. Check whether optional spec-kit and reviewed hooks/rules are present using
+5. Check whether optional spec-kit and reviewed hooks/rules are present using
    their documented status commands or file existence only. Never print rule,
    hook, or configuration contents that might contain secrets.
-5. Flag a marketplace source without an immutable commit SHA or signed release
-   tag as a pinning/drift warning. A warning is informational and must not
-   trigger an update.
 
 ## Report
 
-Use one row per component: `plugins`, `second-opinion`, `playwright`, `spec-kit`,
-`secrets guidance`, and `hooks/rules`. Give each a status of `healthy`,
-`configured`, `missing`, `unhealthy`, `not checked`, or `warning`, followed by
-the smallest safe follow-up.
+Start with one row per published plugin family so installed and missing families
+are explicit. Then use one row per host component: `second-opinion`,
+`playwright`, `spec-kit`, `secrets guidance`, and `hooks/rules`. Give host
+components a status of `healthy`, `configured`, `missing`, `unhealthy`,
+`not checked`, or `warning`, followed by the smallest safe follow-up. Keep this
+inventory read-only and do not turn a missing row into an implicit install.

--- a/.codex/skills/cxpp-update/SKILL.md
+++ b/.codex/skills/cxpp-update/SKILL.md
@@ -8,24 +8,57 @@ description: "Refresh Codex Power Pack host wiring additively and with explicit 
 Use this skill for `/cxpp:update` when an installed Codex Power Pack setup needs
 an additive refresh without overwriting user-managed configuration.
 
+## Plugin Suite Profiles
+
+When the marketplace is missing or published family plugins are absent, offer:
+
+- **Minimal**: `cxpp` only.
+- **Recommended**: `project`, `spec`, `flow`, `github`, `cicd`, `secrets`,
+  `security`, `agents-md`, `documentation`, `qa`, `self-improvement`, and
+  `cxpp`.
+- **Full suite**: `project`, `spec`, `flow`, `github`, `cicd`, `secrets`,
+  `woodpecker`, `security`, `agents-md`, `documentation`, `qa`, `evaluate`,
+  `second-opinion`, `self-improvement`, and `cxpp`.
+- **Custom**: one or more names from the full-suite list. Reject unknown names,
+  de-duplicate in full-suite order, and treat an empty selection as `skipped by
+  user`.
+
+Suite approval covers only marketplace and plugin installation. It never
+authorizes MCP pointers, credentials or provider setup, hooks, or
+exec-policy rules. It also never authorizes external-service lifecycle changes;
+retain their existing individual prompts.
+
 ## Procedure
 
 1. Run the read-only checks in `/cxpp:status` first and summarize missing,
    unhealthy, or drifted components.
-2. Compare requested MCP pointers with `templates/config.toml.example` using
+2. If the marketplace is missing or family plugins are absent, offer Minimal,
+   Recommended, Full suite, and Custom. Build the desired family set as the
+   union of already installed CxPP families and the selected profile so an
+   update never drops an existing family. If the selected set and pinned ref
+   are unchanged, report `already current` and perform no write.
+3. Require a confirmed signed release tag or immutable commit SHA, resolve a
+   tag to its commit SHA, and reject floating refs. Before approval, show the
+   selected profile and plugins, every resulting sparse path (`.agents` plus
+   `plugins/<family>` in full-suite order), the previous ref, requested ref,
+   resolved SHA, and exact additive marketplace/plugin commands.
+4. After explicit approval, expand the sparse marketplace snapshot and install
+   only missing selected plugins. Preserve existing families and configuration.
+   Re-run `/cxpp:status` to verify the result.
+5. Compare requested MCP pointers with `templates/config.toml.example` using
    `codex mcp get`; do not print or parse the full global configuration file.
-3. For each change, show the precise additive action and ask for approval. Never
-   delete a pointer, plugin, hook, rule, or user configuration entry.
-4. Reinstall or upgrade plugins only from a signed release tag or immutable
-   commit SHA after the user confirms the target ref. Keep the prior ref in the
-   report for rollback.
-5. Re-run `codex execpolicy check` before adding or changing any rule, and let
+6. For each host change, show the precise additive action and ask for separate
+   approval. Never delete a pointer, plugin, hook, rule, or user configuration
+   entry.
+7. Re-run `codex execpolicy check` before adding or changing any rule, and let
    Codex perform its normal hook-review flow for changed hook files.
-6. Re-run the non-secret MCP checks and report whether a fresh Codex session is
+8. Re-run the non-secret MCP checks and report whether a fresh Codex session is
    needed. Do not manage the lifecycle of an external host service.
 
 ## Report
 
-Separate `updated`, `already current`, `skipped by user`, and `needs host
-prerequisite`. Include the previous and requested pinned plugin refs whenever a
-plugin changes.
+Separate `updated`, `already current`, `skipped by user`, and
+`needs host prerequisite`. Include the previous ref, requested signed tag or
+immutable SHA, and resolved SHA whenever a marketplace or plugin changes so
+rollback remains possible. Re-running an unchanged selection at the same
+resolved SHA must be idempotent and report `already current`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- Added minimal, recommended, full, and custom plugin-suite choices to the
+  consent-first CxPP init/update workflows, with complete family status,
+  immutable-ref previews, rollback refs, and strict host-configuration
+  boundaries (#132).
 - Documented the pinned marketplace release, upgrade, and rollback process for
   Codex plugin releases (#79).
 - Cut newcomer documentation over to native Codex marketplace installation and

--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ spec-kit and `$spec-sync` task-to-issue previews. Install `cxpp` when a fresh
 machine needs the consent-first `/cxpp:init`, `/cxpp:update`, and
 `/cxpp:status` fallback skills.
 
+When the marketplace or family plugins are missing, `/cxpp:init` and
+`/cxpp:update` offer four suite profiles:
+
+- **Minimal** installs only `cxpp`.
+- **Recommended** installs `project`, `spec`, `flow`, `github`, `cicd`,
+  `secrets`, `security`, `agents-md`, `documentation`, `qa`,
+  `self-improvement`, and `cxpp` for common development workflows.
+- **Full suite** installs every published family listed above.
+- **Custom** installs only the individually selected families.
+
+Before writing, the workflow shows the exact sparse paths and plugins plus the
+previous, requested, and resolved immutable refs. Suite approval covers only
+marketplace and plugin installation; MCP pointers, credentials, hooks/rules,
+and external services retain separate consent prompts. `/cxpp:status` reports
+every family as installed or missing without changing the machine.
+
 Release installs and upgrades follow `docs/release-process.md`: use a signed
 release tag or immutable commit SHA, record the resolved SHA, and preserve
 rollback refs in the release notes.

--- a/docs/HOST_MANAGED.md
+++ b/docs/HOST_MANAGED.md
@@ -64,6 +64,21 @@ Install the `cxpp` plugin when plugins need a thin, host-side bootstrap layer:
 3. `/cxpp:status` is read-only. It reports installed CxPP plugins, MCP pointer
    presence and health, optional bootstrap state, and pin/drift warnings.
 
+When the marketplace or family plugins are missing, init and update offer
+Minimal (`cxpp`), Recommended (the common development families), Full suite
+(all published families), and Custom profiles. Status reports each published
+family as installed or missing. Before an approved install, init/update show the
+selected plugins, exact `.agents` and `plugins/<family>` sparse paths, previous
+ref, requested signed tag or immutable commit SHA, and resolved SHA. Re-running
+an unchanged profile is `already current`; other outcomes are `updated`,
+`skipped by user`, or `needs host prerequisite`.
+
+Plugin-suite consent is deliberately narrow. It authorizes only the previewed
+marketplace and plugin actions. It does not authorize MCP pointer changes,
+credential or provider setup, hooks, exec-policy rules, or external-service
+lifecycle operations. Those remain separate components with individual consent
+prompts.
+
 The commands use `templates/config.toml.example` as the MCP-pointer source,
 run non-secret checks such as `curl -sf http://127.0.0.1:8080/readyz` and
 `codex mcp get playwright`, and report missing services without trying to

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -81,6 +81,21 @@ codex plugin add project@codex-power-pack
 The marketplace pinning policy accepts immutable commit SHAs and signed release
 tags, resolved through `codex plugin marketplace add --ref`.
 
+## Suite Profiles And Sparse Expansion
+
+The consent-first `/cxpp:init` and `/cxpp:update` skills can expand a pinned
+marketplace snapshot using Minimal, Recommended, Full suite, or Custom profiles.
+For any profile, the preview and command must include `.agents` plus one
+`plugins/<family>` sparse path for every selected or already-preserved family.
+The update path takes the union of installed and selected families so expanding
+a profile never drops an existing plugin from the snapshot.
+
+Before approval, record the selected plugins, all sparse paths, previous ref,
+requested signed release tag or immutable commit SHA, and the requested ref's
+resolved commit SHA. Reject floating branches. Installing a suite does not
+authorize MCP, credential/provider, hook, exec-policy, or external-service
+changes; those use separate consent prompts.
+
 ## Upgrade Procedure
 
 1. Read the release notes and `CHANGELOG.md`.
@@ -116,4 +131,3 @@ Every release note must preserve:
 - resolved commit SHA for the new ref
 - reason for the upgrade
 - reason for rollback, if a rollback is performed
-

--- a/plugins/cxpp/skills/cxpp-init/SKILL.md
+++ b/plugins/cxpp/skills/cxpp-init/SKILL.md
@@ -19,37 +19,78 @@ machine after installing family plugins from the pinned marketplace.
   or Playwright. Missing host services are reported as prerequisites.
 - Use additive updates only. Preserve existing configuration and rules.
 
+Selecting a plugin suite consents only to the marketplace and family-plugin
+actions shown in that suite's preview. It never consents to MCP pointers,
+credentials, hooks, exec-policy rules, or external-service lifecycle changes;
+each of those remains a separate setup component with its own approval.
+
+## Plugin Suite Profiles
+
+Offer these choices when the CxPP marketplace is missing or one or more
+published family plugins are missing:
+
+- **Minimal**: `cxpp` only.
+- **Recommended**: `project`, `spec`, `flow`, `github`, `cicd`, `secrets`,
+  `security`, `agents-md`, `documentation`, `qa`, `self-improvement`, and
+  `cxpp`. This is the documented default for common development workflows.
+- **Full suite**: `project`, `spec`, `flow`, `github`, `cicd`, `secrets`,
+  `woodpecker`, `security`, `agents-md`, `documentation`, `qa`, `evaluate`,
+  `second-opinion`, `self-improvement`, and `cxpp`.
+- **Custom**: one or more individually selected names from the full-suite list.
+  Reject unknown names, de-duplicate selections in full-suite order, and treat
+  an empty selection as `skipped by user`.
+
 ## Procedure
 
 1. Confirm Codex is available with `codex --version`, then ask which components
    to configure: CxPP marketplace/plugins, host-managed MCP pointers, spec-kit,
    secrets-provider guidance, and reviewed hooks/rules. Do not assume all are
    wanted.
-2. For marketplace/plugins, require a signed release tag or immutable commit
-   SHA. Show the selected sparse paths, then, after approval, add the marketplace
-   and install only requested family plugins. Do not use a floating branch ref.
-3. For MCP pointers, show the two entries from the CxPP config pointer template
+2. For marketplace/plugins, run the read-only `/cxpp:status` checks first. If
+   the marketplace is missing or family plugins are absent, offer Minimal,
+   Recommended, Full suite, and Custom; otherwise report the suite as
+   `already current` without prompting for a reinstall.
+3. Require the requested marketplace ref to be either a confirmed signed
+   release tag or an immutable commit SHA. Resolve a signed tag to its commit
+   SHA and reject floating branch refs. Before installation, show one approval
+   preview containing:
+   - the chosen profile and selected plugins;
+   - every sparse path, exactly `.agents` plus `plugins/<family>` for each
+     selected family in full-suite order;
+   - the previous marketplace ref (`none` on a fresh setup);
+   - the requested signed tag or immutable commit SHA and its resolved SHA; and
+   - the exact additive `codex plugin marketplace add ... --ref ... --sparse
+     ...` and `codex plugin add <family>@codex-power-pack` actions.
+4. After explicit approval, add the pinned marketplace snapshot and install
+   only selected plugins that are missing. Do not use a floating ref, install an
+   unselected family, or change host configuration as a side effect. Re-run
+   `/cxpp:status` to verify the result.
+5. For MCP pointers, show the two entries from the CxPP config pointer template
    (`templates/config.toml.example` in a checkout or `config.toml.example` in
    the installed plugin): `second-opinion` at
    `http://127.0.0.1:8080/mcp` and `playwright` via
    `npx -y @playwright/mcp@latest`. After approval, use the matching `codex mcp
    add` commands. Do not edit TOML by string replacement.
-4. For spec-kit, ask whether the official tool should be installed for the
+6. For spec-kit, ask whether the official tool should be installed for the
    current user. Confirm its documented install command and version before
    executing it; do not install it as a side effect of another component.
-5. For secrets, install or enable the requested `secrets` family plugin and
+7. For secrets, install or enable the requested `secrets` family plugin and
    point to its provider setup. Do not ask for credentials or echo environment
    values.
-6. For hooks/rules, show every proposed file and destination. Run
+8. For hooks/rules, show every proposed file and destination. Run
    `codex execpolicy check` against a proposed rule before writing it. Install
    only reviewed, additive entries and wait for Codex's normal hook-trust review.
-7. Run only non-secret checks: `codex mcp get second-opinion`,
+9. Run only non-secret checks: `codex mcp get second-opinion`,
    `codex mcp get playwright`, and, when the service is expected locally,
    `curl -sf http://127.0.0.1:8080/readyz`. A failed health check is a report,
    not a reason to start the service.
 
 ## Report
 
-Report each component as `configured`, `already configured`, `skipped`, or
-`needs host prerequisite`. Include the exact non-secret follow-up needed and
-state that a new Codex session is required after MCP configuration changes.
+Separate every result into `updated`, `already current`, `skipped by user`, or
+`needs host prerequisite`. Preserve the previous ref, requested ref, and
+resolved SHA in the plugin report so rollback is possible. Include the exact
+non-secret follow-up needed and state that a new Codex session is required after
+plugin or MCP configuration changes. Re-running the same approved profile at
+the same ref must produce `already current`, not another marketplace or plugin
+write.

--- a/plugins/cxpp/skills/cxpp-status/SKILL.md
+++ b/plugins/cxpp/skills/cxpp-status/SKILL.md
@@ -9,26 +9,38 @@ Use this skill for `/cxpp:status` to inspect Codex Power Pack host wiring. This
 skill is read-only: it must not install, update, write, restart, or delete
 anything.
 
+## Published Plugin Families
+
+Treat the repo marketplace as authoritative for these published families, in
+this order: `project`, `spec`, `flow`, `github`, `cicd`, `secrets`,
+`woodpecker`, `security`, `agents-md`, `documentation`, `qa`, `evaluate`,
+`second-opinion`, `self-improvement`, and `cxpp`.
+
 ## Procedure
 
-1. Run `codex plugin list --json` and report installed CxPP family plugins,
-   their enabled state, marketplace source, and pinned ref when Codex exposes
-   it. Do not expose authentication data.
-2. Run `codex mcp get second-opinion` and `codex mcp get playwright`. Report
+1. Run `codex plugin marketplace list` and `codex plugin list --available
+   --json`. For every published family, report `installed` or `missing`, plus
+   enabled state, marketplace source, and pinned ref when Codex exposes them.
+   A missing marketplace means every family not otherwise visible is `missing`;
+   it is not permission to add the marketplace. Do not expose authentication
+   data.
+2. Flag a marketplace source without an immutable commit SHA or confirmed
+   signed release tag as a pinning/drift `warning`. A warning is informational
+   and must not trigger an update.
+3. Run `codex mcp get second-opinion` and `codex mcp get playwright`. Report
    each pointer as configured or missing without reading global TOML directly.
-3. When `second-opinion` is configured for localhost, run
+4. When `second-opinion` is configured for localhost, run
    `curl -sf http://127.0.0.1:8080/readyz`; otherwise label its health as not
    checked. Run no process-management command.
-4. Check whether optional spec-kit and reviewed hooks/rules are present using
+5. Check whether optional spec-kit and reviewed hooks/rules are present using
    their documented status commands or file existence only. Never print rule,
    hook, or configuration contents that might contain secrets.
-5. Flag a marketplace source without an immutable commit SHA or signed release
-   tag as a pinning/drift warning. A warning is informational and must not
-   trigger an update.
 
 ## Report
 
-Use one row per component: `plugins`, `second-opinion`, `playwright`, `spec-kit`,
-`secrets guidance`, and `hooks/rules`. Give each a status of `healthy`,
-`configured`, `missing`, `unhealthy`, `not checked`, or `warning`, followed by
-the smallest safe follow-up.
+Start with one row per published plugin family so installed and missing families
+are explicit. Then use one row per host component: `second-opinion`,
+`playwright`, `spec-kit`, `secrets guidance`, and `hooks/rules`. Give host
+components a status of `healthy`, `configured`, `missing`, `unhealthy`,
+`not checked`, or `warning`, followed by the smallest safe follow-up. Keep this
+inventory read-only and do not turn a missing row into an implicit install.

--- a/plugins/cxpp/skills/cxpp-update/SKILL.md
+++ b/plugins/cxpp/skills/cxpp-update/SKILL.md
@@ -8,24 +8,57 @@ description: "Refresh Codex Power Pack host wiring additively and with explicit 
 Use this skill for `/cxpp:update` when an installed Codex Power Pack setup needs
 an additive refresh without overwriting user-managed configuration.
 
+## Plugin Suite Profiles
+
+When the marketplace is missing or published family plugins are absent, offer:
+
+- **Minimal**: `cxpp` only.
+- **Recommended**: `project`, `spec`, `flow`, `github`, `cicd`, `secrets`,
+  `security`, `agents-md`, `documentation`, `qa`, `self-improvement`, and
+  `cxpp`.
+- **Full suite**: `project`, `spec`, `flow`, `github`, `cicd`, `secrets`,
+  `woodpecker`, `security`, `agents-md`, `documentation`, `qa`, `evaluate`,
+  `second-opinion`, `self-improvement`, and `cxpp`.
+- **Custom**: one or more names from the full-suite list. Reject unknown names,
+  de-duplicate in full-suite order, and treat an empty selection as `skipped by
+  user`.
+
+Suite approval covers only marketplace and plugin installation. It never
+authorizes MCP pointers, credentials or provider setup, hooks, or
+exec-policy rules. It also never authorizes external-service lifecycle changes;
+retain their existing individual prompts.
+
 ## Procedure
 
 1. Run the read-only checks in `/cxpp:status` first and summarize missing,
    unhealthy, or drifted components.
-2. Compare requested MCP pointers with `templates/config.toml.example` using
+2. If the marketplace is missing or family plugins are absent, offer Minimal,
+   Recommended, Full suite, and Custom. Build the desired family set as the
+   union of already installed CxPP families and the selected profile so an
+   update never drops an existing family. If the selected set and pinned ref
+   are unchanged, report `already current` and perform no write.
+3. Require a confirmed signed release tag or immutable commit SHA, resolve a
+   tag to its commit SHA, and reject floating refs. Before approval, show the
+   selected profile and plugins, every resulting sparse path (`.agents` plus
+   `plugins/<family>` in full-suite order), the previous ref, requested ref,
+   resolved SHA, and exact additive marketplace/plugin commands.
+4. After explicit approval, expand the sparse marketplace snapshot and install
+   only missing selected plugins. Preserve existing families and configuration.
+   Re-run `/cxpp:status` to verify the result.
+5. Compare requested MCP pointers with `templates/config.toml.example` using
    `codex mcp get`; do not print or parse the full global configuration file.
-3. For each change, show the precise additive action and ask for approval. Never
-   delete a pointer, plugin, hook, rule, or user configuration entry.
-4. Reinstall or upgrade plugins only from a signed release tag or immutable
-   commit SHA after the user confirms the target ref. Keep the prior ref in the
-   report for rollback.
-5. Re-run `codex execpolicy check` before adding or changing any rule, and let
+6. For each host change, show the precise additive action and ask for separate
+   approval. Never delete a pointer, plugin, hook, rule, or user configuration
+   entry.
+7. Re-run `codex execpolicy check` before adding or changing any rule, and let
    Codex perform its normal hook-review flow for changed hook files.
-6. Re-run the non-secret MCP checks and report whether a fresh Codex session is
+8. Re-run the non-secret MCP checks and report whether a fresh Codex session is
    needed. Do not manage the lifecycle of an external host service.
 
 ## Report
 
-Separate `updated`, `already current`, `skipped by user`, and `needs host
-prerequisite`. Include the previous and requested pinned plugin refs whenever a
-plugin changes.
+Separate `updated`, `already current`, `skipped by user`, and
+`needs host prerequisite`. Include the previous ref, requested signed tag or
+immutable SHA, and resolved SHA whenever a marketplace or plugin changes so
+rollback remains possible. Re-running an unchanged selection at the same
+resolved SHA must be idempotent and report `already current`.

--- a/tests/test_cxpp_plugin.py
+++ b/tests/test_cxpp_plugin.py
@@ -2,11 +2,35 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SKILLS = ROOT / ".codex" / "skills"
 PLUGIN = ROOT / "plugins" / "cxpp"
+MARKETPLACE = ROOT / ".agents" / "plugins" / "marketplace.json"
+
+FULL_FAMILIES = (
+    "project",
+    "spec",
+    "flow",
+    "github",
+    "cicd",
+    "secrets",
+    "woodpecker",
+    "security",
+    "agents-md",
+    "documentation",
+    "qa",
+    "evaluate",
+    "second-opinion",
+    "self-improvement",
+    "cxpp",
+)
+
+RECOMMENDED_FAMILIES = tuple(
+    family for family in FULL_FAMILIES if family not in {"woodpecker", "evaluate", "second-opinion"}
+)
 
 
 def read_skill(name: str) -> str:
@@ -40,9 +64,44 @@ def test_cxpp_status_is_read_only_and_checks_host_pointers() -> None:
     text = read_skill("cxpp-status")
 
     assert "skill is read-only" in text
-    assert "codex plugin list --json" in text
+    assert "codex plugin list --available" in text
+    assert "`installed` or `missing`" in text
     assert "codex mcp get second-opinion" in text
     assert "curl -sf http://127.0.0.1:8080/readyz" in text
+
+
+def test_cxpp_status_inventory_matches_every_marketplace_family() -> None:
+    marketplace = json.loads(MARKETPLACE.read_text(encoding="utf-8"))
+    marketplace_families = tuple(plugin["name"] for plugin in marketplace["plugins"])
+    text = read_skill("cxpp-status")
+
+    assert marketplace_families == FULL_FAMILIES
+    for family in FULL_FAMILIES:
+        assert f"`{family}`" in text
+
+
+def test_cxpp_init_and_update_offer_idempotent_suite_profiles() -> None:
+    for name in ("cxpp-init", "cxpp-update"):
+        text = read_skill(name)
+
+        for profile in ("Minimal", "Recommended", "Full suite", "Custom"):
+            assert f"**{profile}**" in text
+        for family in RECOMMENDED_FAMILIES:
+            assert f"`{family}`" in text
+        for field in ("previous ref", "requested", "resolved SHA", ".agents", "plugins/<family>"):
+            assert field in text
+        for outcome in ("updated", "already current", "skipped by user", "needs host prerequisite"):
+            assert outcome in text
+        assert "floating" in text
+        assert "idempotent" in text or "Re-running" in text
+
+
+def test_suite_consent_does_not_authorize_host_changes() -> None:
+    for name in ("cxpp-init", "cxpp-update"):
+        text = read_skill(name)
+
+        for boundary in ("MCP pointers", "credentials", "hooks", "exec-policy rules", "external-service"):
+            assert boundary in text
 
 
 def test_cxpp_plugin_includes_the_host_pointer_template() -> None:


### PR DESCRIPTION
## Summary
- add minimal, recommended, full, and custom profiles to cxpp init and update
- report every published family as installed or missing in cxpp status
- preserve immutable refs, rollback data, idempotent outcomes, and separate host consent
- document the suite behavior and enforce it with native/package parity tests

## Test plan
- deterministic finish plan: lint, full tests, security scan
- UV_CACHE_DIR=/tmp/uv-cache make verify
- focused cxpp tests: 7 passed
- plugin and skill schema validation
- source/package byte parity, worktree leak guard, and git diff check

Closes #132