### PR TITLE
docs(spec): define project-init composition contract (Closes #166)

### DIFF
--- a/.agents/project-init-spec-kit-contract.json
+++ b/.agents/project-init-spec-kit-contract.json
@@ -1,0 +1,376 @@
+{
+  "$schema": "./project-init-spec-kit-contract.schema.json",
+  "schema_version": "1.0",
+  "tracking_issue": 166,
+  "status": "accepted",
+  "runtime_changes": false,
+  "audit": {
+    "surfaces": [
+      {
+        "repository": "codex-power-pack",
+        "path": ".codex/skills/project-init/SKILL.md",
+        "kind": "skill"
+      },
+      {
+        "repository": "codex-power-pack",
+        "path": "plugins/project/skills/project-init/agents/openai.yaml",
+        "kind": "agent-metadata"
+      },
+      {
+        "repository": "codex-power-pack",
+        "path": "plugins/project/skills/project-help/SKILL.md",
+        "kind": "help"
+      },
+      {
+        "repository": "codex-power-pack",
+        "path": "plugins/project/.codex-plugin/plugin.json",
+        "kind": "plugin-manifest"
+      },
+      {
+        "repository": "codex-power-pack",
+        "path": "plugins/spec/skills/spec-adopt/SKILL.md",
+        "kind": "skill"
+      },
+      {
+        "repository": "codex-power-pack",
+        "path": "plugins/spec/skills/spec-sync/SKILL.md",
+        "kind": "skill"
+      },
+      {
+        "repository": "claude-power-pack",
+        "path": ".claude/commands/project/init.md",
+        "kind": "workflow"
+      }
+    ],
+    "contradictions": [
+      {
+        "id": "PIC-001",
+        "promise": "Project help and metadata advertise a zero-to-GitHub, multi-language orchestrator.",
+        "actual": "The native project-init helper creates only a local Python scaffold and an optional local commit.",
+        "owner_issue": 159
+      },
+      {
+        "id": "PIC-002",
+        "promise": "Project help says project-init installs Power Pack state, hooks, and Spec Kit automatically.",
+        "actual": "The native skill correctly delegates publication, Spec Kit adoption, issue sync, and persistent influence to separate workflows.",
+        "owner_issue": 159
+      },
+      {
+        "id": "PIC-003",
+        "promise": "Every parsed Spec Kit task becomes a useful, independently actionable GitHub issue.",
+        "actual": "The duplicate helpers emit one low-context issue per matching line and silently ignore malformed task-like lines.",
+        "owner_issue": 160
+      },
+      {
+        "id": "PIC-004",
+        "promise": "Spec Kit adoption follows a durable upstream boundary.",
+        "actual": "spec-adopt currently installs from the moving upstream repository without a reviewed release pin.",
+        "owner_issue": 160
+      }
+    ],
+    "duplicate_helpers": [
+      {
+        "repository": "codex-power-pack",
+        "path": ".codex/skills/evaluate-help/scripts/speckit-tasks-to-issues.sh",
+        "sha256": "bcc4296e59d6d2d3d8f63b52103e3a5b9af8616009d4664ff49db08d0353d45f",
+        "disposition": "retire-in-favor-of-spec-sync",
+        "owner_issue": 160
+      },
+      {
+        "repository": "codex-power-pack",
+        "path": ".codex/skills/evaluate-issue/scripts/speckit-tasks-to-issues.sh",
+        "sha256": "bcc4296e59d6d2d3d8f63b52103e3a5b9af8616009d4664ff49db08d0353d45f",
+        "disposition": "retire-in-favor-of-spec-sync",
+        "owner_issue": 160
+      },
+      {
+        "repository": "codex-power-pack",
+        "path": ".codex/skills/project-init/scripts/speckit-tasks-to-issues.sh",
+        "sha256": "bcc4296e59d6d2d3d8f63b52103e3a5b9af8616009d4664ff49db08d0353d45f",
+        "disposition": "retire-in-favor-of-spec-sync",
+        "owner_issue": 160
+      },
+      {
+        "repository": "codex-power-pack",
+        "path": ".codex/skills/spec-sync/scripts/speckit-tasks-to-issues.sh",
+        "sha256": "e26721af333fc466cae9e42b5394489ab55f814903650229b72829657bae03a1",
+        "disposition": "retire-in-favor-of-spec-sync",
+        "owner_issue": 160
+      },
+      {
+        "repository": "codex-power-pack",
+        "path": "plugins/evaluate/skills/evaluate-help/scripts/speckit-tasks-to-issues.sh",
+        "sha256": "bcc4296e59d6d2d3d8f63b52103e3a5b9af8616009d4664ff49db08d0353d45f",
+        "disposition": "retire-in-favor-of-spec-sync",
+        "owner_issue": 160
+      },
+      {
+        "repository": "codex-power-pack",
+        "path": "plugins/evaluate/skills/evaluate-issue/scripts/speckit-tasks-to-issues.sh",
+        "sha256": "bcc4296e59d6d2d3d8f63b52103e3a5b9af8616009d4664ff49db08d0353d45f",
+        "disposition": "retire-in-favor-of-spec-sync",
+        "owner_issue": 160
+      },
+      {
+        "repository": "codex-power-pack",
+        "path": "plugins/project/skills/project-init/scripts/speckit-tasks-to-issues.sh",
+        "sha256": "bcc4296e59d6d2d3d8f63b52103e3a5b9af8616009d4664ff49db08d0353d45f",
+        "disposition": "retire-in-favor-of-spec-sync",
+        "owner_issue": 160
+      },
+      {
+        "repository": "codex-power-pack",
+        "path": "plugins/spec/skills/spec-sync/scripts/speckit-tasks-to-issues.sh",
+        "sha256": "e26721af333fc466cae9e42b5394489ab55f814903650229b72829657bae03a1",
+        "disposition": "retire-in-favor-of-spec-sync",
+        "owner_issue": 160
+      },
+      {
+        "repository": "claude-power-pack",
+        "path": "scripts/speckit-tasks-to-issues.sh",
+        "sha256": "bcc4296e59d6d2d3d8f63b52103e3a5b9af8616009d4664ff49db08d0353d45f",
+        "disposition": "retire-in-favor-of-spec-sync",
+        "owner_issue": 160
+      },
+      {
+        "repository": "claude-power-pack",
+        "path": "codex/skills/evaluate-help/scripts/speckit-tasks-to-issues.sh",
+        "sha256": "bcc4296e59d6d2d3d8f63b52103e3a5b9af8616009d4664ff49db08d0353d45f",
+        "disposition": "retire-in-favor-of-spec-sync",
+        "owner_issue": 160
+      },
+      {
+        "repository": "claude-power-pack",
+        "path": "codex/skills/evaluate-issue/scripts/speckit-tasks-to-issues.sh",
+        "sha256": "bcc4296e59d6d2d3d8f63b52103e3a5b9af8616009d4664ff49db08d0353d45f",
+        "disposition": "retire-in-favor-of-spec-sync",
+        "owner_issue": 160
+      },
+      {
+        "repository": "claude-power-pack",
+        "path": "codex/skills/project-init/scripts/speckit-tasks-to-issues.sh",
+        "sha256": "bcc4296e59d6d2d3d8f63b52103e3a5b9af8616009d4664ff49db08d0353d45f",
+        "disposition": "retire-in-favor-of-spec-sync",
+        "owner_issue": 160
+      },
+      {
+        "repository": "claude-power-pack",
+        "path": "codex/skills/project-next/scripts/speckit-tasks-to-issues.sh",
+        "sha256": "bcc4296e59d6d2d3d8f63b52103e3a5b9af8616009d4664ff49db08d0353d45f",
+        "disposition": "retire-in-favor-of-spec-sync",
+        "owner_issue": 160
+      }
+    ]
+  },
+  "routing": {
+    "default": "safe-local-scaffold",
+    "project_init_selection": "explicit-only",
+    "routes": [
+      {
+        "intent": "new-local-python-project",
+        "owner": "project-init",
+        "selection": "explicit",
+        "consent": "target-path",
+        "project_init_negative": false
+      },
+      {
+        "intent": "existing-repository-orientation",
+        "owner": "project-lite",
+        "selection": "explicit-or-narrow-implicit",
+        "consent": "read-only",
+        "project_init_negative": true
+      },
+      {
+        "intent": "next-work-recommendation",
+        "owner": "project-next",
+        "selection": "explicit-or-narrow-implicit",
+        "consent": "read-only",
+        "project_init_negative": true
+      },
+      {
+        "intent": "github-publication",
+        "owner": "github-publication-workflow",
+        "selection": "explicit",
+        "consent": "separate-explicit",
+        "project_init_negative": true
+      },
+      {
+        "intent": "spec-kit-adoption",
+        "owner": "spec-adopt",
+        "selection": "explicit",
+        "consent": "separate-explicit",
+        "project_init_negative": true
+      },
+      {
+        "intent": "issue-compilation",
+        "owner": "spec-sync",
+        "selection": "explicit",
+        "consent": "separate-explicit",
+        "project_init_negative": true
+      },
+      {
+        "intent": "persistent-influence",
+        "owner": "cxpp-init",
+        "selection": "explicit",
+        "consent": "separate-explicit",
+        "project_init_negative": true
+      }
+    ]
+  },
+  "spec_kit": {
+    "upstream": "https://github.com/github/spec-kit",
+    "release": "v0.16.0",
+    "commit": "5dce710ce099067c7d3f2ef47a37b9a1c300b327",
+    "install": "uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@v0.16.0",
+    "initialization": "specify init --here --integration codex",
+    "composition": {
+      "choice": "extension",
+      "rationale": "Readiness analysis and GitHub issue compilation add capabilities after official authoring; they do not replace core Spec Kit commands or templates.",
+      "rejected": [
+        {
+          "choice": "preset",
+          "reason": "A preset would override or compose core authoring files and create an unnecessary fork of the official workflow."
+        },
+        {
+          "choice": "bundle",
+          "reason": "A bundle only distributes multiple primitives; it is unnecessary until CxPP has more than the single issue-compilation extension to compose."
+        },
+        {
+          "choice": "hand-authored-scaffold",
+          "reason": "A substitute .specify scaffold would drift from the pinned official Codex integration."
+        }
+      ]
+    },
+    "readiness_gate": {
+      "approval_required": true,
+      "result": "ready-only-when-all-checks-pass",
+      "checks": [
+        {
+          "id": "spec-exists",
+          "failure": "The selected feature must contain .specify/specs/<feature>/spec.md."
+        },
+        {
+          "id": "plan-exists",
+          "failure": "The selected feature must contain .specify/specs/<feature>/plan.md."
+        },
+        {
+          "id": "tasks-exist",
+          "failure": "The selected feature must contain a non-empty .specify/specs/<feature>/tasks.md with canonical task identifiers."
+        },
+        {
+          "id": "consistency-analysis-clean",
+          "failure": "The official consistency analysis must report no unresolved errors across spec, plan, and tasks."
+        },
+        {
+          "id": "no-placeholders",
+          "failure": "Unresolved template markers, empty required sections, and placeholder tests block compilation."
+        },
+        {
+          "id": "exact-paths",
+          "failure": "Implementation tasks must name exact repository-relative paths or explicitly identify path discovery as their outcome."
+        },
+        {
+          "id": "independent-tests",
+          "failure": "Every issue group must carry an independently runnable acceptance checkpoint and quality commands."
+        },
+        {
+          "id": "dependencies-explicit",
+          "failure": "Cross-group prerequisites and blockers must be explicit and acyclic."
+        },
+        {
+          "id": "user-approved",
+          "failure": "The analyzed artifact set and proposed grouping require explicit approval before GitHub writes."
+        }
+      ]
+    }
+  },
+  "issue_compilation": {
+    "owner": "spec-sync",
+    "default_granularity": "stage-or-story",
+    "task_granularity": "explicit-request-only",
+    "stable_identity": "spec-sync:v1:<repo>:<tasks-path>:<stage-or-story-id>",
+    "required_body_sections": [
+      "outcome",
+      "tasks",
+      "user-story-traceability",
+      "acceptance-checkpoint",
+      "dependencies",
+      "constraints",
+      "quality-commands",
+      "immutable-artifact-links",
+      "sync-identity",
+      "mapping-write-back"
+    ],
+    "immutable_links": "Use GitHub blob URLs pinned to the approved artifact commit for spec.md, plan.md, and tasks.md.",
+    "mapping_write_back": "Update the selected tasks.md Issue Sync ledger with stable group identity, issue number, URL, and state after successful synchronization.",
+    "idempotency_scope": "open-and-closed-issues"
+  },
+  "rollout_ownership": [
+    {
+      "issue": 158,
+      "stage": "project-next fidelity foundation (complete)",
+      "responsibilities": [
+        "Provide the deterministic project-next models, collector, ranking core, and structured uncertainty boundary consumed by the mapping integration.",
+        "Leave stable mapping consumption to issue #160 because #158 merged before the prerequisite contract."
+      ],
+      "acceptance_evidence": [
+        "PR #167 merged the deterministic foundation and closed #158 while issue #166 was in progress."
+      ]
+    },
+    {
+      "issue": 159,
+      "stage": "invocation and metadata",
+      "responsibilities": [
+        "Align project-init skill, metadata, help, manifest, and prompts to the local-only default.",
+        "Make project-init explicit-only and enforce negative routing."
+      ],
+      "acceptance_evidence": [
+        "Fresh prompt inventory contains no contradictory project-init promises."
+      ]
+    },
+    {
+      "issue": 160,
+      "stage": "semantic compatibility and implementation",
+      "responsibilities": [
+        "Implement pinned Spec Kit adoption and the CxPP extension boundary.",
+        "Make spec-sync the only issue compiler and implement readiness, grouping, rich bodies, idempotency, and mapping write-back.",
+        "Replace project-next task-ID heuristics with stable mapping consumption and mapped dependency handling.",
+        "Retire every duplicate helper recorded by this contract."
+      ],
+      "acceptance_evidence": [
+        "Invalid artifacts fail loudly and approved artifacts compile into dependency-aware Flow issues."
+      ]
+    },
+    {
+      "issue": 161,
+      "stage": "evaluation",
+      "responsibilities": [
+        "Test positive and negative routing, scaffold consent, artifact parsing, grouping, rich bodies, idempotency, and end-to-end handoff."
+      ],
+      "acceptance_evidence": [
+        "Evaluation results distinguish routing, artifact, parser, grouping, body, mapping, and runtime failures."
+      ]
+    },
+    {
+      "issue": 162,
+      "stage": "persistent influence",
+      "responsibilities": [
+        "Keep AGENTS.md guidance, hooks, permissions, trust, and plugin state behind the separate cxpp-init consent boundary."
+      ],
+      "acceptance_evidence": [
+        "Declining persistent influence leaves only the ordinary local scaffold."
+      ]
+    },
+    {
+      "issue": 163,
+      "stage": "rollout",
+      "responsibilities": [
+        "Document migration and prove a clean-project workflow against immutable releases.",
+        "Keep task-granular synchronization an explicit compatibility option."
+      ],
+      "acceptance_evidence": [
+        "Dogfood demonstrates actionable, sequenced issues without hidden publication, installation, or persistence."
+      ]
+    }
+  ]
+}

--- a/.agents/project-init-spec-kit-contract.schema.json
+++ b/.agents/project-init-spec-kit-contract.schema.json
@@ -1,0 +1,282 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cooneycw/codex-power-pack/blob/main/.agents/project-init-spec-kit-contract.schema.json",
+  "title": "Project Init and Spec Kit Composition Contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "$schema",
+    "schema_version",
+    "tracking_issue",
+    "status",
+    "runtime_changes",
+    "audit",
+    "routing",
+    "spec_kit",
+    "issue_compilation",
+    "rollout_ownership"
+  ],
+  "properties": {
+    "$schema": {"const": "./project-init-spec-kit-contract.schema.json"},
+    "schema_version": {"const": "1.0"},
+    "tracking_issue": {"const": 166},
+    "status": {"const": "accepted"},
+    "runtime_changes": {"const": false},
+    "audit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["surfaces", "contradictions", "duplicate_helpers"],
+      "properties": {
+        "surfaces": {
+          "type": "array",
+          "minItems": 6,
+          "items": {"$ref": "#/$defs/surface"}
+        },
+        "contradictions": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"$ref": "#/$defs/contradiction"}
+        },
+        "duplicate_helpers": {
+          "type": "array",
+          "minItems": 2,
+          "items": {"$ref": "#/$defs/helper"}
+        }
+      }
+    },
+    "routing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["default", "project_init_selection", "routes"],
+      "properties": {
+        "default": {"const": "safe-local-scaffold"},
+        "project_init_selection": {"const": "explicit-only"},
+        "routes": {
+          "type": "array",
+          "minItems": 7,
+          "items": {"$ref": "#/$defs/route"}
+        }
+      }
+    },
+    "spec_kit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "upstream",
+        "release",
+        "commit",
+        "install",
+        "initialization",
+        "composition",
+        "readiness_gate"
+      ],
+      "properties": {
+        "upstream": {"const": "https://github.com/github/spec-kit"},
+        "release": {"type": "string", "pattern": "^v[0-9]+\\.[0-9]+\\.[0-9]+$"},
+        "commit": {"type": "string", "pattern": "^[0-9a-f]{40}$"},
+        "install": {"type": "string", "minLength": 1},
+        "initialization": {"const": "specify init --here --integration codex"},
+        "composition": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["choice", "rationale", "rejected"],
+          "properties": {
+            "choice": {"const": "extension"},
+            "rationale": {"type": "string", "minLength": 1},
+            "rejected": {
+              "type": "array",
+              "minItems": 2,
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["choice", "reason"],
+                "properties": {
+                  "choice": {"enum": ["preset", "bundle", "hand-authored-scaffold"]},
+                  "reason": {"type": "string", "minLength": 1}
+                }
+              }
+            }
+          }
+        },
+        "readiness_gate": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["approval_required", "result", "checks"],
+          "properties": {
+            "approval_required": {"const": true},
+        "result": {"const": "ready-only-when-all-checks-pass"},
+            "checks": {
+              "type": "array",
+              "minItems": 9,
+              "items": {"$ref": "#/$defs/readiness_check"}
+            }
+          }
+        }
+      }
+    },
+    "issue_compilation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "owner",
+        "default_granularity",
+        "task_granularity",
+        "stable_identity",
+        "required_body_sections",
+        "immutable_links",
+        "mapping_write_back",
+        "idempotency_scope"
+      ],
+      "properties": {
+        "owner": {"const": "spec-sync"},
+        "default_granularity": {"const": "stage-or-story"},
+        "task_granularity": {"const": "explicit-request-only"},
+        "stable_identity": {"type": "string", "minLength": 1},
+        "required_body_sections": {
+          "type": "array",
+          "minItems": 10,
+          "items": {
+            "enum": [
+              "outcome",
+              "tasks",
+              "user-story-traceability",
+              "acceptance-checkpoint",
+              "dependencies",
+              "constraints",
+              "quality-commands",
+              "immutable-artifact-links",
+              "sync-identity",
+              "mapping-write-back"
+            ]
+          },
+          "uniqueItems": true
+        },
+        "immutable_links": {"type": "string", "minLength": 1},
+        "mapping_write_back": {"type": "string", "minLength": 1},
+        "idempotency_scope": {"const": "open-and-closed-issues"}
+      }
+    },
+    "rollout_ownership": {
+      "type": "array",
+      "minItems": 6,
+      "maxItems": 6,
+      "items": {"$ref": "#/$defs/ownership"}
+    }
+  },
+  "$defs": {
+    "surface": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "path", "kind"],
+      "properties": {
+        "repository": {"enum": ["codex-power-pack", "claude-power-pack"]},
+        "path": {"type": "string", "minLength": 1},
+        "kind": {
+          "enum": [
+            "skill",
+            "agent-metadata",
+            "help",
+            "plugin-manifest",
+            "workflow",
+            "issue-compiler"
+          ]
+        }
+      }
+    },
+    "contradiction": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "promise", "actual", "owner_issue"],
+      "properties": {
+        "id": {"type": "string", "pattern": "^PIC-[0-9]{3}$"},
+        "promise": {"type": "string", "minLength": 1},
+        "actual": {"type": "string", "minLength": 1},
+        "owner_issue": {"type": "integer", "minimum": 158, "maximum": 163}
+      }
+    },
+    "helper": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository", "path", "sha256", "disposition", "owner_issue"],
+      "properties": {
+        "repository": {"enum": ["codex-power-pack", "claude-power-pack"]},
+        "path": {"type": "string", "minLength": 1},
+        "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+        "disposition": {"const": "retire-in-favor-of-spec-sync"},
+        "owner_issue": {"const": 160}
+      }
+    },
+    "route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["intent", "owner", "selection", "consent", "project_init_negative"],
+      "properties": {
+        "intent": {
+          "enum": [
+            "new-local-python-project",
+            "existing-repository-orientation",
+            "next-work-recommendation",
+            "github-publication",
+            "spec-kit-adoption",
+            "issue-compilation",
+            "persistent-influence"
+          ]
+        },
+        "owner": {
+          "enum": [
+            "project-init",
+            "project-lite",
+            "project-next",
+            "github-publication-workflow",
+            "spec-adopt",
+            "spec-sync",
+            "cxpp-init"
+          ]
+        },
+        "selection": {"enum": ["explicit", "explicit-or-narrow-implicit"]},
+        "consent": {"enum": ["target-path", "separate-explicit", "read-only"]},
+        "project_init_negative": {"type": "boolean"}
+      }
+    },
+    "readiness_check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "failure"],
+      "properties": {
+        "id": {
+          "enum": [
+            "spec-exists",
+            "plan-exists",
+            "tasks-exist",
+            "consistency-analysis-clean",
+            "no-placeholders",
+            "exact-paths",
+            "independent-tests",
+            "dependencies-explicit",
+            "user-approved"
+          ]
+        },
+        "failure": {"type": "string", "minLength": 1}
+      }
+    },
+    "ownership": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["issue", "stage", "responsibilities", "acceptance_evidence"],
+      "properties": {
+        "issue": {"type": "integer", "minimum": 158, "maximum": 163},
+        "stage": {"type": "string", "minLength": 1},
+        "responsibilities": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string", "minLength": 1}
+        },
+        "acceptance_evidence": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string", "minLength": 1}
+        }
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ desktop.ini
 !.agents/skill-evaluation-cases.schema.json
 !templates/project-next.schema.json
 !tests/project_next/fixtures/scenarios.json
+!.agents/project-init-spec-kit-contract.json
+!.agents/project-init-spec-kit-contract.schema.json
 !plugins/**/.codex-plugin/plugin.json
 !docs/architecture/c4-model.json
 !docs/architecture/c4-manifest.json

--- a/.specify/specs/wave-7-skill-influence-fidelity/plan.md
+++ b/.specify/specs/wave-7-skill-influence-fidelity/plan.md
@@ -30,6 +30,9 @@ mergeable and has a hard checkpoint before dependent work begins.
 | Lifecycle integration | Plugin-bundled Codex hooks | Native, trust-reviewed, and scoped to owning plugins |
 | Deterministic contracts | JSON fixtures and structured engine output | Separates data classification from model explanation |
 | Live evaluation | Bounded `codex exec --json` lane | Tests real selection and workflow adherence without burdening every PR |
+| Project creation | Explicit local Python scaffold | Makes the safe implemented behavior the default and separates later external effects |
+| Spec Kit boundary | Official `v0.16.0` Codex integration plus CxPP extension | Pins upstream authoring and adds compilation without replacing core templates |
+| Issue unit | Stage/story by default; task only by explicit request | Produces independently deliverable work suitable for `flow-auto` |
 
 ---
 
@@ -77,6 +80,22 @@ plugin source ----> semantic contract validator ----> packaged plugin
 
 target AGENTS.md routing + trusted plugin hooks
              -> optional durable session influence
+
+local project scaffold --separate consent--> GitHub publication
+         |
+         +--separate consent--> pinned official Spec Kit adoption
+                                      |
+                                      v
+                         spec/plan/tasks authoring
+                                      |
+                           blocking readiness gate
+                                      |
+                                      v
+                    CxPP Spec Kit extension (`spec-sync`)
+                                      |
+                         stage/story GitHub issues
+                                      |
+                         project-next -> flow-auto
 ```
 
 ### Key Design Decisions
@@ -91,6 +110,10 @@ target AGENTS.md routing + trusted plugin hooks
 | Compatibility validation | Hash parity, denylist lint, semantic graph | Keep parity plus semantic graph validation | Existing checks remain useful but no longer define completeness |
 | Persistent influence | Global prompt injection, target AGENTS.md, hooks only | Consent-first AGENTS.md routing plus narrowly owned hooks | Uses native durable surfaces while keeping changes transparent and removable |
 | Evaluation cadence | All live on every PR, deterministic only, split lane | Deterministic per PR; bounded live manual/scheduled lane | Preserves reliable CI without external-model flakiness or uncontrolled cost |
+| Project-init product | CPP zero-to-GitHub orchestration, native local scaffold, hybrid automatic pipeline | Native local scaffold with separately consented handoffs | Matches tested behavior and prevents one prompt from authorizing unrelated external state |
+| Spec Kit composition | Hand-authored scaffold, preset, extension, bundle | Official pinned authoring plus one CxPP extension | Readiness and issue compilation are additive capabilities, not core-template replacements or a multi-component distribution stack |
+| Issue compiler ownership | Copies in evaluate/project/project-next, spec-sync, shared helper | `spec-sync` only | One parser, grouping policy, idempotency model, and mapping writer can be tested and evolved coherently |
+| Sync identity | Title/task ID, artifact commit, stable ledger identity | Stable repo + task-ledger path + group ID | Survives title edits and artifact revisions while immutable links preserve the approved source commit |
 
 ### Behavioral Contract Boundaries
 
@@ -106,6 +129,26 @@ The wave distinguishes four contracts:
    visible, trusted, scoped, and removable.
 
 No single hash, metadata flag, or prompt-inventory assertion satisfies all four.
+
+### Project-to-Issue Composition Boundary
+
+Issue #166 publishes the normative contract in
+`.agents/project-init-spec-kit-contract.json` and its schema. The corresponding
+decision record is `docs/project-init-spec-kit-contract.md`. This prerequisite
+changes no runtime behavior; Stages 1 through 6 consume its assigned slices.
+
+The composition is sequential but not automatic. A successful local scaffold
+does not authorize publication. Publication does not authorize Spec Kit
+installation. Adoption does not authorize issue creation. A readiness result
+does not authorize GitHub writes until the user approves the artifact commit,
+grouping, and repository. Persistent AGENTS.md or hook influence remains a
+separate `cxpp-init` decision throughout.
+
+The Spec Kit integration is pinned to `v0.16.0` at commit
+`5dce710ce099067c7d3f2ef47a37b9a1c300b327`. CxPP will implement readiness and
+issue compilation as an extension. The extension preserves official spec,
+plan, and task authoring, rejects incomplete artifacts, and emits stable
+stage/story mappings for `project-next` and `flow-auto`.
 
 ---
 
@@ -126,9 +169,12 @@ scripts/
 
 .agents/
 ├── skill-contracts.json      # published skills, aliases, ownership, exclusions
+├── project-init-spec-kit-contract.schema.json
+├── project-init-spec-kit-contract.json
 └── routing-block.md          # concise target-repository AGENTS.md fragment
 
 tests/
+├── test_project_init_spec_kit_contract.py
 ├── project_next/
 │   ├── fixtures/
 │   ├── test_classification.py
@@ -149,6 +195,7 @@ plugins/<family>/
 └── hooks/                    # only where the family owns a reviewed hook
 
 docs/
+├── project-init-spec-kit-contract.md
 ├── skill-quality.md
 └── migration/skill-influence-wave-7.md
 ```
@@ -181,6 +228,11 @@ The stage must decide the final cross-repository source-of-truth location. If a
 CPP change is required, land the CPP contract/generator change first, pin it,
 and then adopt it in CxPP without leaving a second prompt-only fork.
 
+PR #167 merged this foundation and closed #158 while issue #166 was in progress.
+Stable stage/story/task mapping did not yet exist, so the consumer integration
+is assigned to Stage 3 alongside the compiler. Task IDs remain traceability
+keys, not proof that every task owns a GitHub issue.
+
 **Exit gate:** fixture outcomes are deterministic; blocked and in-flight issues
 cannot leak into startable choices; brief/compact/full outputs pass; live dogfood
 chooses the expected action on both power-pack repositories.
@@ -191,6 +243,11 @@ Replace faux plugin slash-command guidance with supported Codex selection,
 rewrite trigger descriptions and starter prompts, and select the initial
 implicit-entrypoint set using golden prompts. Add per-plugin and full-suite
 prompt-inventory tests.
+
+Align project-init's skill text, help, metadata, plugin manifest, and starter
+prompts to the local-only explicit contract. Add negative activation cases for
+orientation, next-work analysis, publication, Spec Kit adoption, issue sync,
+and ordinary changes in existing repositories.
 
 **Exit gate:** every advertised invocation is valid, every starter prompt
 selects a bundled skill, and activation thresholds pass for the changed
@@ -206,6 +263,14 @@ surfaces. Integrate the validator into `make verify` and CI.
 Existing issues #135 and #140 are inputs to this stage; the stage issues must
 either satisfy their exit bars or explicitly narrow the remaining work.
 
+This stage owns the runtime implementation of the project-to-issue contract:
+pin official Spec Kit adoption, add the CxPP extension, implement the readiness
+gate and stage/story compiler, write rich issue bodies and stable mappings, and
+retire every duplicate compiler payload inventoried by issue #166. Replace the
+new project-next task-ID heuristic with those mappings; missing, stale, or
+ambiguous mappings remain uncertainty and cannot make blocked or represented
+work appear startable.
+
 **Exit gate:** source, packaged, and marketplace inventories reconcile; all
 cross-skill links resolve; operational Claude-only constructs require reviewed
 adaptations; every published family passes the semantic gate.
@@ -216,6 +281,10 @@ Add deterministic evaluation cases across priority skills and a bounded live
 Codex lane. Separate activation failures from instruction-following and runtime
 failures so metadata tuning does not mask procedure defects. Store only
 non-secret summaries and aggregate metrics.
+
+Add distinct fixtures for project routing, scaffold consent, pinned adoption,
+artifact readiness, malformed tasks, grouping, issue bodies, idempotency,
+mapping repair, and the complete scaffold-to-Flow dry run.
 
 **Exit gate:** priority entrypoints meet the spec thresholds; deterministic
 evaluations run on every PR; the live lane has a documented manual/scheduled
@@ -228,6 +297,10 @@ Create the concise target-repository `AGENTS.md` routing block and additive
 capture with the owning plugins, preserve Codex's hook trust flow, and extend
 `cxpp-status` with safe diagnostics.
 
+Project creation may offer this stage only as a handoff to `cxpp-init`.
+Declining the handoff leaves the ordinary local scaffold unchanged and never
+installs AGENTS.md routing, hooks, permissions, trust, or plugin state.
+
 **Exit gate:** clean install, upgrade, decline, untrusted-hook, changed-hook,
 disable, and removal scenarios are tested; no persistent component turns itself
 on without approval.
@@ -238,6 +311,11 @@ Publish migration guidance, update help and architecture documentation, cut a
 pinned release, and run representative dogfood sessions. Review the implicit
 set and remaining exclusions against measured results. Close or re-scope legacy
 issues only after their exit bars are demonstrably met.
+
+Dogfood at least one clean project through local scaffold, optional publication,
+pinned Spec Kit adoption, approved artifact readiness, stage/story issue sync,
+`project-next`, and `flow-auto`. Migration guidance must explain retirement of
+duplicate helpers and one-line per-task issues.
 
 **Exit gate:** immutable install and rollback transcripts pass, 20
 representative sessions meet the success criteria, and all wave documentation
@@ -254,7 +332,7 @@ matches the released payload.
 | git | Repository, branch, and worktree state | Stop repository-state workflows with an actionable prerequisite |
 | GitHub CLI (`gh`) | Issues, PRs, checks, and repository identity | Report authentication or rate-limit state; never rank an incomplete inventory as complete |
 | Codex CLI | Prompt inventory and bounded live evaluation | Deterministic gates continue; live lane reports not checked |
-| Optional spec-kit | Detect unsynchronized specification tasks | Skip with an explicit not-configured status |
+| Official Spec Kit `v0.16.0` | Author spec, plan, and task artifacts through the Codex integration | Adoption stops on pin/install/init failure; repository analysis reports not configured when absent |
 | Optional MCP services | Skill-specific live tools | Declare/check dependency and degrade per owning skill |
 
 ### Internal Dependencies
@@ -279,6 +357,8 @@ matches the released payload.
   path classification, and metadata policies.
 - AGENTS.md block generation and additive merge behavior.
 - Hook payload validation, masking, failure-open behavior, and status reporting.
+- Project routing, artifact-readiness checks, grouping, stable sync identity,
+  issue-body rendering, open/closed idempotency, and mapping write-back.
 
 ### Integration Tests
 

--- a/.specify/specs/wave-7-skill-influence-fidelity/spec.md
+++ b/.specify/specs/wave-7-skill-influence-fidelity/spec.md
@@ -215,6 +215,42 @@ workflows,
 
 ---
 
+### US7: Safe Project-to-Issue Composition [P1]
+
+**As a** maintainer starting a new project or compiling approved planning
+artifacts,
+**I want** each state-changing stage to have one truthful owner and a separate
+consent boundary,
+**So that** a local scaffold cannot silently publish, install, persist, or
+create low-context implementation issues.
+
+**Acceptance Criteria:**
+
+- [ ] `project-init` defaults to a local Python scaffold and is explicit-only;
+      GitHub publication, Spec Kit adoption, issue synchronization, and
+      persistent influence are separate reviewed handoffs.
+- [ ] Existing-repository orientation, next-work selection, publication-only,
+      adoption-only, synchronization-only, and ordinary repository changes do
+      not select `project-init`.
+- [ ] Official GitHub Spec Kit is installed from a reviewed immutable release,
+      initialized with the Codex integration, and never replaced by a
+      hand-authored `.specify/` scaffold.
+- [ ] CxPP adds artifact readiness and issue compilation through an official
+      Spec Kit extension; it does not override core authoring through a preset.
+- [ ] Missing artifacts, unresolved consistency errors, placeholders, malformed
+      tasks, vague paths, missing independent tests, unresolved dependencies,
+      or absent user approval block issue writes.
+- [ ] `spec-sync` is the sole issue compiler and defaults to independently
+      deliverable stage or story groups; per-task issues require an explicit
+      compatibility request.
+- [ ] Issue bodies carry the full outcome, task descriptions, traceability,
+      acceptance, dependencies, constraints, quality commands, immutable
+      artifact links, stable identity, and mapping write-back contract.
+- [ ] Synchronization is idempotent across open and closed issues and updates
+      the selected feature task ledger after successful writes.
+
+---
+
 ## Edge Cases
 
 | Scenario | Expected Behavior |
@@ -227,6 +263,10 @@ workflows,
 | A plugin hook changes after trust was granted | Codex's normal hash-based trust review applies; the changed hook remains inactive until reviewed |
 | A target repository already has custom AGENTS.md routing | Preview a bounded additive merge and preserve existing instructions |
 | Live model evaluation is unavailable | Deterministic gates still run; mark the live lane not checked rather than green |
+| A non-empty tasks file yields zero parsed tasks | Fail readiness and identify each malformed task-like line; never report an empty successful sync |
+| A prior mapped issue is closed or renamed | Match its stable sync identity, preserve the mapping, and do not create a replacement |
+| A task belongs to multiple stories or has ambiguous grouping | Stop at preview and require an explicit stage/story boundary or task-granularity request |
+| Spec Kit initialization would overwrite existing files | Show the affected paths and require explicit approval before any `--force` use |
 
 ---
 
@@ -263,6 +303,13 @@ workflows,
 | R9 | Offer additive target-repository AGENTS.md routing with explicit consent | Should | US5 |
 | R10 | Package owner-specific hooks with trust and status diagnostics | Should | US5 |
 | R11 | Publish migration, rollback, and immutable-pin verification | Must | US6 |
+| R12 | Keep project-init local-by-default, explicit-only, and negatively routed away from narrower existing-repository workflows | Must | US2, US7 |
+| R13 | Adopt official Spec Kit at the reviewed release pin with the Codex integration and no substitute scaffold | Must | US3, US7 |
+| R14 | Add CxPP readiness and issue compilation as a Spec Kit extension rather than a core-authoring preset | Must | US3, US7 |
+| R15 | Block issue writes until artifact presence, consistency, placeholder, path, test, dependency, and approval checks pass | Must | US7 |
+| R16 | Make spec-sync the only compiler and default to independently deliverable stage/story groups | Must | US7 |
+| R17 | Generate context-complete issue bodies with immutable artifact links and stable synchronization identities | Must | US1, US7 |
+| R18 | Synchronize idempotently across open and closed issues and write mappings back to the feature task ledger | Must | US1, US7 |
 
 ### Non-Functional Requirements
 
@@ -274,6 +321,7 @@ workflows,
 | NFR4 | Portability | Deterministic tooling uses Python 3.11+ and runs on Linux, macOS, and Windows where git/gh are available |
 | NFR5 | Auditability | Every exclusion and evaluation exception has an owner, reason, and expiry/review date |
 | NFR6 | Backward compatibility | Existing explicit skill selection remains functional during migration |
+| NFR7 | Composition safety | Each external write, installation, publication, or persistent change has one owner and a separate recorded approval |
 
 ---
 
@@ -290,6 +338,8 @@ workflows,
 - [ ] All staged implementation issues are merged with `make verify` green.
 - [ ] Documentation, release guidance, and rollback instructions match the
       installed behavior.
+- [ ] The project-init and Spec Kit composition contract remains schema-valid,
+      and every runtime responsibility is closed by its assigned Wave 7 stage.
 
 ---
 

--- a/.specify/specs/wave-7-skill-influence-fidelity/tasks.md
+++ b/.specify/specs/wave-7-skill-influence-fidelity/tasks.md
@@ -44,33 +44,60 @@ No runtime behavior changes in this stage.
 
 ---
 
+## Prerequisite: `project-init` and Spec Kit Composition Contract
+
+- [x] **T090** [US7] Audit the native project-init skill, scaffold helper,
+      agent metadata, generated help, project manifest, CPP orchestration, Spec
+      Kit skills, and every bundled task-to-issues helper.
+- [x] **T091** [US7] Define the safe local scaffold default and separate consent
+      boundaries for local Git, GitHub publication, Spec Kit adoption, issue
+      compilation, and persistent influence.
+- [x] **T092** [US2,US7] Define positive and negative routing, including
+      explicit-only project-init selection.
+- [x] **T093** [US3,US7] Pin the reviewed official Spec Kit Codex integration and
+      select an additive CxPP extension rather than a preset, bundle, or
+      hand-authored substitute scaffold.
+- [x] **T094** [US7] Define the blocking artifact-readiness checks and explicit
+      approval boundary.
+- [x] **T095** [US1,US7] Define stage/story grouping, rich issue bodies, stable
+      sync identity, open/closed idempotency, and feature-ledger write-back.
+- [x] **T096** [US1-US7] Assign implementation, evaluation, consent, and rollout
+      responsibilities to issues #158 through #163.
+- [x] **T097** [US3,US7] Publish and test the versioned machine-readable
+      composition contract without changing runtime behavior.
+
+**Checkpoint:** Issue #166 has one reviewed decision record and schema-validated
+contract; every runtime change has exactly one open Wave 7 owner.
+
+---
+
 ## Stage 1: `project-next` Fidelity Vertical Slice
 
-- [ ] **T101** [US1] Write a shared `project-next` behavioral contract covering
+- [x] **T101** [US1] Write a shared `project-next` behavioral contract covering
       inputs, classification sets, ranking, top action, next startable issue,
       modes, uncertainty, and failure states.
-- [ ] **T102** [US1] Decide and document the durable CPP/CxPP source-of-truth and
+- [x] **T102** [US1] Decide and document the durable CPP/CxPP source-of-truth and
       generation boundary; create/link a CPP twin issue if required.
-- [ ] **T103** [US1] Add structured repository-state and recommendation models
+- [x] **T103** [US1] Add structured repository-state and recommendation models
       under `lib/project_next/`.
-- [ ] **T104** [US1] Implement deterministic in-flight mapping, dependency graph,
+- [x] **T104** [US1] Implement deterministic in-flight mapping, dependency graph,
       transitive/cycle blocking, availability validation, and uncertainty.
-- [ ] **T105** [US1] Implement stable ranking for critical work, priority,
+- [x] **T105** [US1] Implement stable ranking for critical work, priority,
       phase/wave, issue type, quick wins, staleness, and tie-breaks.
-- [ ] **T106** [US1] Implement top-action selection separately from the next new
+- [x] **T106** [US1] Implement top-action selection separately from the next new
       issue that is safe to start.
-- [ ] **T107** [US1] Add a git/gh/spec collection adapter that reports incomplete
+- [x] **T107** [US1] Add a git/gh/spec collection adapter that reports incomplete
       inventories and rate-limit/authentication failures without false certainty.
-- [ ] **T108** [US1] Add harness-neutral project-next configuration with schema,
+- [x] **T108** [US1] Add harness-neutral project-next configuration with schema,
       defaults, validation, and examples.
-- [ ] **T109** [US1] Update the Codex skill to call the deterministic core and
+- [x] **T109** [US1] Update the Codex skill to call the deterministic core and
       render versioned `--brief`, compact, and `--full` outputs.
-- [ ] **T110** [P] [US1,US4] Add fixtures for active PRs, remote branches, dirty
+- [x] **T110** [P] [US1,US4] Add fixtures for active PRs, remote branches, dirty
       worktrees, reviews, CI failures, epics, priorities, dependency chains,
       cycles, ambiguity, and unsynchronized spec tasks.
-- [ ] **T111** [US1,US4] Add end-to-end fixture and dogfood tests against both
+- [x] **T111** [US1,US4] Add end-to-end fixture and dogfood tests against both
       power-pack repositories.
-- [ ] **T112** [US1] Reconcile or retire the conflicting generated/native
+- [x] **T112** [US1] Reconcile or retire the conflicting generated/native
       `project-next` exception so only the documented ownership model remains.
 
 **Checkpoint:** The deterministic fixtures select the expected top action and
@@ -99,6 +126,14 @@ all three output modes pass; CxPP dogfood no longer needs a Claude rerun.
       uniqueness, priority-preservation, and metadata-budget tests.
 - [ ] **T208** [US2,US6] Version plugin payloads and document the new-session or
       reinstall boundary required to pick up metadata changes.
+- [ ] **T209** [US2,US7] Align project-init skill, help, agent metadata, plugin
+      manifest, and starter prompts to the explicit local Python scaffold.
+- [ ] **T210** [US2,US7] Add negative routing for existing-repository
+      orientation, next-work analysis, publication, Spec Kit adoption, issue
+      synchronization, and ordinary repository changes.
+- [ ] **T211** [US7] Present publication, adoption, synchronization, and
+      persistent influence only as separately consented owning-workflow
+      handoffs.
 
 **Checkpoint:** All advertised invocation paths work in a fresh session, starter
 prompts resolve, and priority skill activation meets the initial thresholds.
@@ -130,6 +165,32 @@ prompts resolve, and priority skill activation meets the initial thresholds.
       record keep/adapt/exclude decisions for every affected surface.
 - [ ] **T311** [US3,US4] Integrate semantic validation into `make verify` and CI
       while retaining hash-parity and focused harness-lint checks.
+- [ ] **T312** [US3,US7] Pin official Spec Kit adoption to the reviewed release,
+      record the installed version, preserve the Codex integration, and require
+      path-level approval before any forced replacement.
+- [ ] **T313** [US3,US7] Implement the CxPP readiness and issue-compilation
+      boundary as an official Spec Kit extension without overriding core
+      authoring templates.
+- [ ] **T314** [US3,US7] Retire duplicate compilers from evaluate, project-init,
+      project-next, generated payloads, and plugin payloads so `spec-sync` is
+      the sole owner.
+- [ ] **T315** [US7] Validate canonical task syntax and block missing artifacts,
+      consistency errors, placeholders, vague paths, missing independent tests,
+      unresolved dependencies, and absent approval.
+- [ ] **T316** [US7] Implement explicit stage, story, and task grouping with
+      independently deliverable stage/story groups as the default.
+- [ ] **T317** [US1,US7] Render complete issue bodies with outcome, tasks,
+      traceability, acceptance, dependencies, constraints, quality commands,
+      immutable artifact links, and stable sync identity.
+- [ ] **T318** [US1,US7] Synchronize idempotently across open and closed issues
+      and write issue number, URL, state, and stable group identity back to the
+      selected feature task ledger.
+- [ ] **T319** [US7] Keep project-init limited to offering `spec-adopt` and
+      `spec-sync` as separate handoffs; never create placeholder artifacts or
+      GitHub issues automatically.
+- [ ] **T320** [US1,US7] Replace project-next's task-ID synchronization heuristic
+      with stable stage/story/task mappings, follow mapped dependencies, and
+      report missing, stale, or ambiguous mappings as uncertainty.
 
 **Checkpoint:** Every published family passes semantic validation; all links
 resolve; operational host mismatches require narrow reviewed adaptations; the
@@ -155,6 +216,17 @@ source/package/marketplace inventory is complete.
       manual/scheduled live cadence and release-gating policy.
 - [ ] **T408** [US4] Publish a concise baseline-versus-current scorecard for
       priority skills without storing prompts or data that contain secrets.
+- [ ] **T409** [US2,US4,US7] Add direct project-init activation and negative
+      orientation, publication-only, adoption-only, sync-only, and existing-repo
+      activation cases.
+- [ ] **T410** [US4,US7] Add local scaffold and separate-consent fixtures for
+      publication, Spec Kit adoption, and declined handoffs.
+- [ ] **T411** [US4,US7] Add canonical, malformed, multiline, placeholder,
+      zero-task, multiple-feature, and dependency parser fixtures.
+- [ ] **T412** [US4,US7] Add golden stage/story/task issue bodies, open/closed
+      idempotency, mapping write-back, and stale-mapping repair fixtures.
+- [ ] **T413** [US1,US4,US7] Add an isolated dry run from local scaffold through
+      pinned adoption, readiness, preview, mapping, and project-next consumption.
 
 **Checkpoint:** Direct recall is 100%, indirect recall is at least 90% for
 implicit priority skills, negative precision is at least 95%, and evaluation
@@ -180,6 +252,8 @@ failures identify the failing contract layer.
       untrusted, disabled, removal, and plugin-uninstall tests.
 - [ ] **T507** [P] [US5] Add security tests proving hooks fail open, mask output,
       avoid secrets, and never grant permissions or invoke shipping actions.
+- [ ] **T508** [US5,US7] Prove project-init never installs persistent influence
+      and that declining its `cxpp-init` handoff leaves only the local scaffold.
 
 **Checkpoint:** Persistent influence is transparent, consent-first, trust-
 reviewed, status-visible, and fully removable; declining it leaves the ordinary
@@ -207,6 +281,16 @@ skill workflow intact.
       verify `cxpp-status` against the installed payload in a fresh session.
 - [ ] **T608** [US6] Mark the wave complete only after all spec success criteria
       and repository quality gates pass.
+- [ ] **T609** [US6,US7] Dogfood a clean project through local scaffold,
+      optional publication, pinned adoption, readiness, stage/story sync,
+      project-next, and flow-auto.
+- [ ] **T610** [US6,US7] Verify adoption install and rollback against immutable
+      Spec Kit and CxPP release refs.
+- [ ] **T611** [US6,US7] Publish migration from duplicate compilers and one-line
+      task issues, retaining task-granular sync only as an explicit option.
+- [ ] **T612** [US6,US7] Include issue outcome, traceability, independent
+      acceptance, dependency, command, and immutable-link quality in rollout
+      evidence.
 
 **Checkpoint:** Migration and rollback are proven, 20 dogfood sessions meet the
 quality thresholds, and repository documentation matches an immutable released
@@ -257,18 +341,18 @@ Stage 0 baseline
 |-------|-------|-------|--------|
 | Specification | spec.md, plan.md, tasks.md | #153 | complete |
 | 0 - Baseline | T001-T006 | #157 | complete |
-| Contract augmentation | project-init / Spec Kit | #166 | open |
-| 1 - project-next | T101-T112 | #158 | open |
-| 2 - Invocation/metadata | T201-T208 | #159 | open |
-| 3 - Semantic gates | T301-T311 | #160 | open |
-| 4 - Evaluations | T401-T408 | #161 | open |
-| 5 - Persistent influence | T501-T507 | #162 | open |
-| 6 - Rollout | T601-T608 | #163 | open |
+| Composition prerequisite | T090-T097 | #166 | in progress |
+| 1 - project-next | T101-T112 | #158 | complete |
+| 2 - Invocation/metadata | T201-T211 | #159 | open |
+| 3 - Semantic gates | T301-T320 | #160 | open |
+| 4 - Evaluations | T401-T413 | #161 | open |
+| 5 - Persistent influence | T501-T508 | #162 | open |
+| 6 - Rollout | T601-T612 | #163 | open |
 
-Completion sequence: #157 is complete. The #158 core and #166 may proceed in
-parallel; #166 unlocks #159 and the issue-mapping slice of #158; #159 unlocks
-#160; #158 and #160 jointly unlock #161; #160 and #161 jointly unlock #162;
-#158 through #162 plus #166 must close before #163 can close the wave.
+Completion sequence: #157 and #158 are complete. #166 unlocks #159 and the
+project-next mapping integration now assigned to #160; #159 unlocks #160; #160
+unlocks #161; #160 and #161 jointly unlock #162; #158 through #162 plus #166
+must close before #163 can close the wave.
 
 ---
 

--- a/docs/architecture/c4-manifest.json
+++ b/docs/architecture/c4-manifest.json
@@ -1,6 +1,6 @@
 {
   "project": "Codex Power Pack",
-  "generated_at": "2026-08-06T20:21:11Z",
+  "generated_at": "2026-08-06T20:31:44Z",
   "engine": "c4-mermaid",
   "diagrams": [
     {

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -123,4 +123,4 @@ classDiagram
   OutputMasker --> SecretBundle : masks values from
 ```
 
-_Generated 2026-08-06T20:21:11Z_
+_Generated 2026-08-06T20:31:44Z_

--- a/docs/project-init-spec-kit-contract.md
+++ b/docs/project-init-spec-kit-contract.md
@@ -1,0 +1,190 @@
+# Project Init and Spec Kit Composition Contract
+
+- Status: Accepted
+- Decision issue: [#166](https://github.com/cooneycw/codex-power-pack/issues/166)
+- Parent specification: [Wave 7 skill influence and behavioral fidelity](../.specify/specs/wave-7-skill-influence-fidelity/spec.md)
+- Executable contract: [`.agents/project-init-spec-kit-contract.json`](../.agents/project-init-spec-kit-contract.json)
+
+## Context
+
+CxPP currently presents two incompatible project-creation products. The native
+`project-init` skill and its tested helper create a deterministic local Python
+project, optionally initialize local Git, and optionally create one local
+commit. Generated `project-help`, the project plugin manifest, and agent
+metadata instead advertise a multi-language, zero-to-GitHub orchestrator that
+also installs Power Pack state and initializes Spec Kit.
+
+Issue compilation has a similar ownership problem. The original CPP helper is
+copied into generated evaluate, project-init, and project-next payloads and then
+copied again into CxPP source and plugin payloads. The newer `spec-sync` copy is
+safer about preview and consent, but both implementations assume one issue per
+task and produce a one-line body. Neither contract is sufficient input for an
+independently executed `flow-auto` lifecycle.
+
+This record chooses the product boundaries before Wave 7 changes runtime
+behavior. The checked-in JSON instance is normative; this document explains
+the decisions for reviewers.
+
+## Audit Findings
+
+The audit covered:
+
+- the native `.codex/skills/project-init/` skill and scaffold helper;
+- `plugins/project/skills/project-init/agents/openai.yaml`;
+- generated `project-help` and the project plugin manifest;
+- native `spec-adopt` and `spec-sync` skills and their plugin metadata;
+- CPP's `.claude/commands/project/init.md` orchestration workflow;
+- every `speckit-tasks-to-issues.sh` payload in CxPP and the sibling CPP
+  checkout.
+
+Thirteen helper payloads were found: eight in CxPP and five in CPP. Eleven are
+byte-identical copies of the original helper; the two `spec-sync` copies are
+byte-identical to each other. The executable contract records every path and
+observed SHA-256 digest so Stage 3 can retire the duplicates without relying on
+another ad hoc inventory.
+
+The contradictions are product claims, not missing convenience:
+
+| Surface | Advertised promise | Verified behavior | Owner |
+|---------|--------------------|-------------------|-------|
+| `project-help`, project metadata, plugin manifest | Multi-language scaffold through pushed GitHub repository | Local Python scaffold; optional local Git and commit | #159 |
+| generated CPP workflow | Toolkit installation, hooks, Spec Kit scaffold, placeholder first spec, immediate issue sync | None of these are part of the native CxPP helper | #159 |
+| duplicated issue helpers | Useful issue per task and safe repeat runs | Thin one-line bodies; malformed task-like lines can be ignored; title-based dedup only | #160 |
+| `spec-adopt` | Durable official Spec Kit adoption | Install follows a moving Git branch | #160 |
+
+## Decision 1: Project Init Is a Safe Local Scaffold
+
+`project-init` has one default outcome: create a new local Python project in a
+reviewed target directory. It is explicit-only because it writes several files
+and may create a Git repository or commit when those options are separately
+requested. No activation request may silently widen the operation into GitHub
+publication, Spec Kit installation, issue creation, plugin installation,
+AGENTS.md influence, hook installation, permission changes, or trust decisions.
+
+Publication, adoption, synchronization, and persistent influence are handoffs,
+not hidden phases of project-init:
+
+| User intent | Owning workflow | Project-init boundary |
+|-------------|-----------------|-----------------------|
+| Create a new local Python project | `$project-init` | Positive route; confirm destination and optional local Git/commit |
+| Orient within an existing repository | `$project-lite` | Negative route; do not scaffold |
+| Choose the next repository action | `$project-next` | Negative route; remain read-only |
+| Publish a repository to GitHub | repository-aware GitHub workflow or reviewed `gh repo create` | Separate approval of owner, name, visibility, remote, and first push |
+| Adopt official Spec Kit | `$spec-adopt` | Separate approval after previewing affected paths and the immutable release |
+| Compile approved artifacts into issues | `$spec-sync` | Separate dry-run and approval; never a scaffold side effect |
+| Add persistent CxPP guidance or hooks | `$cxpp-init` | Separate preview, trust, approval, status, and removal contract |
+
+The destination confirmation authorizes only the local scaffold. Each later
+handoff receives its own consent and can be declined without invalidating the
+project.
+
+## Decision 2: Official Spec Kit Is the Authoring Boundary
+
+CxPP adopts GitHub Spec Kit rather than recreating `.specify/` by hand. The
+reviewed boundary is release `v0.16.0`, resolving to commit
+`5dce710ce099067c7d3f2ef47a37b9a1c300b327`:
+
+```text
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git@v0.16.0
+specify init --here --integration codex
+```
+
+Stage 3 may update the pin only through a reviewed contract change. It must
+record the installed version. `specify init` remains consent-first and must not
+receive `--force` unless the user has seen the exact paths at risk and explicitly
+approves replacement.
+
+CxPP's additional readiness and issue-compilation behavior will be an official
+Spec Kit **extension**:
+
+- An extension is additive and is the upstream mechanism for new commands,
+  external integrations, and quality gates.
+- A preset is rejected because presets replace or compose core authoring
+  commands and templates; CxPP does not need a fork of official authoring.
+- A bundle is rejected for now because it only distributes a stack of existing
+  primitives. One extension is not a stack. A later bundle may be proposed if
+  CxPP has multiple independently versioned Spec Kit components.
+- A hand-authored substitute scaffold is rejected because it would immediately
+  establish a second, drifting authoring product.
+
+## Decision 3: Artifact Readiness Is a Blocking Gate
+
+`spec-sync` may preview issue groups only when it can identify one selected
+feature directory. GitHub writes require every check below to pass and the user
+to approve the analyzed commit and grouping:
+
+1. `.specify/specs/<feature>/spec.md` exists and contains its required outcome,
+   stories, requirements, and acceptance criteria.
+2. `.specify/specs/<feature>/plan.md` exists and describes the implementation
+   approach, constraints, and dependencies.
+3. `.specify/specs/<feature>/tasks.md` is non-empty and every task-like line
+   parses with a canonical stable task identifier.
+4. The official consistency analysis has no unresolved errors across the three
+   artifacts. Warnings must be shown and explicitly accepted.
+5. No unresolved template markers, empty required sections, placeholder tests,
+   or placeholder implementation descriptions remain.
+6. Implementation tasks name exact repository-relative paths. A discovery task
+   is allowed only when discovering those paths is its explicit outcome.
+7. Every proposed issue group has an independently runnable acceptance
+   checkpoint and named quality commands.
+8. Cross-group dependencies are explicit, resolvable, and acyclic.
+9. The user approves the artifact commit, proposed groups, repository, and
+   resulting GitHub writes after the dry-run.
+
+A non-empty task file that yields zero parsed tasks is always an error. A
+task-like line with an invalid identifier or malformed syntax is always an
+error. The compiler never treats skipped input as successful readiness.
+
+## Decision 4: Compile Deliverable Groups, Not Micro-Issues
+
+The default unit is an independently deliverable stage or story:
+
+1. Use explicit stage, wave, or phase groups when the ledger defines them as
+   independently mergeable checkpoints.
+2. Otherwise group by user story when each story has its own outcome and
+   acceptance checkpoint.
+3. Refuse ambiguous automatic grouping and request a documented boundary.
+4. Create one issue per task only when the user explicitly selects task
+   granularity. Task mode is a compatibility option, not the CxPP default.
+
+`spec-sync` is the only owner of compilation and synchronization. Evaluate,
+project-init, project-next, and other skills may call or consume its public
+contract; they may not carry private compiler copies.
+
+Each issue body contains:
+
+- the deliverable outcome;
+- every included task ID and full task description;
+- user-story and requirement traceability;
+- an independent acceptance checkpoint;
+- mapped prerequisite issue numbers and unresolved dependency identifiers;
+- constraints and explicit non-goals;
+- exact quality commands;
+- immutable GitHub blob links to the approved `spec.md`, `plan.md`, and
+  `tasks.md` commit;
+- a hidden stable identity of the form
+  `spec-sync:v1:<repo>:<tasks-path>:<stage-or-story-id>`;
+- the feature-ledger mapping that will be written after successful sync.
+
+Idempotency searches the stable identity across open and closed issues. Closed
+work is not recreated. Changed titles or descriptions do not create duplicates.
+After a successful create or repair, `spec-sync` updates the selected
+`tasks.md` Issue Sync ledger with the stable group identity, issue number, URL,
+and state. A partial write reports exactly which mappings remain unresolved and
+does not claim the ledger is synchronized.
+
+## Ownership and Rollout
+
+| Issue | Owner contract | Required evidence |
+|-------|----------------|-------------------|
+| #158 | Deterministic `project-next` foundation, merged in PR #167 while this contract was in progress | Structured models, collection, ranking, and uncertainty boundary are available for the Stage 3 mapping integration |
+| #159 | Align project-init skill, help, metadata, manifest, prompts, explicit-only policy, and negative routing | Fresh prompt inventory contains no contradictory claims |
+| #160 | Implement the pin, extension, readiness gate, sole compiler, grouping, rich bodies, idempotency, mapping write-back, project-next mapping consumption, and duplicate retirement | Invalid artifacts fail loudly; approved artifacts create actionable Flow issues and mapped dependencies drive recommendations |
+| #161 | Evaluate routing, consent, parsing, grouping, body, mapping, idempotency, and the complete handoff | Failures identify the correct contract layer |
+| #162 | Keep persistent influence behind `cxpp-init` preview, trust, approval, status, decline, and removal | Declining influence leaves only the local scaffold |
+| #163 | Publish migration guidance and dogfood the pinned clean-project lifecycle | Released workflow produces sequenced issues without hidden side effects |
+
+Issue #166 changes no runtime behavior. It closes when this decision record,
+the schema and instance, the Wave 7 artifact updates, and their deterministic
+tests are reviewed and green. Runtime changes belong exclusively to the owners
+above.

--- a/tests/test_project_init_spec_kit_contract.py
+++ b/tests/test_project_init_spec_kit_contract.py
@@ -1,0 +1,185 @@
+"""Executable guardrails for the project-init and Spec Kit contract (#166)."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT_PATH = ROOT / ".agents" / "project-init-spec-kit-contract.json"
+SCHEMA_PATH = ROOT / ".agents" / "project-init-spec-kit-contract.schema.json"
+DECISION_PATH = ROOT / "docs" / "project-init-spec-kit-contract.md"
+WAVE_ROOT = ROOT / ".specify" / "specs" / "wave-7-skill-influence-fidelity"
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def resolve_ref(schema_root: dict[str, Any], ref: str) -> dict[str, Any]:
+    assert ref.startswith("#/")
+    node: Any = schema_root
+    for component in ref[2:].split("/"):
+        node = node[component]
+    assert isinstance(node, dict)
+    return node
+
+
+def validate(instance: Any, schema: dict[str, Any], schema_root: dict[str, Any], path: str = "$") -> None:
+    """Validate the JSON Schema features used by this versioned contract."""
+    if "$ref" in schema:
+        validate(instance, resolve_ref(schema_root, schema["$ref"]), schema_root, path)
+        return
+
+    if "const" in schema:
+        assert instance == schema["const"], f"{path}: expected {schema['const']!r}"
+    if "enum" in schema:
+        assert instance in schema["enum"], f"{path}: {instance!r} is not in enum"
+
+    expected_type = schema.get("type")
+    type_checks = {
+        "object": lambda value: isinstance(value, dict),
+        "array": lambda value: isinstance(value, list),
+        "string": lambda value: isinstance(value, str),
+        "integer": lambda value: isinstance(value, int) and not isinstance(value, bool),
+        "boolean": lambda value: isinstance(value, bool),
+    }
+    if expected_type:
+        assert type_checks[expected_type](instance), f"{path}: expected {expected_type}"
+
+    if isinstance(instance, dict):
+        required = schema.get("required", [])
+        assert not (set(required) - set(instance)), f"{path}: missing {set(required) - set(instance)}"
+        properties = schema.get("properties", {})
+        if schema.get("additionalProperties") is False:
+            assert not (set(instance) - set(properties)), f"{path}: unexpected {set(instance) - set(properties)}"
+        for key, value in instance.items():
+            if key in properties:
+                validate(value, properties[key], schema_root, f"{path}.{key}")
+
+    if isinstance(instance, list):
+        assert len(instance) >= schema.get("minItems", 0), f"{path}: too few items"
+        if "maxItems" in schema:
+            assert len(instance) <= schema["maxItems"], f"{path}: too many items"
+        if schema.get("uniqueItems"):
+            serialized = [json.dumps(item, sort_keys=True) for item in instance]
+            assert len(serialized) == len(set(serialized)), f"{path}: duplicate items"
+        item_schema = schema.get("items")
+        if item_schema:
+            for index, value in enumerate(instance):
+                validate(value, item_schema, schema_root, f"{path}[{index}]")
+
+    if isinstance(instance, str):
+        assert len(instance) >= schema.get("minLength", 0), f"{path}: string is too short"
+        if "pattern" in schema:
+            assert re.search(schema["pattern"], instance), f"{path}: pattern mismatch"
+
+    if isinstance(instance, int) and not isinstance(instance, bool):
+        assert instance >= schema.get("minimum", instance), f"{path}: below minimum"
+        assert instance <= schema.get("maximum", instance), f"{path}: above maximum"
+
+
+def test_contract_instance_validates_against_published_schema() -> None:
+    schema = load_json(SCHEMA_PATH)
+    contract = load_json(CONTRACT_PATH)
+
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert schema["$id"].endswith("/.agents/project-init-spec-kit-contract.schema.json")
+    validate(contract, schema, schema)
+
+
+def test_project_init_is_local_explicit_and_negatively_routed() -> None:
+    contract = load_json(CONTRACT_PATH)
+    routing = contract["routing"]
+    routes = {route["intent"]: route for route in routing["routes"]}
+
+    assert routing["default"] == "safe-local-scaffold"
+    assert routing["project_init_selection"] == "explicit-only"
+    assert routes["new-local-python-project"] == {
+        "intent": "new-local-python-project",
+        "owner": "project-init",
+        "selection": "explicit",
+        "consent": "target-path",
+        "project_init_negative": False,
+    }
+    assert all(
+        route["project_init_negative"]
+        for intent, route in routes.items()
+        if intent != "new-local-python-project"
+    )
+
+
+def test_spec_kit_boundary_is_immutable_official_and_additive() -> None:
+    spec_kit = load_json(CONTRACT_PATH)["spec_kit"]
+
+    assert spec_kit["upstream"] == "https://github.com/github/spec-kit"
+    assert spec_kit["release"] == "v0.16.0"
+    assert spec_kit["commit"] == "5dce710ce099067c7d3f2ef47a37b9a1c300b327"
+    assert spec_kit["install"].endswith("github/spec-kit.git@v0.16.0")
+    assert spec_kit["initialization"] == "specify init --here --integration codex"
+    assert spec_kit["composition"]["choice"] == "extension"
+    assert {item["choice"] for item in spec_kit["composition"]["rejected"]} == {
+        "preset",
+        "bundle",
+        "hand-authored-scaffold",
+    }
+
+
+def test_readiness_and_issue_compilation_contract_is_complete() -> None:
+    contract = load_json(CONTRACT_PATH)
+    readiness = contract["spec_kit"]["readiness_gate"]
+    compilation = contract["issue_compilation"]
+
+    assert readiness["approval_required"] is True
+    assert {check["id"] for check in readiness["checks"]} == {
+        "spec-exists",
+        "plan-exists",
+        "tasks-exist",
+        "consistency-analysis-clean",
+        "no-placeholders",
+        "exact-paths",
+        "independent-tests",
+        "dependencies-explicit",
+        "user-approved",
+    }
+    assert compilation["owner"] == "spec-sync"
+    assert compilation["default_granularity"] == "stage-or-story"
+    assert compilation["task_granularity"] == "explicit-request-only"
+    assert compilation["idempotency_scope"] == "open-and-closed-issues"
+    assert len(compilation["required_body_sections"]) == 10
+    assert "tasks.md" in compilation["mapping_write_back"]
+
+
+def test_audit_and_rollout_have_complete_ownership() -> None:
+    contract = load_json(CONTRACT_PATH)
+    helpers = contract["audit"]["duplicate_helpers"]
+    ownership = contract["rollout_ownership"]
+
+    assert len(helpers) == 13
+    assert {helper["repository"] for helper in helpers} == {
+        "codex-power-pack",
+        "claude-power-pack",
+    }
+    assert all(helper["owner_issue"] == 160 for helper in helpers)
+    assert {item["issue"] for item in ownership} == set(range(158, 164))
+    assert all(item["responsibilities"] and item["acceptance_evidence"] for item in ownership)
+
+
+def test_decision_and_wave_artifacts_reference_the_contract() -> None:
+    decision = DECISION_PATH.read_text(encoding="utf-8")
+    spec = (WAVE_ROOT / "spec.md").read_text(encoding="utf-8")
+    plan = (WAVE_ROOT / "plan.md").read_text(encoding="utf-8")
+    tasks = (WAVE_ROOT / "tasks.md").read_text(encoding="utf-8")
+
+    assert "project-init-spec-kit-contract.json" in decision
+    assert "Thirteen helper payloads" in decision
+    assert "US7: Safe Project-to-Issue Composition" in spec
+    assert ".agents/project-init-spec-kit-contract.json" in plan
+    assert "T090-T097" in tasks
+    for issue in range(158, 164):
+        assert f"#{issue}" in decision
+        assert f"#{issue}" in tasks


### PR DESCRIPTION
## Summary

- publish the accepted project-init and Spec Kit composition decision plus a versioned executable JSON contract
- define local-only routing, pinned official Spec Kit v0.16.0 adoption, extension ownership, readiness, grouping, rich issue bodies, and stable mapping semantics
- assign implementation and rollout work across Wave 7, including transferring stable project-next mapping integration to #160 after #158 merged
- add deterministic schema, routing, readiness, audit, and ownership tests

## Test plan

- `flow-finish-gate.sh` (lint, full pytest suite, security quick scan)
- `uv run pytest -q tests/test_project_init_spec_kit_contract.py`
- `uv run ruff check tests/test_project_init_spec_kit_contract.py`
- C4 renderer: zero invalid references
- ignored-additions and strict worktree-leak guards

Closes #166