### PR TITLE
fix(project): exclude in-flight issues from next picks

### DIFF
--- a/.codex/skills/project-next/SKILL.md
+++ b/.codex/skills/project-next/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-next
-description: Analyze a GitHub-backed repository's open issues, pull requests, branches, and worktrees to recommend the next issue or cleanup action. Use when Codex is asked what to work on next, to triage project backlog, or to choose between open GitHub issues.
+description: Analyze a GitHub-backed repository's open issues, pull requests, branches, and worktrees to recommend the next unclaimed issue or cleanup action. Use when Codex is asked what to work on next, to triage project backlog, or to choose between open GitHub issues.
 ---
 
 # Project Next
@@ -15,17 +15,30 @@ Produce a prioritized next-step report for the current repository.
    - If the repository cannot be resolved, ask for the repo name.
 2. Inspect active work:
    - Run `git worktree list --porcelain`.
-   - Run `gh pr list --state open --json number,title,headRefName,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup,url`.
+   - Run `gh pr list --state open --json number,title,body,headRefName,closingIssuesReferences,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup,url`.
    - Run `git branch -a --format='%(refname:short) %(upstream:short)'`.
+   - For each non-default worktree, record its path and branch. Map it to an issue using, in order:
+     1. An issue number in an `issue-<N>-*` branch name.
+     2. An open PR whose `headRefName` exactly matches the worktree branch, using the PR's `closingIssuesReferences`.
+     3. An explicit issue reference in the matching PR title or body.
+   - Do not guess from similar wording. Report any unmapped worktree and inspect its status and recent commits with `git -C <path> status --short` and `git -C <path> log --oneline -5`.
 3. Inspect candidate issues:
    - Run `gh issue list --state open --limit 100 --json number,title,labels,assignees,updatedAt,createdAt,url,body`.
    - Prefer story/task issues over epic tracking issues unless the user asks for planning.
-   - Treat issues with matching branches, worktrees, or open PRs as in flight.
-4. Apply the gate:
-   - Recommend finishing or unblocking in-flight work before starting a new issue.
+4. Materialize the selection sets before ranking:
+   - `IN_FLIGHT_ISSUES`: every open issue mapped to a non-default worktree, matching local or remote branch, or open PR.
+   - `DEPENDENCY_MAP`: explicit `depends on`, `blocked by`, `after`, or `requires` relationships between open issues.
+   - `BLOCKED_ISSUES`: issues with an open dependency. Keep in-flight issues in this graph so their dependents remain blocked.
+   - `AVAILABLE_ISSUES`: all open issues not in `IN_FLIGHT_ISSUES` or `BLOCKED_ISSUES`.
+   - Account for every open issue exactly once. If a classification is uncertain, report it instead of silently treating the issue as available.
+5. Apply the hard gate:
+   - Choose a "next issue to start" only from `AVAILABLE_ISSUES`.
+   - Never place an issue from `IN_FLIGHT_ISSUES` or `BLOCKED_ISSUES` in the top pick or startable alternatives.
+   - Show in-flight issues separately as work to continue, review, unblock, or clean up.
    - Recommend cleanup only when stale branches or worktrees are clearly merged or abandoned.
    - If verification gates are failing or unknown, prefer fixing the gate before starting broad feature work.
-5. Report compactly:
+   - Before reporting, validate that the top pick and every startable alternative are in `AVAILABLE_ISSUES`.
+6. Report compactly:
    - State the top recommendation first.
    - List the evidence: open PRs, worktrees, relevant branches, and gate status.
    - Include the next 2-4 candidates only when helpful.
@@ -36,12 +49,19 @@ Produce a prioritized next-step report for the current repository.
 Top pick: #NN Title
 Why: <one or two concrete reasons>
 
-Also consider:
+Other available issues:
 - #NN Title - <reason>
+
+Active work (not startable):
+- #NN Title - <worktree or PR evidence>
+
+Blocked (not startable):
+- #NN Title - blocked by #MM
 
 Current state:
 - PRs: <open PR count and notable blockers>
 - Worktrees: <active issue worktrees>
+- Unmapped worktrees: <paths and branches, or none>
 - Branch cleanup: <stale merged branches or none>
 - Gates: <known local or CI status>
 ```

--- a/plugins/project/skills/project-next/SKILL.md
+++ b/plugins/project/skills/project-next/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-next
-description: Analyze a GitHub-backed repository's open issues, pull requests, branches, and worktrees to recommend the next issue or cleanup action. Use when Codex is asked what to work on next, to triage project backlog, or to choose between open GitHub issues.
+description: Analyze a GitHub-backed repository's open issues, pull requests, branches, and worktrees to recommend the next unclaimed issue or cleanup action. Use when Codex is asked what to work on next, to triage project backlog, or to choose between open GitHub issues.
 ---
 
 # Project Next
@@ -15,17 +15,30 @@ Produce a prioritized next-step report for the current repository.
    - If the repository cannot be resolved, ask for the repo name.
 2. Inspect active work:
    - Run `git worktree list --porcelain`.
-   - Run `gh pr list --state open --json number,title,headRefName,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup,url`.
+   - Run `gh pr list --state open --json number,title,body,headRefName,closingIssuesReferences,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup,url`.
    - Run `git branch -a --format='%(refname:short) %(upstream:short)'`.
+   - For each non-default worktree, record its path and branch. Map it to an issue using, in order:
+     1. An issue number in an `issue-<N>-*` branch name.
+     2. An open PR whose `headRefName` exactly matches the worktree branch, using the PR's `closingIssuesReferences`.
+     3. An explicit issue reference in the matching PR title or body.
+   - Do not guess from similar wording. Report any unmapped worktree and inspect its status and recent commits with `git -C <path> status --short` and `git -C <path> log --oneline -5`.
 3. Inspect candidate issues:
    - Run `gh issue list --state open --limit 100 --json number,title,labels,assignees,updatedAt,createdAt,url,body`.
    - Prefer story/task issues over epic tracking issues unless the user asks for planning.
-   - Treat issues with matching branches, worktrees, or open PRs as in flight.
-4. Apply the gate:
-   - Recommend finishing or unblocking in-flight work before starting a new issue.
+4. Materialize the selection sets before ranking:
+   - `IN_FLIGHT_ISSUES`: every open issue mapped to a non-default worktree, matching local or remote branch, or open PR.
+   - `DEPENDENCY_MAP`: explicit `depends on`, `blocked by`, `after`, or `requires` relationships between open issues.
+   - `BLOCKED_ISSUES`: issues with an open dependency. Keep in-flight issues in this graph so their dependents remain blocked.
+   - `AVAILABLE_ISSUES`: all open issues not in `IN_FLIGHT_ISSUES` or `BLOCKED_ISSUES`.
+   - Account for every open issue exactly once. If a classification is uncertain, report it instead of silently treating the issue as available.
+5. Apply the hard gate:
+   - Choose a "next issue to start" only from `AVAILABLE_ISSUES`.
+   - Never place an issue from `IN_FLIGHT_ISSUES` or `BLOCKED_ISSUES` in the top pick or startable alternatives.
+   - Show in-flight issues separately as work to continue, review, unblock, or clean up.
    - Recommend cleanup only when stale branches or worktrees are clearly merged or abandoned.
    - If verification gates are failing or unknown, prefer fixing the gate before starting broad feature work.
-5. Report compactly:
+   - Before reporting, validate that the top pick and every startable alternative are in `AVAILABLE_ISSUES`.
+6. Report compactly:
    - State the top recommendation first.
    - List the evidence: open PRs, worktrees, relevant branches, and gate status.
    - Include the next 2-4 candidates only when helpful.
@@ -36,12 +49,19 @@ Produce a prioritized next-step report for the current repository.
 Top pick: #NN Title
 Why: <one or two concrete reasons>
 
-Also consider:
+Other available issues:
 - #NN Title - <reason>
+
+Active work (not startable):
+- #NN Title - <worktree or PR evidence>
+
+Blocked (not startable):
+- #NN Title - blocked by #MM
 
 Current state:
 - PRs: <open PR count and notable blockers>
 - Worktrees: <active issue worktrees>
+- Unmapped worktrees: <paths and branches, or none>
 - Branch cleanup: <stale merged branches or none>
 - Gates: <known local or CI status>
 ```

--- a/tests/test_project_next_skill.py
+++ b/tests/test_project_next_skill.py
@@ -1,0 +1,33 @@
+"""Behavioral contract tests for the native project-next skill."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+NATIVE_SKILL = REPO_ROOT / ".codex" / "skills" / "project-next" / "SKILL.md"
+PLUGIN_SKILL = REPO_ROOT / "plugins" / "project" / "skills" / "project-next" / "SKILL.md"
+
+
+def test_native_and_plugin_project_next_payloads_match() -> None:
+    assert NATIVE_SKILL.read_bytes() == PLUGIN_SKILL.read_bytes()
+
+
+def test_project_next_has_a_hard_in_flight_exclusion_gate() -> None:
+    text = NATIVE_SKILL.read_text(encoding="utf-8")
+
+    required_contract = (
+        "git worktree list --porcelain",
+        "closingIssuesReferences",
+        "IN_FLIGHT_ISSUES",
+        "DEPENDENCY_MAP",
+        "BLOCKED_ISSUES",
+        "AVAILABLE_ISSUES",
+        'Choose a "next issue to start" only from `AVAILABLE_ISSUES`.',
+        "Never place an issue from `IN_FLIGHT_ISSUES` or `BLOCKED_ISSUES`",
+        "Keep in-flight issues in this graph so their dependents remain blocked.",
+        "Unmapped worktrees:",
+    )
+
+    for instruction in required_contract:
+        assert instruction in text


### PR DESCRIPTION
## Summary

- map non-default worktrees to issues through issue-style branches, exact PR head branches, and PR closing-issue references
- restore explicit in-flight, dependency, blocked, and available issue sets
- hard-exclude in-flight and blocked issues from the next issue and startable alternatives
- report active and unmapped worktrees separately
- add native/plugin parity and behavioral contract tests

## Root cause

The native `project-next` replacement collected worktree state but reduced the former exclusion and validation gates to advisory prose. That allowed issues with active worktrees to leak into startable recommendations.

## Impact

`project-next` now recommends a new issue only from the available set while retaining in-flight issues in dependency analysis, so downstream issues remain blocked correctly.

## Validation

- both skill packages pass `quick_validate.py`
- `make verify` (404 tests, Ruff, mypy, Codex skill drift, harness lint)

Closes #146