### PR TITLE
Increase Claude review turn limit

### DIFF
--- a/.codex/skills/claude-code-review/scripts/claude_code_review.py
+++ b/.codex/skills/claude-code-review/scripts/claude_code_review.py
@@ -11,6 +11,7 @@ import sys
 from pathlib import Path
 
 MAX_DIFF_BYTES = 1_500_000
+DEFAULT_MAX_TURNS = 50
 READ_ONLY_TOOLS = ["Read", "Glob", "Grep"]
 DISALLOWED_TOOLS = [
     "Bash",
@@ -166,7 +167,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--issue", required=True, help="Issue and acceptance-criteria summary")
     parser.add_argument("--blocker", required=True, help="Safe blocker summary and review question")
     parser.add_argument("--claude-cli", default=shutil.which("claude"), help=argparse.SUPPRESS)
-    parser.add_argument("--max-turns", type=int, default=8)
+    parser.add_argument("--max-turns", type=int, default=DEFAULT_MAX_TURNS)
     parser.add_argument("--max-budget-usd", type=float, default=2.0)
     parser.add_argument("--dry-run", action="store_true", help="Validate and summarize without calling Claude")
     return parser.parse_args()

--- a/plugins/claude/.codex-plugin/plugin.json
+++ b/plugins/claude/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude",
-  "version": "0.1.0",
+  "version": "0.1.0+codex.20260725200828",
   "description": "Read-only Claude Code support for Codex workflows.",
   "author": {
     "name": "Codex Power Pack maintainers",

--- a/plugins/claude/skills/claude-code-review/scripts/claude_code_review.py
+++ b/plugins/claude/skills/claude-code-review/scripts/claude_code_review.py
@@ -11,6 +11,7 @@ import sys
 from pathlib import Path
 
 MAX_DIFF_BYTES = 1_500_000
+DEFAULT_MAX_TURNS = 50
 READ_ONLY_TOOLS = ["Read", "Glob", "Grep"]
 DISALLOWED_TOOLS = [
     "Bash",
@@ -166,7 +167,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--issue", required=True, help="Issue and acceptance-criteria summary")
     parser.add_argument("--blocker", required=True, help="Safe blocker summary and review question")
     parser.add_argument("--claude-cli", default=shutil.which("claude"), help=argparse.SUPPRESS)
-    parser.add_argument("--max-turns", type=int, default=8)
+    parser.add_argument("--max-turns", type=int, default=DEFAULT_MAX_TURNS)
     parser.add_argument("--max-budget-usd", type=float, default=2.0)
     parser.add_argument("--dry-run", action="store_true", help="Validate and summarize without calling Claude")
     return parser.parse_args()

--- a/tests/test_claude_code_review.py
+++ b/tests/test_claude_code_review.py
@@ -39,6 +39,10 @@ runner = _load(RUNNER_PATH, "claude_code_review")
 sync = _load(SYNC_PATH, "codex_skills_sync_claude_review")
 
 
+def test_review_default_allows_large_projects() -> None:
+    assert runner.DEFAULT_MAX_TURNS == 50
+
+
 def _git(repo: Path, *args: str) -> str:
     result = subprocess.run(
         ["git", *args],

--- a/tests/test_project_plugin_marketplace.py
+++ b/tests/test_project_plugin_marketplace.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -175,7 +176,7 @@ def test_each_family_plugin_manifest_is_native_codex_shape() -> None:
         manifest = load_json(PLUGINS_ROOT / family / ".codex-plugin" / "plugin.json")
 
         assert manifest["name"] == family
-        assert manifest["version"] == "0.1.0"
+        assert re.fullmatch(r"0\.1\.0(?:\+codex\.[A-Za-z0-9.-]+)?", manifest["version"])
         assert manifest["skills"] == "./skills/"
         assert manifest["repository"] == "https://github.com/cooneycw/codex-power-pack"
         assert manifest["license"] == "MIT"


### PR DESCRIPTION
## What changed

- raise the default bounded Claude Code review session from 8 to 50 turns
- keep the existing `$2` estimated-usage guard and read-only tool restrictions
- refresh the Claude plugin cachebuster so installations can pick up the change
- allow supported Codex cachebuster suffixes in marketplace manifest validation
- add regression coverage for the 50-turn default

## Why

Eight turns can terminate reviews before Claude has inspected enough context on larger projects. Fifty turns provides the agreed upper bound while preserving the independent budget and permission controls.

## Validation

- `UV_CACHE_DIR=/tmp/cxpp-turn-limit-pr-uv-cache make verify`
- 403 tests passed
- Ruff, mypy, generated-skill drift, and harness lint passed