### PR TITLE
fix(plugins): advertise every packaged skill to Codex

### DIFF
--- a/.specify/specs/plugin-marketplace-modernization/plan.md
+++ b/.specify/specs/plugin-marketplace-modernization/plan.md
@@ -78,8 +78,10 @@ owner-approved before any Epic C/D/E implementation PR merges.
   plugin (project family) with `.codex-plugin/plugin.json`; prove E2E with
   `/plugins` install from the repo as a git-backed source.
 - **C2** Package all families as per-family plugins; per-skill
-  `agents/openai.yaml` (default `allow_implicit_invocation: false`,
-  display metadata).
+  `agents/openai.yaml` (default `allow_implicit_invocation: true`,
+  display metadata). Skills reach the Codex session prompt inventory only
+  when implicit invocation is enabled, so the original `false` default left
+  installed families invisible to the model.
 - **C3** Version pinning and release process: tagged releases, marketplace
   entries pin ref/sha, upgrade documented.
 - **C4** `cxpp:init/update/status` thin fallback for non-plugin infra:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ tool integrations, with client-side pointers documented in `docs/HOST_MANAGED.md
 - Plugin-packaged copies of generated skills under `plugins/<family>/skills/`
   keep their skill payload files byte-identical to `.codex/skills/`. The only
   package-local overlay is `agents/openai.yaml`, which supplies Codex plugin UI
-  metadata and disables implicit invocation by default.
+  metadata and enables implicit invocation by default.
 - Reconcile by editing the upstream source, never the generated copy: edit
   `.claude/commands/<family>/` in claude-power-pack, regenerate there (`make codex-skills`),
   then re-pull here (`make codex-skills-refresh`). The drift gate `make codex-skills-check`

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ checkout.
 Each plugin packages one workflow family so users can install and remove them
 independently. Packaged skill payloads stay byte-identical to `.codex/skills/`;
 the package-local `agents/openai.yaml` files supply display metadata and set
-`allow_implicit_invocation: false` by default.
+`allow_implicit_invocation: true` by default.
 
 ## Command Skills
 

--- a/plugins/agents-md/.codex-plugin/plugin.json
+++ b/plugins/agents-md/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agents-md",
-  "version": "0.1.0",
+  "version": "0.1.0+codex.20260727145047",
   "description": "AGENTS.md governance lint and help skills.",
   "author": {
     "name": "Codex Power Pack maintainers",

--- a/plugins/agents-md/skills/agents-md-help/agents/openai.yaml
+++ b/plugins/agents-md/skills/agents-md-help/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Trigger /agents-md:help for AGENTS.md governance command guidance"
   default_prompt: "Use $agents-md-help when you need trigger /agents-md:help for AGENTS.md governance command guidance"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/agents-md/skills/agents-md-lint/agents/openai.yaml
+++ b/plugins/agents-md/skills/agents-md-lint/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Trigger /agents-md:lint to audit AGENTS.md governance directives"
   default_prompt: "Use $agents-md-lint when you need trigger /agents-md:lint to audit AGENTS.md governance directives"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/cicd/.codex-plugin/plugin.json
+++ b/plugins/cicd/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cicd",
-  "version": "0.1.0",
+  "version": "0.1.0+codex.20260727145047",
   "description": "Makefile, pipeline, smoke, health, and infrastructure CI/CD skills.",
   "author": {
     "name": "Codex Power Pack maintainers",

--- a/plugins/cicd/skills/cicd-check/agents/openai.yaml
+++ b/plugins/cicd/skills/cicd-check/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Validate Makefile against CPP standards"
   default_prompt: "Use $cicd-check when you need validate Makefile against CPP standards"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/cicd/skills/cicd-container/agents/openai.yaml
+++ b/plugins/cicd/skills/cicd-container/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "CI/CD Container Generation - Generate Dockerfile, docker-compose.yml, and .dockerignore for the current project."
   default_prompt: "Use $cicd-container when you need cI/CD Container Generation - Generate Dockerfile, docker-compose.yml, and .dockerignore for the current project."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/cicd/skills/cicd-health/agents/openai.yaml
+++ b/plugins/cicd/skills/cicd-health/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Run health checks against configured endpoints and processes"
   default_prompt: "Use $cicd-health when you need run health checks against configured endpoints and processes"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/cicd/skills/cicd-help/agents/openai.yaml
+++ b/plugins/cicd/skills/cicd-help/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "CI/CD Commands - Build, verify, and deploy automation for Claude Code projects."
   default_prompt: "Use $cicd-help when you need cI/CD Commands - Build, verify, and deploy automation for Claude Code projects."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/cicd/skills/cicd-infra-discover/agents/openai.yaml
+++ b/plugins/cicd/skills/cicd-infra-discover/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Generate cloud resource discovery script for IaC import"
   default_prompt: "Use $cicd-infra-discover when you need generate cloud resource discovery script for IaC import"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/cicd/skills/cicd-infra-init/agents/openai.yaml
+++ b/plugins/cicd/skills/cicd-infra-init/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Scaffold IaC directory with tiered structure (foundation/platform/app)"
   default_prompt: "Use $cicd-infra-init when you need scaffold IaC directory with tiered structure (foundation/platform/app)"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/cicd/skills/cicd-infra-pipeline/agents/openai.yaml
+++ b/plugins/cicd/skills/cicd-infra-pipeline/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Generate CI/CD pipelines for infrastructure tiers with approval gates"
   default_prompt: "Use $cicd-infra-pipeline when you need generate CI/CD pipelines for infrastructure tiers with approval gates"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/cicd/skills/cicd-init/agents/openai.yaml
+++ b/plugins/cicd/skills/cicd-init/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Detect framework and generate/validate Makefile for CI/CD integration"
   default_prompt: "Use $cicd-init when you need detect framework and generate/validate Makefile for CI/CD integration"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/cicd/skills/cicd-pipeline/agents/openai.yaml
+++ b/plugins/cicd/skills/cicd-pipeline/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Generate CI/CD workflows (GitHub Actions, or self-hosted Woodpecker via provider)"
   default_prompt: "Use $cicd-pipeline when you need generate CI/CD workflows (GitHub Actions, or self-hosted Woodpecker via provider)"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/cicd/skills/cicd-smoke/agents/openai.yaml
+++ b/plugins/cicd/skills/cicd-smoke/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Run smoke tests from cicd.yml configuration"
   default_prompt: "Use $cicd-smoke when you need run smoke tests from cicd.yml configuration"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/cicd/skills/cicd-verify/agents/openai.yaml
+++ b/plugins/cicd/skills/cicd-verify/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Verify a deployment against a pre-deploy baseline (proceed/rollback)"
   default_prompt: "Use $cicd-verify when you need verify a deployment against a pre-deploy baseline (proceed/rollback)"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/claude/.codex-plugin/plugin.json
+++ b/plugins/claude/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude",
-  "version": "0.1.0+codex.20260725200828",
+  "version": "0.1.0+codex.20260727145047",
   "description": "Read-only Claude Code support for Codex workflows.",
   "author": {
     "name": "Codex Power Pack maintainers",

--- a/plugins/claude/skills/claude-code-review/agents/openai.yaml
+++ b/plugins/claude/skills/claude-code-review/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Read-only cross-model review via Claude"
   default_prompt: "Use $claude-code-review to ask Claude Code for a read-only review of the current issue diff."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/cxpp/.codex-plugin/plugin.json
+++ b/plugins/cxpp/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cxpp",
-  "version": "0.1.0",
+  "version": "0.1.0+codex.20260727145047",
   "description": "Consent-first bootstrap, refresh, and status skills for Codex Power Pack host configuration.",
   "author": {
     "name": "Codex Power Pack maintainers",

--- a/plugins/cxpp/skills/cxpp-init/agents/openai.yaml
+++ b/plugins/cxpp/skills/cxpp-init/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Bootstrap CxPP host wiring with explicit consent."
   default_prompt: "Use $cxpp-init when you need to set up Codex Power Pack host wiring"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/cxpp/skills/cxpp-status/agents/openai.yaml
+++ b/plugins/cxpp/skills/cxpp-status/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Inspect CxPP plugins, pointers, health, and drift."
   default_prompt: "Use $cxpp-status when you need to inspect Codex Power Pack host wiring"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/cxpp/skills/cxpp-update/agents/openai.yaml
+++ b/plugins/cxpp/skills/cxpp-update/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Refresh CxPP host wiring without overwriting user settings."
   default_prompt: "Use $cxpp-update when you need to refresh Codex Power Pack host wiring"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/documentation/.codex-plugin/plugin.json
+++ b/plugins/documentation/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "documentation",
-  "version": "0.1.0",
+  "version": "0.1.0+codex.20260727145047",
   "description": "Documentation, C4 diagram, and PPTX skills.",
   "author": {
     "name": "Codex Power Pack maintainers",

--- a/plugins/documentation/skills/documentation-c4/agents/openai.yaml
+++ b/plugins/documentation/skills/documentation-c4/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Generate C4 architecture diagrams for the current project (all 4 levels) as GitHub-renderable Mermaid"
   default_prompt: "Use $documentation-c4 when you need generate C4 architecture diagrams for the current project (all 4 levels) as GitHub-renderable Mermaid"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/documentation/skills/documentation-help/agents/openai.yaml
+++ b/plugins/documentation/skills/documentation-help/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Overview of documentation and diagram commands"
   default_prompt: "Use $documentation-help when you need overview of documentation and diagram commands"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/documentation/skills/documentation-pptx/agents/openai.yaml
+++ b/plugins/documentation/skills/documentation-pptx/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Create a PowerPoint presentation with optional diagrams"
   default_prompt: "Use $documentation-pptx when you need create a PowerPoint presentation with optional diagrams"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/evaluate/.codex-plugin/plugin.json
+++ b/plugins/evaluate/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "evaluate",
-  "version": "0.1.0",
+  "version": "0.1.0+codex.20260727145047",
   "description": "Multi-model evaluation skills.",
   "author": {
     "name": "Codex Power Pack maintainers",

--- a/plugins/evaluate/skills/evaluate-help/agents/openai.yaml
+++ b/plugins/evaluate/skills/evaluate-help/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Overview of evaluate commands"
   default_prompt: "Use $evaluate-help when you need overview of evaluate commands"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/evaluate/skills/evaluate-issue/agents/openai.yaml
+++ b/plugins/evaluate/skills/evaluate-issue/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Multi-model evaluation flow for issues, ideas, and architectural decisions"
   default_prompt: "Use $evaluate-issue when you need multi-model evaluation flow for issues, ideas, and architectural decisions"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/flow/.codex-plugin/plugin.json
+++ b/plugins/flow/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "flow",
-  "version": "0.1.0+codex.20260727132110",
+  "version": "0.1.0+codex.20260727145047",
   "description": "Issue-driven development lifecycle skills.",
   "author": {
     "name": "Codex Power Pack maintainers",

--- a/plugins/flow/skills/flow-check/agents/openai.yaml
+++ b/plugins/flow/skills/flow-check/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Run quality checks (lint + security) without committing"
   default_prompt: "Use $flow-check when you need run quality checks (lint + security) without committing"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/flow/skills/flow-cleanup/agents/openai.yaml
+++ b/plugins/flow/skills/flow-cleanup/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Clean up stale worktree references and merged branches"
   default_prompt: "Use $flow-cleanup when you need clean up stale worktree references and merged branches"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/flow/skills/flow-deploy/agents/openai.yaml
+++ b/plugins/flow/skills/flow-deploy/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Flow: Deploy via Makefile - Run deployment using the project's Makefile targets."
   default_prompt: "Use $flow-deploy when you need flow: Deploy via Makefile - Run deployment using the project's Makefile targets."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/flow/skills/flow-doctor/agents/openai.yaml
+++ b/plugins/flow/skills/flow-doctor/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Diagnose flow workflow setup and environment"
   default_prompt: "Use $flow-doctor when you need diagnose flow workflow setup and environment"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/flow/skills/flow-eli5/agents/openai.yaml
+++ b/plugins/flow/skills/flow-eli5/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Flow: ELI5 - Post-Analysis Plan + Necessity Gate - The post-analysis, pre-implementation communication and approval gate. Restates an iss..."
   default_prompt: "Use $flow-eli5 when you need flow: ELI5 - Post-Analysis Plan + Necessity Gate - The post-analysis, pre-implementation communication and approval gate. Restates an iss..."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/flow/skills/flow-finish/agents/openai.yaml
+++ b/plugins/flow/skills/flow-finish/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Flow: Finish - Quality Gates, Commit, Push, and Create PR - Run quality checks, commit changes, push the branch, and create a pull request."
   default_prompt: "Use $flow-finish when you need flow: Finish - Quality Gates, Commit, Push, and Create PR - Run quality checks, commit changes, push the branch, and create a pull request."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/flow/skills/flow-help/agents/openai.yaml
+++ b/plugins/flow/skills/flow-help/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Flow Commands - Streamlined worktree-based development workflow. No locks, no Redis - just git."
   default_prompt: "Use $flow-help when you need flow Commands - Streamlined worktree-based development workflow. No locks, no Redis - just git."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/flow/skills/flow-merge/agents/openai.yaml
+++ b/plugins/flow/skills/flow-merge/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Flow: Merge PR and Clean Up - Merge the current branch's PR, then clean up the worktree and branch."
   default_prompt: "Use $flow-merge when you need flow: Merge PR and Clean Up - Merge the current branch's PR, then clean up the worktree and branch."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/flow/skills/flow-start/agents/openai.yaml
+++ b/plugins/flow/skills/flow-start/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Flow: Start Working on an Issue - Create a worktree and branch for a GitHub issue. Stateless - all context from git and GitHub."
   default_prompt: "Use $flow-start when you need flow: Start Working on an Issue - Create a worktree and branch for a GitHub issue. Stateless - all context from git and GitHub."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/flow/skills/flow-status/agents/openai.yaml
+++ b/plugins/flow/skills/flow-status/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Flow: Status of Active Worktrees - Show all active worktrees with their issue, branch, dirty state, and PR status."
   default_prompt: "Use $flow-status when you need flow: Status of Active Worktrees - Show all active worktrees with their issue, branch, dirty state, and PR status."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/flow/skills/flow-sync/agents/openai.yaml
+++ b/plugins/flow/skills/flow-sync/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Flow: Sync - Push WIP to Remote for Cross-Machine Pickup - Push the current branch to the remote so you can continue work on another mach..."
   default_prompt: "Use $flow-sync when you need flow: Sync - Push WIP to Remote for Cross-Machine Pickup - Push the current branch to the remote so you can continue work on another mach..."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/github/.codex-plugin/plugin.json
+++ b/plugins/github/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "github",
-  "version": "0.1.0",
+  "version": "0.1.0+codex.20260727145047",
   "description": "GitHub issue management skills.",
   "author": {
     "name": "Codex Power Pack maintainers",

--- a/plugins/github/skills/github-help/agents/openai.yaml
+++ b/plugins/github/skills/github-help/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Overview of all GitHub issue management commands"
   default_prompt: "Use $github-help when you need overview of all GitHub issue management commands"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/github/skills/github-issue-close/agents/openai.yaml
+++ b/plugins/github/skills/github-issue-close/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Close a GitHub issue with optional comment"
   default_prompt: "Use $github-issue-close when you need close a GitHub issue with optional comment"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/github/skills/github-issue-create/agents/openai.yaml
+++ b/plugins/github/skills/github-issue-create/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Create a new GitHub issue in claude-power-pack"
   default_prompt: "Use $github-issue-create when you need create a new GitHub issue in claude-power-pack"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/github/skills/github-issue-list/agents/openai.yaml
+++ b/plugins/github/skills/github-issue-list/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "List and search GitHub issues in claude-power-pack"
   default_prompt: "Use $github-issue-list when you need list and search GitHub issues in claude-power-pack"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/github/skills/github-issue-update/agents/openai.yaml
+++ b/plugins/github/skills/github-issue-update/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Update an existing GitHub issue (title, body, labels, assignees, comments)"
   default_prompt: "Use $github-issue-update when you need update an existing GitHub issue (title, body, labels, assignees, comments)"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/github/skills/github-issue-view/agents/openai.yaml
+++ b/plugins/github/skills/github-issue-view/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "View GitHub issue details and comments"
   default_prompt: "Use $github-issue-view when you need view GitHub issue details and comments"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/project/.codex-plugin/plugin.json
+++ b/plugins/project/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "project",
-  "version": "0.1.0",
+  "version": "0.1.0+codex.20260727145047",
   "description": "Codex Power Pack project scaffolding skills.",
   "author": {
     "name": "Codex Power Pack maintainers",

--- a/plugins/project/skills/project-help/agents/openai.yaml
+++ b/plugins/project/skills/project-help/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Overview of project management commands"
   default_prompt: "Use $project-help when you need overview of project management commands"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/project/skills/project-init/agents/openai.yaml
+++ b/plugins/project/skills/project-init/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Full project scaffolding orchestrator - zero to GitHub repo in one command"
   default_prompt: "Use $project-init when you need full project scaffolding orchestrator - zero to GitHub repo in one command"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/project/skills/project-lite/agents/openai.yaml
+++ b/plugins/project/skills/project-lite/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Orient quickly in a repository"
   default_prompt: "Use $project-lite to summarize the current repository, branch, worktrees, and available commands."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/project/skills/project-next/agents/openai.yaml
+++ b/plugins/project/skills/project-next/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Recommend the next project issue"
   default_prompt: "Use $project-next to recommend the next issue or cleanup action for this repository."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/qa/.codex-plugin/plugin.json
+++ b/plugins/qa/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa",
-  "version": "0.1.0",
+  "version": "0.1.0+codex.20260727145047",
   "description": "Automated web QA testing skills.",
   "author": {
     "name": "Codex Power Pack maintainers",

--- a/plugins/qa/skills/qa-help/agents/openai.yaml
+++ b/plugins/qa/skills/qa-help/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "QA Commands Help - Automated QA testing commands for web applications."
   default_prompt: "Use $qa-help when you need qA Commands Help - Automated QA testing commands for web applications."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/qa/skills/qa-test/agents/openai.yaml
+++ b/plugins/qa/skills/qa-test/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "QA Test - Automated Web Testing - Perform automated QA testing on a web application using the upstream `@playwright/mcp` server (register..."
   default_prompt: "Use $qa-test when you need qA Test - Automated Web Testing - Perform automated QA testing on a web application using the upstream `@playwright/mcp` server (register..."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/second-opinion/.codex-plugin/plugin.json
+++ b/plugins/second-opinion/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "second-opinion",
-  "version": "0.1.0",
+  "version": "0.1.0+codex.20260727145047",
   "description": "Second-opinion model selection and review skills.",
   "author": {
     "name": "Codex Power Pack maintainers",

--- a/plugins/second-opinion/skills/second-opinion-help/agents/openai.yaml
+++ b/plugins/second-opinion/skills/second-opinion-help/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Overview of Second Opinion commands"
   default_prompt: "Use $second-opinion-help when you need overview of Second Opinion commands"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/second-opinion/skills/second-opinion-models/agents/openai.yaml
+++ b/plugins/second-opinion/skills/second-opinion-models/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Select models and depth for second opinion code review"
   default_prompt: "Use $second-opinion-models when you need select models and depth for second opinion code review"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/second-opinion/skills/second-opinion-start/agents/openai.yaml
+++ b/plugins/second-opinion/skills/second-opinion-start/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Quick second opinion with sensible defaults"
   default_prompt: "Use $second-opinion-start when you need quick second opinion with sensible defaults"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/secrets/.codex-plugin/plugin.json
+++ b/plugins/secrets/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "secrets",
-  "version": "0.1.0",
+  "version": "0.1.0+codex.20260727145047",
   "description": "Secret retrieval, storage, validation, and masked command execution skills.",
   "author": {
     "name": "Codex Power Pack maintainers",

--- a/plugins/secrets/skills/secrets-delete/agents/openai.yaml
+++ b/plugins/secrets/skills/secrets-delete/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Delete a Secret - Remove a secret key from the project's store. Logs the deletion to the audit log (never the value)."
   default_prompt: "Use $secrets-delete when you need delete a Secret - Remove a secret key from the project's store. Logs the deletion to the audit log (never the value)."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/secrets/skills/secrets-get/agents/openai.yaml
+++ b/plugins/secrets/skills/secrets-get/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Get credentials securely with masking"
   default_prompt: "Use $secrets-get when you need get credentials securely with masking"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/secrets/skills/secrets-help/agents/openai.yaml
+++ b/plugins/secrets/skills/secrets-help/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Secrets Commands - Overview of all secrets management commands."
   default_prompt: "Use $secrets-help when you need secrets Commands - Overview of all secrets management commands."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/secrets/skills/secrets-list/agents/openai.yaml
+++ b/plugins/secrets/skills/secrets-list/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "List Secrets - List all secret keys for the current project (values masked)."
   default_prompt: "Use $secrets-list when you need list Secrets - List all secret keys for the current project (values masked)."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/secrets/skills/secrets-rotate/agents/openai.yaml
+++ b/plugins/secrets/skills/secrets-rotate/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Rotate a Secret - Update an existing secret with a new value. Logs the rotation action to the audit log (never the value)."
   default_prompt: "Use $secrets-rotate when you need rotate a Secret - Update an existing secret with a new value. Logs the rotation action to the audit log (never the value)."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/secrets/skills/secrets-run/agents/openai.yaml
+++ b/plugins/secrets/skills/secrets-run/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Run with Secrets - Execute a command with project secrets injected as environment variables. Secrets never appear in CLI arguments, logs,..."
   default_prompt: "Use $secrets-run when you need run with Secrets - Execute a command with project secrets injected as environment variables. Secrets never appear in CLI arguments, logs,..."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/secrets/skills/secrets-set/agents/openai.yaml
+++ b/plugins/secrets/skills/secrets-set/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Set a Secret - Set or update a secret value in the project's global config store."
   default_prompt: "Use $secrets-set when you need set a Secret - Set or update a secret value in the project's global config store."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/secrets/skills/secrets-ui/agents/openai.yaml
+++ b/plugins/secrets/skills/secrets-ui/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Secrets Web UI - Launch a local web interface for managing project secrets."
   default_prompt: "Use $secrets-ui when you need secrets Web UI - Launch a local web interface for managing project secrets."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/secrets/skills/secrets-validate/agents/openai.yaml
+++ b/plugins/secrets/skills/secrets-validate/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Validate credentials without exposing them"
   default_prompt: "Use $secrets-validate when you need validate credentials without exposing them"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/security/.codex-plugin/plugin.json
+++ b/plugins/security/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security",
-  "version": "0.1.0",
+  "version": "0.1.0+codex.20260727145047",
   "description": "Deterministic security scanning and permission audit skills.",
   "author": {
     "name": "Codex Power Pack maintainers",

--- a/plugins/security/skills/security-deep/agents/openai.yaml
+++ b/plugins/security/skills/security-deep/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Deep security scan (includes git history)"
   default_prompt: "Use $security-deep when you need deep security scan (includes git history)"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/security/skills/security-explain/agents/openai.yaml
+++ b/plugins/security/skills/security-explain/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Explain a security finding in detail"
   default_prompt: "Use $security-explain when you need explain a security finding in detail"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/security/skills/security-help/agents/openai.yaml
+++ b/plugins/security/skills/security-help/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Security Commands - Novice-friendly security scanning for Claude Code projects."
   default_prompt: "Use $security-help when you need security Commands - Novice-friendly security scanning for Claude Code projects."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/security/skills/security-permissions/agents/openai.yaml
+++ b/plugins/security/skills/security-permissions/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Risk-graded permission audit - wraps native /fewer-permission-prompts with allow/ask/deny tiers"
   default_prompt: "Use $security-permissions when you need risk-graded permission audit - wraps native /fewer-permission-prompts with allow/ask/deny tiers"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/security/skills/security-quick/agents/openai.yaml
+++ b/plugins/security/skills/security-quick/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Quick security scan (native only, fast)"
   default_prompt: "Use $security-quick when you need quick security scan (native only, fast)"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/security/skills/security-scan/agents/openai.yaml
+++ b/plugins/security/skills/security-scan/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Run full security scan (native + external tools)"
   default_prompt: "Use $security-scan when you need run full security scan (native + external tools)"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/self-improvement/.codex-plugin/plugin.json
+++ b/plugins/self-improvement/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "self-improvement",
-  "version": "0.1.0",
+  "version": "0.1.0+codex.20260727145047",
   "description": "Retrospective improvement and friction review skills.",
   "author": {
     "name": "Codex Power Pack maintainers",

--- a/plugins/self-improvement/skills/self-improvement-deployment/agents/openai.yaml
+++ b/plugins/self-improvement/skills/self-improvement-deployment/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Self-Improvement: Deployment - Retrospective Makefile Analysis - Examine recent errors from the current session and deploy history, then..."
   default_prompt: "Use $self-improvement-deployment when you need self-Improvement: Deployment - Retrospective Makefile Analysis - Examine recent errors from the current session and deploy history, then..."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/self-improvement/skills/self-improvement-help/agents/openai.yaml
+++ b/plugins/self-improvement/skills/self-improvement-help/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Overview of self-improvement commands"
   default_prompt: "Use $self-improvement-help when you need overview of self-improvement commands"
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/self-improvement/skills/self-improvement-retro/agents/openai.yaml
+++ b/plugins/self-improvement/skills/self-improvement-retro/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Self-Improvement: Retro - Post-Run Friction Retro + Codify Loop - The \\\"grill-me cycle\\\": grill a just-finished session for friction, the..."
   default_prompt: "Use $self-improvement-retro when you need self-Improvement: Retro - Post-Run Friction Retro + Codify Loop - The \\\"grill-me cycle\\\": grill a just-finished session for friction, the..."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/spec/.codex-plugin/plugin.json
+++ b/plugins/spec/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec",
-  "version": "0.1.0",
+  "version": "0.1.0+codex.20260727145047",
   "description": "Official spec-kit adoption and gh-CLI issue sync for Codex.",
   "author": {
     "name": "Codex Power Pack maintainers",

--- a/plugins/spec/skills/spec-adopt/agents/openai.yaml
+++ b/plugins/spec/skills/spec-adopt/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Adopt official spec-kit for Codex"
   default_prompt: "Use $spec-adopt to set up official spec-kit in this repository."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/spec/skills/spec-sync/agents/openai.yaml
+++ b/plugins/spec/skills/spec-sync/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Preview spec-kit tasks as GitHub issues"
   default_prompt: "Use $spec-sync to preview a spec-kit task list as GitHub issues."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/woodpecker/.codex-plugin/plugin.json
+++ b/plugins/woodpecker/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "woodpecker",
-  "version": "0.1.0",
+  "version": "0.1.0+codex.20260727145047",
   "description": "Safe Woodpecker CI API client and pipeline generation skills.",
   "author": {
     "name": "Codex Power Pack maintainers",

--- a/plugins/woodpecker/skills/woodpecker-help/agents/openai.yaml
+++ b/plugins/woodpecker/skills/woodpecker-help/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Explain safe Woodpecker CI client workflows"
   default_prompt: "Use $woodpecker-help to choose a safe Woodpecker CI action."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/woodpecker/skills/woodpecker-logs/agents/openai.yaml
+++ b/plugins/woodpecker/skills/woodpecker-logs/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Fetch and decode a Woodpecker step log"
   default_prompt: "Use $woodpecker-logs to inspect a failed Woodpecker step log."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/woodpecker/skills/woodpecker-restart/agents/openai.yaml
+++ b/plugins/woodpecker/skills/woodpecker-restart/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "Restart one confirmed Woodpecker pipeline"
   default_prompt: "Use $woodpecker-restart to restart a confirmed pipeline after approval."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/plugins/woodpecker/skills/woodpecker-status/agents/openai.yaml
+++ b/plugins/woodpecker/skills/woodpecker-status/agents/openai.yaml
@@ -3,4 +3,4 @@ interface:
   short_description: "List recent Woodpecker pipelines safely"
   default_prompt: "Use $woodpecker-status to inspect recent pipeline status."
 policy:
-  allow_implicit_invocation: false
+  allow_implicit_invocation: true

--- a/tests/test_project_plugin_marketplace.py
+++ b/tests/test_project_plugin_marketplace.py
@@ -109,7 +109,11 @@ FAMILY_SKILLS = {
 EXPECTED_FAMILIES = list(FAMILY_SKILLS)
 CORE_BUDGET_FAMILIES = ("project", "spec", "github")
 SKILL_LIST_BUDGET_CHARS = 8_000
-IMPLICIT_SKILLS = {"flow-auto"}
+# Every packaged skill is advertised to Codex. Skills only reach the session
+# prompt inventory when implicit invocation is enabled, so a `false` here means
+# the skill is installed but invisible to the model (issue #150 for flow-auto).
+# Narrow this back to a subset if a family should become opt-in again.
+IMPLICIT_SKILLS = {skill for skills in FAMILY_SKILLS.values() for skill in skills}
 
 
 def load_json(path: Path) -> dict[str, Any]:
@@ -211,7 +215,7 @@ def test_plugin_skill_payloads_match_generated_source_with_metadata_overlay() ->
             assert sha256(plugin_files[rel]) == sha256(source_file), rel
 
 
-def test_only_selected_packaged_skills_allow_implicit_invocation() -> None:
+def test_packaged_skills_advertise_implicit_invocation() -> None:
     for family, expected_skills in FAMILY_SKILLS.items():
         for skill_name in expected_skills:
             payload = load_agent_manifest(family, skill_name)


### PR DESCRIPTION
## Problem

All 16 codex-power-pack plugins install and enable correctly, but typing `/` in Codex shows none of their skills — and neither does the model know they exist.

Root cause: a skill only reaches the Codex **session prompt inventory** when `allow_implicit_invocation: true`. The C2 packaging default was `false`, so 72 of 73 skills were installed-but-invisible. Verified against a live config:

```
$ codex debug prompt-input | (parse skill entries)
advertised skill entries: 8
   flow:flow-auto        <- the only codex-power-pack skill
   imagegen, openai-docs, plugin-creator, skill-creator,
   skill-installer, Pipes, Relevance
```

`flow-auto` is the lone exception because #150/#151 flipped it for exactly this reason.

Note the `/` menu is a separate surface, sourced from `$CODEX_HOME/prompts/*.md`; that path was retired in #433, so packaged skills reach Codex through the prompt inventory, not slash commands.

## Change

- Enable `allow_implicit_invocation` for all 73 packaged skills (`plugins/*/skills/*/agents/openai.yaml`).
- Widen `IMPLICIT_SKILLS` in `tests/test_project_plugin_marketplace.py` to the full `FAMILY_SKILLS` set, and rename the test to `test_packaged_skills_advertise_implicit_invocation`. The allowlist structure is kept so a family can be narrowed back to opt-in.
- Correct the Epic C2 note in `.specify/specs/plugin-marketplace-modernization/plan.md`, which still recorded `false` as the intended default.
- Fix `README.md` and `AGENTS.md`, which described implicit invocation as disabled by default.
- Bump all 16 `plugin.json` versions to `0.1.0+codex.20260727145047` so installed payloads re-fetch rather than serving the cached manifest — same cache-bust #151 needed.

## Blast radius

This lets Codex implicitly invoke every family, including `secrets-*` and `security-*`. That was a deliberate call by the repo owner over two narrower options (entrypoints-only, or all-except-sensitive). Per-skill `approval_mode` in `config.toml` remains the guard for anything destructive.

## Verification

`make verify` clean: 408 tests passed, mypy clean across 112 files, `codex-skills-sync` reports 124 files across 55 generated skills in sync, harness-lint 109 files passed.

After merge, picking this up locally needs `codex plugin marketplace upgrade codex-power-pack` — the marketplace tracks the GitHub remote, so the new revision has to land on `main` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)