### PR TITLE
feat(cxpp): add consent-first persistent influence

### DIFF
--- a/.agents/routing-block.md
+++ b/.agents/routing-block.md
@@ -1,0 +1,10 @@
+## Codex Power Pack routing
+
+- Need repository orientation or a next action? Use `$project-lite` or `$project-next`.
+- Need a complete GitHub issue lifecycle? Use `$flow-auto`; use `$flow-check` for read-only quality gates.
+- Need official Spec Kit adoption or approved task-to-issue synchronization? Use `$spec-adopt` or `$spec-sync`.
+- Need GitHub issue, PR, review-comment, CI, or publication work? Use the owning `$github-*` skill.
+- Need secrets, security, CI/CD, QA, documentation, or a friction retrospective? Use that installed family’s skill.
+- Use `$cxpp-status` to inspect CxPP state. Use `$cxpp-update` or `$cxpp-init` only after previewing and approving persistent changes.
+
+Persistent guidance and hooks are optional. Never infer approval to install, trust, enable, publish, ship, or change permissions.

--- a/.codex/skills/cxpp-init/SKILL.md
+++ b/.codex/skills/cxpp-init/SKILL.md
@@ -45,8 +45,8 @@ published family plugins are missing:
 
 1. Confirm Codex is available with `codex --version`, then ask which components
    to configure: CxPP marketplace/plugins, host-managed MCP pointers, spec-kit,
-   secrets-provider guidance, and reviewed hooks/rules. Do not assume all are
-   wanted.
+   secrets-provider guidance, target `AGENTS.md` routing, and reviewed
+   hooks/rules. Do not assume all are wanted.
 2. For marketplace/plugins, run the read-only `$cxpp-status` checks first. If
    the marketplace is missing or family plugins are absent, offer Minimal,
    Recommended, Full suite, and Custom; otherwise report the suite as
@@ -78,10 +78,21 @@ published family plugins are missing:
 7. For secrets, install or enable the requested `secrets` family plugin and
    point to its provider setup. Do not ask for credentials or echo environment
    values.
-8. For hooks/rules, show every proposed file and destination. Run
-   `codex execpolicy check` against a proposed rule before writing it. Install
-   only reviewed, additive entries and wait for Codex's normal hook-trust review.
-9. Run only non-secret checks: `codex mcp get second-opinion`,
+8. For optional target routing, locate `scripts/cxpp-influence.py` in the
+   checkout or `${PLUGIN_ROOT}/scripts/cxpp-influence.py` in the installed
+   `cxpp` plugin. Run `python3 HELPER status TARGET` and then `python3
+   HELPER preview TARGET`; show the exact diff and ask for separate explicit
+   approval before `python3 HELPER apply TARGET --approve`. A decline must run
+   `python3 HELPER decline TARGET` and leave the target
+   unchanged. Stop on `conflict` rather than overwriting user edits. Require
+   `python3 HELPER preview-remove TARGET` before `python3 HELPER remove
+   TARGET --approve`.
+9. For hooks/rules, show every proposed file and destination. The `secrets`
+   and `self-improvement` plugins package reviewed hooks, but installation
+   does not authorize trusting or enabling them. Run `codex execpolicy check`
+   before writing a rule, then use `/hooks` for Codex's exact-hash trust
+   review. Changed hooks require review again.
+10. Run only non-secret checks: `codex mcp get second-opinion`,
    `codex mcp get playwright`, and, when the service is expected locally,
    `curl -sf http://127.0.0.1:8080/readyz`. A failed health check is a report,
    not a reason to start the service.
@@ -94,4 +105,6 @@ resolved SHA in the plugin report so rollback is possible. Include the exact
 non-secret follow-up needed and state that a new Codex session is required after
 plugin or MCP configuration changes. Re-running the same approved profile at
 the same ref must produce `already current`, not another marketplace or plugin
-write.
+write. Report target routing as `absent`, `current`, `upgrade`, or
+`conflict`, and hook trust/enabled state without printing file contents. A
+new Codex session is required after persistent routing or hook changes.

--- a/.codex/skills/cxpp-status/SKILL.md
+++ b/.codex/skills/cxpp-status/SKILL.md
@@ -32,15 +32,24 @@ this order: `project`, `spec`, `flow`, `github`, `cicd`, `secrets`,
 4. When `second-opinion` is configured for localhost, run
    `curl -sf http://127.0.0.1:8080/readyz`; otherwise label its health as not
    checked. Run no process-management command.
-5. Check whether optional spec-kit and reviewed hooks/rules are present using
-   their documented status commands or file existence only. Never print rule,
-   hook, or configuration contents that might contain secrets.
+5. Run `python3 scripts/cxpp-influence.py status TARGET --json` or the
+   installed `${PLUGIN_ROOT}/scripts/cxpp-influence.py` equivalent. Report
+   only `absent`, `current`, `upgrade`, or `conflict`; never print
+   `AGENTS.md`.
+6. Check whether optional spec-kit and reviewed hooks/rules are present using
+   documented status commands or file existence only. Report each packaged
+   hook as present or missing and each plugin as enabled or disabled from
+   `codex plugin list --available --json`. Use `/hooks` for exact-hash trust
+   state when available; otherwise say `unknown—inspect /hooks`. A changed or
+   untrusted hook is a warning, never permission to trust or enable it. Never
+   print rule, hook, or configuration contents that might contain secrets.
 
 ## Report
 
 Start with one row per published plugin family so installed and missing families
 are explicit. Then use one row per host component: `second-opinion`,
-`playwright`, `spec-kit`, `secrets guidance`, and `hooks/rules`. Give host
+`playwright`, `spec-kit`, `secrets guidance`, `target routing`, and
+`hooks/rules`. Give host
 components a status of `healthy`, `configured`, `missing`, `unhealthy`,
 `not checked`, or `warning`, followed by the smallest safe follow-up. Keep this
 inventory read-only and do not turn a missing row into an implicit install.

--- a/.codex/skills/cxpp-update/SKILL.md
+++ b/.codex/skills/cxpp-update/SKILL.md
@@ -45,14 +45,24 @@ retain their existing individual prompts.
 4. After explicit approval, expand the sparse marketplace snapshot and install
    only missing selected plugins. Preserve existing families and configuration.
    Re-run `$cxpp-status` to verify the result.
-5. Compare requested MCP pointers with `templates/config.toml.example` using
+5. Inspect optional target routing with the checkout
+   `scripts/cxpp-influence.py` or installed
+   `${PLUGIN_ROOT}/scripts/cxpp-influence.py`. For `absent` or `upgrade`,
+   run `python3 HELPER preview TARGET` and require separate explicit approval
+   before `python3 HELPER apply TARGET --approve`. Report `current` without
+   writing. Stop on `conflict` rather than overwriting user edits. Require
+   `python3 HELPER preview-remove TARGET` before `python3 HELPER remove TARGET
+   --approve`; a decline runs `python3 HELPER decline TARGET` and writes
+   nothing.
+6. Compare requested MCP pointers with `templates/config.toml.example` using
    `codex mcp get`; do not print or parse the full global configuration file.
-6. For each host change, show the precise additive action and ask for separate
+7. For each host change, show the precise additive action and ask for separate
    approval. Never delete a pointer, plugin, hook, rule, or user configuration
    entry.
-7. Re-run `codex execpolicy check` before adding or changing any rule, and let
-   Codex perform its normal hook-review flow for changed hook files.
-8. Re-run the non-secret MCP checks and report whether a fresh Codex session is
+8. Re-run `codex execpolicy check` before adding or changing any rule. Plugin
+   installation does not authorize hook trust or enablement; use `/hooks` for
+   exact-hash review, and require a new review whenever a hook changes.
+9. Re-run the non-secret MCP checks and report whether a fresh Codex session is
    needed. Do not manage the lifecycle of an external host service.
 
 ## Report
@@ -61,4 +71,5 @@ Separate `updated`, `already current`, `skipped by user`, and
 `needs host prerequisite`. Include the previous ref, requested signed tag or
 immutable SHA, and resolved SHA whenever a marketplace or plugin changes so
 rollback remains possible. Re-running an unchanged selection at the same
-resolved SHA must be idempotent and report `already current`.
+resolved SHA must be idempotent and report `already current`. Include target
+routing state and hook trust/enabled state without printing file contents.

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,8 @@ desktop.ini
 
 # Project specific
 *.json
+!plugins/secrets/hooks/hooks.json
+!plugins/self-improvement/hooks/hooks.json
 !package.json
 !tsconfig.json
 !.codex/hooks.json

--- a/.specify/specs/wave-7-skill-influence-fidelity/tasks.md
+++ b/.specify/specs/wave-7-skill-influence-fidelity/tasks.md
@@ -236,23 +236,23 @@ failures identify the failing contract layer.
 
 ## Stage 5: Consent-First Persistent Influence
 
-- [ ] **T501** [US5] Author a concise outcome-based CxPP routing block for target
+- [x] **T501** [US5] Author a concise outcome-based CxPP routing block for target
       repository `AGENTS.md`, with a documented byte budget.
-- [ ] **T502** [US5] Add idempotent preview, approve, unchanged, skip, conflict,
+- [x] **T502** [US5] Add idempotent preview, approve, unchanged, skip, conflict,
       and removal behavior to `cxpp-init` and `cxpp-update`.
-- [ ] **T503** [US5] Package the reviewed PostToolUse masking hook with the
+- [x] **T503** [US5] Package the reviewed PostToolUse masking hook with the
       secrets plugin and use `${PLUGIN_ROOT}`-relative commands.
-- [ ] **T504** [US5] Package only the reviewed friction-capture lifecycle hooks
+- [x] **T504** [US5] Package only the reviewed friction-capture lifecycle hooks
       with the self-improvement plugin; keep codification and external writes
       explicit.
-- [ ] **T505** [US5] Extend `cxpp-status` to report routing-block state, hook
+- [x] **T505** [US5] Extend `cxpp-status` to report routing-block state, hook
       presence, trust/review state when exposed, enabled state, and drift without
       printing configuration contents.
-- [ ] **T506** [P] [US5] Add clean install, decline, already-current, changed-hook,
+- [x] **T506** [P] [US5] Add clean install, decline, already-current, changed-hook,
       untrusted, disabled, removal, and plugin-uninstall tests.
-- [ ] **T507** [P] [US5] Add security tests proving hooks fail open, mask output,
+- [x] **T507** [P] [US5] Add security tests proving hooks fail open, mask output,
       avoid secrets, and never grant permissions or invoke shipping actions.
-- [ ] **T508** [US5,US7] Prove project-init never installs persistent influence
+- [x] **T508** [US5,US7] Prove project-init never installs persistent influence
       and that declining its `cxpp-init` handoff leaves only the local scaffold.
 
 **Checkpoint:** Persistent influence is transparent, consent-first, trust-

--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,10 @@ project-next-sync:
 	@python3 scripts/project_next_sync.py --write
 
 skill-eval-check:
-	@python3 scripts/skill-eval.py deterministic
+	@uv run --extra dev python scripts/skill-eval.py deterministic
 
 skill-eval-live:
-	@python3 scripts/skill-eval.py live --allow-live
+	@uv run --extra dev python scripts/skill-eval.py live --allow-live
 
 build:
 	uv build

--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ marketplace and plugin installation; MCP pointers, credentials, hooks/rules,
 and external services retain separate consent prompts. `$cxpp-status` reports
 every family as installed or missing without changing the machine.
 
+The `cxpp` plugin also includes an optional, bounded `AGENTS.md` routing block.
+`$cxpp-init` and `$cxpp-update` always show the exact diff and require separate
+approval before adding, upgrading, or removing it; edited managed blocks become
+conflicts and are never overwritten. The `secrets` and `self-improvement`
+plugins package reviewed hooks, but plugin installation never implies hook
+trust or enablement. Review exact hashes in `/hooks`; changed hooks require a
+new review. `$cxpp-status` reports routing, presence, enabled, trust, and drift
+states without printing configuration contents.
+
 Release installs and upgrades follow `docs/release-process.md`: use a signed
 release tag or immutable commit SHA, record the resolved SHA, and preserve
 rollback refs in the release notes.

--- a/docs/security/codex-hooks-friction-telemetry.md
+++ b/docs/security/codex-hooks-friction-telemetry.md
@@ -255,6 +255,29 @@ Open uncertainty for E2 to verify with fixture hooks:
   public manual where possible and treat binary-string observations as
   non-contractual.
 
+## Stage 5 Packaged Contract
+
+Issue #162 packages the reviewed surface with the owning plugins. The `secrets`
+plugin uses a `${PLUGIN_ROOT}`-relative `PostToolUse` hook. Current Codex does
+not support rewriting tool output inline, so a secret-shaped result is blocked
+and replaced with generic safe feedback; the hook never echoes the candidate
+output. Malformed input and internal errors return an empty, successful hook
+result.
+
+The `self-improvement` plugin packages only `PermissionRequest`, `PostToolUse`,
+and `UserPromptSubmit` capture. It derives allowlisted metadata and writes no
+raw prompt, tool input, or tool output. Persistent capture is off unless the
+operator explicitly sets `CXPP_FRICTION_QUEUE`; the resulting local JSONL file
+uses mode `0600`. Capture never invokes codification, shared-memory writes,
+shipping, permission grants, or external services. Plugin installation does
+not trust or enable either hook surface: exact hashes remain subject to the
+normal `/hooks` review, and changed hooks require review again.
+
+The companion `cxpp-influence.py` helper manages only its marked routing block.
+Preview, application, upgrade, decline, conflict, and removal are deterministic;
+all writes require `--approve`, and blocks whose body no longer matches their
+recorded hash are preserved as user-owned conflicts.
+
 ## Conclusion
 
 E1 remains necessary after Phase 0: the threat model says what must be safe, and

--- a/plugins/cxpp/assets/routing-block.md
+++ b/plugins/cxpp/assets/routing-block.md
@@ -1,0 +1,10 @@
+## Codex Power Pack routing
+
+- Need repository orientation or a next action? Use `$project-lite` or `$project-next`.
+- Need a complete GitHub issue lifecycle? Use `$flow-auto`; use `$flow-check` for read-only quality gates.
+- Need official Spec Kit adoption or approved task-to-issue synchronization? Use `$spec-adopt` or `$spec-sync`.
+- Need GitHub issue, PR, review-comment, CI, or publication work? Use the owning `$github-*` skill.
+- Need secrets, security, CI/CD, QA, documentation, or a friction retrospective? Use that installed family’s skill.
+- Use `$cxpp-status` to inspect CxPP state. Use `$cxpp-update` or `$cxpp-init` only after previewing and approving persistent changes.
+
+Persistent guidance and hooks are optional. Never infer approval to install, trust, enable, publish, ship, or change permissions.

--- a/plugins/cxpp/scripts/cxpp-influence.py
+++ b/plugins/cxpp/scripts/cxpp-influence.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Consent-first management of the optional CxPP AGENTS.md routing block."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+START_RE = re.compile(r"<!-- cxpp-routing:start sha256=([0-9a-f]{64}) -->")
+END = "<!-- cxpp-routing:end -->"
+BYTE_BUDGET = 1024
+
+
+def digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def default_template() -> Path:
+    root = Path(__file__).resolve().parents[1]
+    repo_template = root / ".agents" / "routing-block.md"
+    return repo_template if repo_template.is_file() else root / "assets" / "routing-block.md"
+
+
+def agents_path(value: str) -> Path:
+    path = Path(value).expanduser().resolve()
+    return path if path.name == "AGENTS.md" else path / "AGENTS.md"
+
+
+def rendered(template: str) -> str:
+    clean = template.strip() + "\n"
+    if len(clean.encode("utf-8")) > BYTE_BUDGET:
+        raise ValueError(f"routing block exceeds {BYTE_BUDGET}-byte budget")
+    return f"<!-- cxpp-routing:start sha256={digest(clean)} -->\n{clean}{END}\n"
+
+
+def inspect(content: str, template: str) -> tuple[str, tuple[int, int] | None]:
+    starts = list(START_RE.finditer(content))
+    ends = [match.start() for match in re.finditer(re.escape(END), content)]
+    if not starts and not ends:
+        return "absent", None
+    if len(starts) != 1 or len(ends) != 1 or ends[0] < starts[0].end():
+        return "conflict", None
+    start = starts[0].start()
+    finish = ends[0] + len(END)
+    finish += 1 if content[finish:finish + 1] == "\n" else 0
+    body_start = starts[0].end() + (1 if content[starts[0].end():starts[0].end() + 1] == "\n" else 0)
+    body = content[body_start:ends[0]]
+    owned = digest(body) == starts[0].group(1)
+    if not owned:
+        return "conflict", (start, finish)
+    return ("current" if body == template.strip() + "\n" else "upgrade"), (start, finish)
+
+
+def desired(content: str, template: str, operation: str) -> tuple[str, str]:
+    state, span = inspect(content, template)
+    if state == "conflict":
+        raise ValueError("managed routing block was edited or has malformed markers")
+    if operation == "apply":
+        block = rendered(template)
+        if state == "absent":
+            separator = "" if not content else ("\n" if content.endswith("\n") else "\n\n")
+            return content + separator + block, "updated"
+        if state == "current":
+            return content, "already current"
+        assert span is not None
+        return content[:span[0]] + block + content[span[1]:], "updated"
+    if state == "absent":
+        return content, "already absent"
+    assert span is not None
+    result = content[:span[0]] + content[span[1]:]
+    return result.rstrip() + ("\n" if result.strip() else ""), "removed"
+
+
+def report(path: Path, state: str, outcome: str, *, as_json: bool) -> None:
+    payload = {"path": str(path), "state": state, "outcome": outcome}
+    print(json.dumps(payload, sort_keys=True) if as_json else f"{outcome}: {path} ({state})")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "operation",
+        choices=("status", "preview", "preview-remove", "apply", "remove", "decline"),
+    )
+    parser.add_argument("target")
+    parser.add_argument("--template", type=Path, default=default_template())
+    parser.add_argument("--approve", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    path = agents_path(args.target)
+    content = path.read_text(encoding="utf-8") if path.exists() else ""
+    template = args.template.read_text(encoding="utf-8")
+    state, _ = inspect(content, template)
+    if args.operation == "status":
+        report(path, state, "inspected", as_json=args.json)
+        return 0
+    if args.operation == "decline":
+        report(path, state, "skipped by user", as_json=args.json)
+        return 0
+    operation = "remove" if args.operation in {"preview-remove", "remove"} else "apply"
+    try:
+        updated, outcome = desired(content, template, operation)
+    except ValueError as exc:
+        print(f"conflict: {path}: {exc}", file=sys.stderr)
+        return 2
+    if args.operation in {"preview", "preview-remove"}:
+        diff = difflib.unified_diff(
+            content.splitlines(True),
+            updated.splitlines(True),
+            fromfile=str(path),
+            tofile=str(path),
+        )
+        print("".join(diff))
+        report(path, state, outcome, as_json=args.json)
+        return 0
+    if not args.approve:
+        print("explicit --approve is required after reviewing preview", file=sys.stderr)
+        return 3
+    if updated != content:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(updated, encoding="utf-8")
+    report(path, state, outcome, as_json=args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/cxpp/skills/cxpp-init/SKILL.md
+++ b/plugins/cxpp/skills/cxpp-init/SKILL.md
@@ -45,8 +45,8 @@ published family plugins are missing:
 
 1. Confirm Codex is available with `codex --version`, then ask which components
    to configure: CxPP marketplace/plugins, host-managed MCP pointers, spec-kit,
-   secrets-provider guidance, and reviewed hooks/rules. Do not assume all are
-   wanted.
+   secrets-provider guidance, target `AGENTS.md` routing, and reviewed
+   hooks/rules. Do not assume all are wanted.
 2. For marketplace/plugins, run the read-only `$cxpp-status` checks first. If
    the marketplace is missing or family plugins are absent, offer Minimal,
    Recommended, Full suite, and Custom; otherwise report the suite as
@@ -78,10 +78,21 @@ published family plugins are missing:
 7. For secrets, install or enable the requested `secrets` family plugin and
    point to its provider setup. Do not ask for credentials or echo environment
    values.
-8. For hooks/rules, show every proposed file and destination. Run
-   `codex execpolicy check` against a proposed rule before writing it. Install
-   only reviewed, additive entries and wait for Codex's normal hook-trust review.
-9. Run only non-secret checks: `codex mcp get second-opinion`,
+8. For optional target routing, locate `scripts/cxpp-influence.py` in the
+   checkout or `${PLUGIN_ROOT}/scripts/cxpp-influence.py` in the installed
+   `cxpp` plugin. Run `python3 HELPER status TARGET` and then `python3
+   HELPER preview TARGET`; show the exact diff and ask for separate explicit
+   approval before `python3 HELPER apply TARGET --approve`. A decline must run
+   `python3 HELPER decline TARGET` and leave the target
+   unchanged. Stop on `conflict` rather than overwriting user edits. Require
+   `python3 HELPER preview-remove TARGET` before `python3 HELPER remove
+   TARGET --approve`.
+9. For hooks/rules, show every proposed file and destination. The `secrets`
+   and `self-improvement` plugins package reviewed hooks, but installation
+   does not authorize trusting or enabling them. Run `codex execpolicy check`
+   before writing a rule, then use `/hooks` for Codex's exact-hash trust
+   review. Changed hooks require review again.
+10. Run only non-secret checks: `codex mcp get second-opinion`,
    `codex mcp get playwright`, and, when the service is expected locally,
    `curl -sf http://127.0.0.1:8080/readyz`. A failed health check is a report,
    not a reason to start the service.
@@ -94,4 +105,6 @@ resolved SHA in the plugin report so rollback is possible. Include the exact
 non-secret follow-up needed and state that a new Codex session is required after
 plugin or MCP configuration changes. Re-running the same approved profile at
 the same ref must produce `already current`, not another marketplace or plugin
-write.
+write. Report target routing as `absent`, `current`, `upgrade`, or
+`conflict`, and hook trust/enabled state without printing file contents. A
+new Codex session is required after persistent routing or hook changes.

--- a/plugins/cxpp/skills/cxpp-status/SKILL.md
+++ b/plugins/cxpp/skills/cxpp-status/SKILL.md
@@ -32,15 +32,24 @@ this order: `project`, `spec`, `flow`, `github`, `cicd`, `secrets`,
 4. When `second-opinion` is configured for localhost, run
    `curl -sf http://127.0.0.1:8080/readyz`; otherwise label its health as not
    checked. Run no process-management command.
-5. Check whether optional spec-kit and reviewed hooks/rules are present using
-   their documented status commands or file existence only. Never print rule,
-   hook, or configuration contents that might contain secrets.
+5. Run `python3 scripts/cxpp-influence.py status TARGET --json` or the
+   installed `${PLUGIN_ROOT}/scripts/cxpp-influence.py` equivalent. Report
+   only `absent`, `current`, `upgrade`, or `conflict`; never print
+   `AGENTS.md`.
+6. Check whether optional spec-kit and reviewed hooks/rules are present using
+   documented status commands or file existence only. Report each packaged
+   hook as present or missing and each plugin as enabled or disabled from
+   `codex plugin list --available --json`. Use `/hooks` for exact-hash trust
+   state when available; otherwise say `unknown—inspect /hooks`. A changed or
+   untrusted hook is a warning, never permission to trust or enable it. Never
+   print rule, hook, or configuration contents that might contain secrets.
 
 ## Report
 
 Start with one row per published plugin family so installed and missing families
 are explicit. Then use one row per host component: `second-opinion`,
-`playwright`, `spec-kit`, `secrets guidance`, and `hooks/rules`. Give host
+`playwright`, `spec-kit`, `secrets guidance`, `target routing`, and
+`hooks/rules`. Give host
 components a status of `healthy`, `configured`, `missing`, `unhealthy`,
 `not checked`, or `warning`, followed by the smallest safe follow-up. Keep this
 inventory read-only and do not turn a missing row into an implicit install.

--- a/plugins/cxpp/skills/cxpp-update/SKILL.md
+++ b/plugins/cxpp/skills/cxpp-update/SKILL.md
@@ -45,14 +45,24 @@ retain their existing individual prompts.
 4. After explicit approval, expand the sparse marketplace snapshot and install
    only missing selected plugins. Preserve existing families and configuration.
    Re-run `$cxpp-status` to verify the result.
-5. Compare requested MCP pointers with `templates/config.toml.example` using
+5. Inspect optional target routing with the checkout
+   `scripts/cxpp-influence.py` or installed
+   `${PLUGIN_ROOT}/scripts/cxpp-influence.py`. For `absent` or `upgrade`,
+   run `python3 HELPER preview TARGET` and require separate explicit approval
+   before `python3 HELPER apply TARGET --approve`. Report `current` without
+   writing. Stop on `conflict` rather than overwriting user edits. Require
+   `python3 HELPER preview-remove TARGET` before `python3 HELPER remove TARGET
+   --approve`; a decline runs `python3 HELPER decline TARGET` and writes
+   nothing.
+6. Compare requested MCP pointers with `templates/config.toml.example` using
    `codex mcp get`; do not print or parse the full global configuration file.
-6. For each host change, show the precise additive action and ask for separate
+7. For each host change, show the precise additive action and ask for separate
    approval. Never delete a pointer, plugin, hook, rule, or user configuration
    entry.
-7. Re-run `codex execpolicy check` before adding or changing any rule, and let
-   Codex perform its normal hook-review flow for changed hook files.
-8. Re-run the non-secret MCP checks and report whether a fresh Codex session is
+8. Re-run `codex execpolicy check` before adding or changing any rule. Plugin
+   installation does not authorize hook trust or enablement; use `/hooks` for
+   exact-hash review, and require a new review whenever a hook changes.
+9. Re-run the non-secret MCP checks and report whether a fresh Codex session is
    needed. Do not manage the lifecycle of an external host service.
 
 ## Report
@@ -61,4 +71,5 @@ Separate `updated`, `already current`, `skipped by user`, and
 `needs host prerequisite`. Include the previous ref, requested signed tag or
 immutable SHA, and resolved SHA whenever a marketplace or plugin changes so
 rollback remains possible. Re-running an unchanged selection at the same
-resolved SHA must be idempotent and report `already current`.
+resolved SHA must be idempotent and report `already current`. Include target
+routing state and hook trust/enabled state without printing file contents.

--- a/plugins/secrets/.codex-plugin/plugin.json
+++ b/plugins/secrets/.codex-plugin/plugin.json
@@ -17,6 +17,7 @@
     "aws"
   ],
   "skills": "./skills/",
+  "hooks": "./hooks/hooks.json",
   "interface": {
     "displayName": "Secrets",
     "shortDescription": "Handle project secrets without exposing values.",

--- a/plugins/secrets/hooks/hooks.json
+++ b/plugins/secrets/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${PLUGIN_ROOT}/scripts/hook-mask-output.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/secrets/scripts/hook-mask-output.py
+++ b/plugins/secrets/scripts/hook-mask-output.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Suppress secret-shaped PostToolUse output without echoing sensitive input."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+PATTERNS = (
+    re.compile(r"(?i)(?:api[_-]?key|token|password|secret)\s*[:=]\s*[^\s,;]{8,}"),
+    re.compile(r"\b(?:ghp|github_pat|sk|xox[baprs])-[-A-Za-z0-9_]{12,}\b"),
+    re.compile(r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"),
+)
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+        candidate = json.dumps(payload.get("tool_response", ""), ensure_ascii=True)
+        if any(pattern.search(candidate) for pattern in PATTERNS):
+            print(json.dumps({
+                "decision": "block",
+                "reason": "Sensitive tool output was suppressed by the Secrets plugin.",
+                "hookSpecificOutput": {
+                    "hookEventName": "PostToolUse",
+                    "additionalContext": (
+                        "Do not repeat the original output. "
+                        "Use $secrets-run or a masked secrets workflow."
+                    ),
+                },
+            }))
+        else:
+            print("{}")
+    except Exception:
+        print("{}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/self-improvement/.codex-plugin/plugin.json
+++ b/plugins/self-improvement/.codex-plugin/plugin.json
@@ -16,6 +16,7 @@
     "friction"
   ],
   "skills": "./skills/",
+  "hooks": "./hooks/hooks.json",
   "interface": {
     "displayName": "Self Improvement",
     "shortDescription": "Turn session friction into improvements.",

--- a/plugins/self-improvement/hooks/hooks.json
+++ b/plugins/self-improvement/hooks/hooks.json
@@ -1,0 +1,36 @@
+{
+  "hooks": {
+    "PermissionRequest": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${PLUGIN_ROOT}/scripts/friction-hook.py\" --event PermissionRequest"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${PLUGIN_ROOT}/scripts/friction-hook.py\" --event PostToolUse"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${PLUGIN_ROOT}/scripts/friction-hook.py\" --event UserPromptSubmit"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/self-improvement/scripts/friction-hook.py
+++ b/plugins/self-improvement/scripts/friction-hook.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Capture only reviewed, minimized friction metadata when explicitly enabled."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+SECRET = re.compile(
+    r"(?i)(?:api[_-]?key|token|password|secret)\s*[:=]\s*[^\s,;]{8,}|"
+    r"\b(?:ghp|github_pat|sk|xox[baprs])-[-A-Za-z0-9_]{12,}\b|"
+    r"-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----"
+)
+
+
+def event(payload: dict[str, object], hook_event: str) -> dict[str, str] | None:
+    encoded = json.dumps(payload, ensure_ascii=True)
+    tool = str(payload.get("tool_name") or "unknown")[:80]
+    if SECRET.search(encoded):
+        kind, severity, summary = "secret_mask_hit", "high", f"Secret-shaped data suppressed during {hook_event}"
+    elif hook_event == "PermissionRequest":
+        kind, severity, summary = "permission_prompt", "low", f"Permission requested by {tool}"
+    elif hook_event == "PostToolUse" and any(
+        key in encoded.lower() for key in ('"iserror": true', '"exit_code": 1', '"status": "failed"')
+    ):
+        kind, severity, summary = "command_failure", "medium", f"Tool failure reported by {tool}"
+    else:
+        return None
+    fingerprint = hashlib.sha256(f"{hook_event}:{kind}:{tool}".encode()).hexdigest()
+    return {
+        "harness": "codex",
+        "event_type": kind,
+        "source": hook_event,
+        "severity": severity,
+        "summary": summary,
+        "fingerprint": fingerprint,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", required=True, choices=("PermissionRequest", "PostToolUse", "UserPromptSubmit"))
+    args = parser.parse_args()
+    try:
+        payload = json.load(sys.stdin)
+        record = event(payload, args.event)
+        queue_value = os.environ.get("CXPP_FRICTION_QUEUE", "")
+        if record is not None and queue_value:
+            queue = Path(queue_value).expanduser()
+            queue.parent.mkdir(parents=True, exist_ok=True)
+            descriptor = os.open(queue, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
+            with os.fdopen(descriptor, "a", encoding="utf-8") as handle:
+                handle.write(json.dumps(record, sort_keys=True) + "\n")
+    except Exception:
+        pass
+    print("{}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cxpp-influence.py
+++ b/scripts/cxpp-influence.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Consent-first management of the optional CxPP AGENTS.md routing block."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+START_RE = re.compile(r"<!-- cxpp-routing:start sha256=([0-9a-f]{64}) -->")
+END = "<!-- cxpp-routing:end -->"
+BYTE_BUDGET = 1024
+
+
+def digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def default_template() -> Path:
+    root = Path(__file__).resolve().parents[1]
+    repo_template = root / ".agents" / "routing-block.md"
+    return repo_template if repo_template.is_file() else root / "assets" / "routing-block.md"
+
+
+def agents_path(value: str) -> Path:
+    path = Path(value).expanduser().resolve()
+    return path if path.name == "AGENTS.md" else path / "AGENTS.md"
+
+
+def rendered(template: str) -> str:
+    clean = template.strip() + "\n"
+    if len(clean.encode("utf-8")) > BYTE_BUDGET:
+        raise ValueError(f"routing block exceeds {BYTE_BUDGET}-byte budget")
+    return f"<!-- cxpp-routing:start sha256={digest(clean)} -->\n{clean}{END}\n"
+
+
+def inspect(content: str, template: str) -> tuple[str, tuple[int, int] | None]:
+    starts = list(START_RE.finditer(content))
+    ends = [match.start() for match in re.finditer(re.escape(END), content)]
+    if not starts and not ends:
+        return "absent", None
+    if len(starts) != 1 or len(ends) != 1 or ends[0] < starts[0].end():
+        return "conflict", None
+    start = starts[0].start()
+    finish = ends[0] + len(END)
+    finish += 1 if content[finish:finish + 1] == "\n" else 0
+    body_start = starts[0].end() + (1 if content[starts[0].end():starts[0].end() + 1] == "\n" else 0)
+    body = content[body_start:ends[0]]
+    owned = digest(body) == starts[0].group(1)
+    if not owned:
+        return "conflict", (start, finish)
+    return ("current" if body == template.strip() + "\n" else "upgrade"), (start, finish)
+
+
+def desired(content: str, template: str, operation: str) -> tuple[str, str]:
+    state, span = inspect(content, template)
+    if state == "conflict":
+        raise ValueError("managed routing block was edited or has malformed markers")
+    if operation == "apply":
+        block = rendered(template)
+        if state == "absent":
+            separator = "" if not content else ("\n" if content.endswith("\n") else "\n\n")
+            return content + separator + block, "updated"
+        if state == "current":
+            return content, "already current"
+        assert span is not None
+        return content[:span[0]] + block + content[span[1]:], "updated"
+    if state == "absent":
+        return content, "already absent"
+    assert span is not None
+    result = content[:span[0]] + content[span[1]:]
+    return result.rstrip() + ("\n" if result.strip() else ""), "removed"
+
+
+def report(path: Path, state: str, outcome: str, *, as_json: bool) -> None:
+    payload = {"path": str(path), "state": state, "outcome": outcome}
+    print(json.dumps(payload, sort_keys=True) if as_json else f"{outcome}: {path} ({state})")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "operation",
+        choices=("status", "preview", "preview-remove", "apply", "remove", "decline"),
+    )
+    parser.add_argument("target")
+    parser.add_argument("--template", type=Path, default=default_template())
+    parser.add_argument("--approve", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    path = agents_path(args.target)
+    content = path.read_text(encoding="utf-8") if path.exists() else ""
+    template = args.template.read_text(encoding="utf-8")
+    state, _ = inspect(content, template)
+    if args.operation == "status":
+        report(path, state, "inspected", as_json=args.json)
+        return 0
+    if args.operation == "decline":
+        report(path, state, "skipped by user", as_json=args.json)
+        return 0
+    operation = "remove" if args.operation in {"preview-remove", "remove"} else "apply"
+    try:
+        updated, outcome = desired(content, template, operation)
+    except ValueError as exc:
+        print(f"conflict: {path}: {exc}", file=sys.stderr)
+        return 2
+    if args.operation in {"preview", "preview-remove"}:
+        diff = difflib.unified_diff(
+            content.splitlines(True),
+            updated.splitlines(True),
+            fromfile=str(path),
+            tofile=str(path),
+        )
+        print("".join(diff))
+        report(path, state, outcome, as_json=args.json)
+        return 0
+    if not args.approve:
+        print("explicit --approve is required after reviewing preview", file=sys.stderr)
+        return 3
+    if updated != content:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(updated, encoding="utf-8")
+    report(path, state, outcome, as_json=args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_persistent_influence.py
+++ b/tests/test_persistent_influence.py
@@ -1,0 +1,98 @@
+"""Consent, idempotency, conflict, and removal contracts for CxPP influence."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "scripts" / "cxpp-influence.py"
+TEMPLATE = ROOT / ".agents" / "routing-block.md"
+SCAFFOLD = ROOT / ".codex/skills/project-init/scripts/project-scaffold.py"
+
+
+def run(*args: object) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(HELPER), *(str(arg) for arg in args)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_routing_asset_is_bounded_and_packaged_helper_is_identical() -> None:
+    assert len(TEMPLATE.read_bytes()) <= 1024
+    assert (ROOT / "plugins/cxpp/assets/routing-block.md").read_bytes() == TEMPLATE.read_bytes()
+    assert (ROOT / "plugins/cxpp/scripts/cxpp-influence.py").read_bytes() == HELPER.read_bytes()
+
+
+def test_install_preview_decline_current_and_remove_are_consent_first(tmp_path: Path) -> None:
+    agents = tmp_path / "AGENTS.md"
+    agents.write_text("# Local guidance\n", encoding="utf-8")
+    original = agents.read_bytes()
+
+    preview = run("preview", tmp_path)
+    assert preview.returncode == 0 and "cxpp-routing:start" in preview.stdout
+    assert agents.read_bytes() == original
+    assert run("apply", tmp_path).returncode == 3
+    assert agents.read_bytes() == original
+    assert "skipped by user" in run("decline", tmp_path).stdout
+    assert agents.read_bytes() == original
+
+    assert run("apply", tmp_path, "--approve").returncode == 0
+    installed = agents.read_bytes()
+    assert b"cxpp-routing:start" in installed
+    assert "current" in run("status", tmp_path).stdout
+    assert "already current" in run("apply", tmp_path, "--approve").stdout
+    assert agents.read_bytes() == installed
+
+    remove_preview = run("preview-remove", tmp_path)
+    assert remove_preview.returncode == 0 and "cxpp-routing:start" in remove_preview.stdout
+    assert agents.read_bytes() == installed
+    assert run("remove", tmp_path).returncode == 3
+    assert agents.read_bytes() == installed
+    assert run("remove", tmp_path, "--approve").returncode == 0
+    assert agents.read_text(encoding="utf-8") == "# Local guidance\n"
+
+
+def test_upgrade_is_owned_and_user_edits_become_conflicts(tmp_path: Path) -> None:
+    agents = tmp_path / "AGENTS.md"
+    assert run("apply", tmp_path, "--approve").returncode == 0
+    prior = tmp_path / "prior.md"
+    prior.write_text("prior managed body\n", encoding="utf-8")
+    assert run("status", tmp_path, "--template", prior).stdout.startswith("inspected")
+
+    # A new template upgrades only a block whose marker still authenticates its body.
+    newer = tmp_path / "newer.md"
+    newer.write_text("new managed body\n", encoding="utf-8")
+    assert "upgrade" in run("status", tmp_path, "--template", newer).stdout
+    assert run("apply", tmp_path, "--template", newer, "--approve").returncode == 0
+    assert "new managed body" in agents.read_text(encoding="utf-8")
+
+    agents.write_text(agents.read_text(encoding="utf-8").replace("new managed", "user changed"), encoding="utf-8")
+    conflict = run("apply", tmp_path, "--template", newer, "--approve")
+    assert conflict.returncode == 2
+    assert "conflict" in conflict.stderr
+    assert "user changed body" in agents.read_text(encoding="utf-8")
+
+
+def test_project_init_decline_leaves_only_the_local_scaffold(tmp_path: Path) -> None:
+    text = (ROOT / ".codex/skills/project-init/SKILL.md").read_text(encoding="utf-8")
+    assert "$cxpp-init" in text
+    assert "persistent" in text.lower()
+    project = tmp_path / "demo"
+    scaffold = subprocess.run(
+        [sys.executable, str(SCAFFOLD), "demo", "--path", str(project)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert scaffold.returncode == 0, scaffold.stderr
+    before = {path.relative_to(project): path.read_bytes() for path in project.rglob("*") if path.is_file()}
+    assert b"cxpp-routing:start" not in before[Path("AGENTS.md")]
+    assert not list(project.rglob("hooks.json"))
+
+    assert run("decline", project).returncode == 0
+    after = {path.relative_to(project): path.read_bytes() for path in project.rglob("*") if path.is_file()}
+    assert after == before

--- a/tests/test_plugin_hooks.py
+++ b/tests/test_plugin_hooks.py
@@ -1,0 +1,107 @@
+"""Security and lifecycle contracts for reviewed persistent plugin hooks."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SECRETS = ROOT / "plugins/secrets"
+RETRO = ROOT / "plugins/self-improvement"
+
+
+def invoke(
+    script: Path,
+    payload: str,
+    *args: str,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(script), *args],
+        input=payload,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def test_manifests_use_plugin_relative_reviewed_hooks() -> None:
+    secrets_manifest = json.loads((SECRETS / ".codex-plugin/plugin.json").read_text(encoding="utf-8"))
+    retro_manifest = json.loads((RETRO / ".codex-plugin/plugin.json").read_text(encoding="utf-8"))
+    assert secrets_manifest["hooks"] == "./hooks/hooks.json"
+    assert retro_manifest["hooks"] == "./hooks/hooks.json"
+
+    secrets_hooks = json.loads((SECRETS / "hooks/hooks.json").read_text(encoding="utf-8"))["hooks"]
+    retro_hooks = json.loads((RETRO / "hooks/hooks.json").read_text(encoding="utf-8"))["hooks"]
+    assert set(secrets_hooks) == {"PostToolUse"}
+    assert set(retro_hooks) == {"PermissionRequest", "PostToolUse", "UserPromptSubmit"}
+    commands = [entries[0]["hooks"][0]["command"] for entries in [*secrets_hooks.values(), *retro_hooks.values()]]
+    assert all("${PLUGIN_ROOT}" in command for command in commands)
+    assert all("allow" not in command.lower() for command in commands)
+
+
+def test_secret_output_is_replaced_without_leaking_and_hook_fails_open() -> None:
+    script = SECRETS / "scripts/hook-mask-output.py"
+    secret = "sk-super-secret-value-123456789"
+    blocked = invoke(script, json.dumps({"tool_response": {"token": secret}}))
+    assert blocked.returncode == 0
+    assert secret not in blocked.stdout
+    assert json.loads(blocked.stdout)["decision"] == "block"
+    assert json.loads(invoke(script, '{broken').stdout) == {}
+    assert json.loads(invoke(script, json.dumps({"tool_response": "ordinary output"})).stdout) == {}
+
+
+def test_friction_capture_is_minimized_opt_in_and_fail_open(tmp_path: Path) -> None:
+    script = RETRO / "scripts/friction-hook.py"
+    queue = tmp_path / "friction.jsonl"
+    secret = "ghp_abcdefghijklmnopqrstuvwxyz123456"
+    payload = json.dumps({"tool_name": "shell", "tool_response": f"token={secret}"})
+
+    assert invoke(script, payload, "--event", "PostToolUse").returncode == 0
+    assert not queue.exists()
+
+    env = dict(os.environ, CXPP_FRICTION_QUEUE=str(queue))
+    captured = invoke(script, payload, "--event", "PostToolUse", env=env)
+    assert captured.returncode == 0 and json.loads(captured.stdout) == {}
+    contents = queue.read_text(encoding="utf-8")
+    assert secret not in contents
+    record = json.loads(contents)
+    assert set(record) == {"created_at", "event_type", "fingerprint", "harness", "severity", "source", "summary"}
+    assert record["event_type"] == "secret_mask_hit"
+    assert queue.stat().st_mode & 0o777 == 0o600
+    assert invoke(script, "bad", "--event", "UserPromptSubmit", env=env).returncode == 0
+
+
+def test_status_documents_changed_untrusted_disabled_and_removal_states() -> None:
+    status = (ROOT / ".codex/skills/cxpp-status/SKILL.md").read_text(encoding="utf-8")
+    init = (ROOT / ".codex/skills/cxpp-init/SKILL.md").read_text(encoding="utf-8")
+    update = (ROOT / ".codex/skills/cxpp-update/SKILL.md").read_text(encoding="utf-8")
+    for word in ("changed", "untrusted", "disabled", "exact-hash", "/hooks"):
+        assert word in status
+    assert "preview-remove" in init and "HELPER remove" in init and "--approve" in init
+    assert "preview-remove" in update and "HELPER remove" in update and "--approve" in update
+    assert "does not authorize" in init and "does not authorize" in update
+
+
+def test_hooks_never_grant_permissions_or_invoke_shipping_actions() -> None:
+    secrets_script = (SECRETS / "scripts/hook-mask-output.py").read_text(encoding="utf-8").lower()
+    retro_script = (RETRO / "scripts/friction-hook.py").read_text(encoding="utf-8").lower()
+    assert '"decision": "block"' in secrets_script
+    for forbidden in ("permissiondecision", '"allow"', "git push", "deploy", "publish"):
+        assert forbidden not in secrets_script
+        assert forbidden not in retro_script
+
+
+def test_plugin_uninstall_removes_its_entire_hook_surface(tmp_path: Path) -> None:
+    for plugin in (SECRETS, RETRO):
+        installed = tmp_path / plugin.name
+        shutil.copytree(plugin, installed)
+        assert (installed / "hooks/hooks.json").is_file()
+        shutil.rmtree(installed)
+        assert not installed.exists()
+    assert not list(tmp_path.rglob("hooks.json"))


### PR DESCRIPTION
## Summary
- add an optional, byte-bounded, hash-owned AGENTS.md routing block with preview, approval, idempotent upgrade/conflict, decline, and removal flows
- package reviewed secrets and friction hooks with plugin-relative commands while preserving Codex trust and enablement boundaries
- extend safe status guidance and cover clean install, disabled/untrusted/changed hooks, uninstall, fail-open, masking, and project-init decline behavior
- run the #161 deterministic evaluation contract through the project Python environment

## Verification
- `make verify` (525 tests; deterministic skill evaluation 23/23)
- `flow-finish-gate.sh` (lint, test, security scan)
- strict worktree and ignored-addition guards

Closes #162