### PR TITLE
fix(plugins): Keep hooks safe across upgrades (Closes #176)

### DIFF
--- a/.agents/skill-contracts.json
+++ b/.agents/skill-contracts.json
@@ -6002,7 +6002,7 @@
     {
       "source_skill": "cxpp-update",
       "path": "plugins/cxpp/skills/cxpp-update/SKILL.md",
-      "line": 55,
+      "line": 60,
       "token": "$cxpp-status",
       "kind": "skill",
       "target": "cxpp-status",

--- a/.codex/skills/cxpp-update/SKILL.md
+++ b/.codex/skills/cxpp-update/SKILL.md
@@ -46,7 +46,12 @@ retain their existing individual prompts.
    the ref changes, preview the bounded `codex plugin marketplace remove
    codex-power-pack --json` followed immediately by the pinned `marketplace
    add` and plugin reinstalls. This replaces only the marketplace snapshot;
-   it does not remove installed plugins or authorize any other deletion.
+   it does not remove installed plugins or authorize any other deletion. When
+   the ref changes and the update includes either hook-bearing family,
+   `secrets` or `self-improvement`, warn before approval that replacing its
+   versioned plugin directory can disrupt every running Codex session that
+   loaded those hooks. Tell the operator to finish or restart affected sessions
+   before applying the update.
 4. After explicit approval, expand an unchanged sparse marketplace snapshot,
    or perform the previewed marketplace-source replacement when the ref
    changes, then reinstall every preserved/selected family at the new snapshot.
@@ -70,8 +75,11 @@ retain their existing individual prompts.
 8. Re-run `codex execpolicy check` before adding or changing any rule. Plugin
    installation does not authorize hook trust or enablement; use `/hooks` for
    exact-hash review, and require a new review whenever a hook changes.
-9. Re-run the non-secret MCP checks and report whether a fresh Codex session is
-   needed. Do not manage the lifecycle of an external host service.
+9. Re-run the non-secret MCP checks. If `secrets` or `self-improvement` changed,
+   report that every Codex session started before the update must be restarted
+   to load the new hook paths; do not describe that restart as optional. Report
+   whether a fresh session is needed for other changes. Do not manage the
+   lifecycle of an external host service.
 
 ## Report
 

--- a/docs/architecture/c4-manifest.json
+++ b/docs/architecture/c4-manifest.json
@@ -1,6 +1,6 @@
 {
   "project": "Codex Power Pack",
-  "generated_at": "2026-08-07T11:21:04Z",
+  "generated_at": "2026-08-07T12:04:14Z",
   "engine": "c4-mermaid",
   "diagrams": [
     {

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -247,4 +247,4 @@ classDiagram
   EvaluationResult --> Observation : classifies
 ```
 
-_Generated 2026-08-07T11:21:04Z_
+_Generated 2026-08-07T12:04:14Z_

--- a/plugins/cxpp/skills/cxpp-update/SKILL.md
+++ b/plugins/cxpp/skills/cxpp-update/SKILL.md
@@ -46,7 +46,12 @@ retain their existing individual prompts.
    the ref changes, preview the bounded `codex plugin marketplace remove
    codex-power-pack --json` followed immediately by the pinned `marketplace
    add` and plugin reinstalls. This replaces only the marketplace snapshot;
-   it does not remove installed plugins or authorize any other deletion.
+   it does not remove installed plugins or authorize any other deletion. When
+   the ref changes and the update includes either hook-bearing family,
+   `secrets` or `self-improvement`, warn before approval that replacing its
+   versioned plugin directory can disrupt every running Codex session that
+   loaded those hooks. Tell the operator to finish or restart affected sessions
+   before applying the update.
 4. After explicit approval, expand an unchanged sparse marketplace snapshot,
    or perform the previewed marketplace-source replacement when the ref
    changes, then reinstall every preserved/selected family at the new snapshot.
@@ -70,8 +75,11 @@ retain their existing individual prompts.
 8. Re-run `codex execpolicy check` before adding or changing any rule. Plugin
    installation does not authorize hook trust or enablement; use `/hooks` for
    exact-hash review, and require a new review whenever a hook changes.
-9. Re-run the non-secret MCP checks and report whether a fresh Codex session is
-   needed. Do not manage the lifecycle of an external host service.
+9. Re-run the non-secret MCP checks. If `secrets` or `self-improvement` changed,
+   report that every Codex session started before the update must be restarted
+   to load the new hook paths; do not describe that restart as optional. Report
+   whether a fresh session is needed for other changes. Do not manage the
+   lifecycle of an external host service.
 
 ## Report
 

--- a/plugins/secrets/hooks/hooks.json
+++ b/plugins/secrets/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/scripts/hook-mask-output.py\""
+            "command": "python3 \"${PLUGIN_ROOT}/scripts/hook-mask-output.py\" || { status=$?; echo \"Secrets plugin masking hook failed. Restart Codex to pick up the upgraded plugin.\" >&2; exit \"$status\"; }"
           }
         ]
       }

--- a/plugins/self-improvement/hooks/hooks.json
+++ b/plugins/self-improvement/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/scripts/friction-hook.py\" --event PermissionRequest"
+            "command": "python3 \"${PLUGIN_ROOT}/scripts/friction-hook.py\" --event PermissionRequest || true"
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/scripts/friction-hook.py\" --event PostToolUse"
+            "command": "python3 \"${PLUGIN_ROOT}/scripts/friction-hook.py\" --event PostToolUse || true"
           }
         ]
       }
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${PLUGIN_ROOT}/scripts/friction-hook.py\" --event UserPromptSubmit"
+            "command": "python3 \"${PLUGIN_ROOT}/scripts/friction-hook.py\" --event UserPromptSubmit || true"
           }
         ]
       }

--- a/tests/test_plugin_hooks.py
+++ b/tests/test_plugin_hooks.py
@@ -14,6 +14,11 @@ SECRETS = ROOT / "plugins/secrets"
 RETRO = ROOT / "plugins/self-improvement"
 
 
+def hook_commands(plugin: Path) -> list[str]:
+    hooks = json.loads((plugin / "hooks/hooks.json").read_text(encoding="utf-8"))["hooks"]
+    return [entries[0]["hooks"][0]["command"] for entries in hooks.values()]
+
+
 def invoke(
     script: Path,
     payload: str,
@@ -27,6 +32,19 @@ def invoke(
         text=True,
         check=False,
         env=env,
+    )
+
+
+def invoke_hook_command(command: str, plugin_root: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        input="{}",
+        capture_output=True,
+        text=True,
+        shell=True,
+        executable="/bin/sh",
+        check=False,
+        env={**os.environ, "PLUGIN_ROOT": str(plugin_root)},
     )
 
 
@@ -77,6 +95,24 @@ def test_friction_capture_is_minimized_opt_in_and_fail_open(tmp_path: Path) -> N
     assert invoke(script, "bad", "--event", "UserPromptSubmit", env=env).returncode == 0
 
 
+def test_missing_hook_scripts_preserve_each_plugins_failure_policy(tmp_path: Path) -> None:
+    retro = tmp_path / "self-improvement"
+    secrets = tmp_path / "secrets"
+    shutil.copytree(RETRO, retro)
+    shutil.copytree(SECRETS, secrets)
+    (retro / "scripts/friction-hook.py").unlink()
+    (secrets / "scripts/hook-mask-output.py").unlink()
+
+    retro_results = [invoke_hook_command(command, retro) for command in hook_commands(retro)]
+    assert len(retro_results) == 3
+    assert all(result.returncode == 0 for result in retro_results)
+
+    blocked = invoke_hook_command(hook_commands(secrets)[0], secrets)
+    assert blocked.returncode != 0
+    assert "Secrets plugin" in blocked.stderr
+    assert "Restart Codex" in blocked.stderr
+
+
 def test_status_documents_changed_untrusted_disabled_and_removal_states() -> None:
     status = (ROOT / ".codex/skills/cxpp-status/SKILL.md").read_text(encoding="utf-8")
     init = (ROOT / ".codex/skills/cxpp-init/SKILL.md").read_text(encoding="utf-8")
@@ -86,6 +122,8 @@ def test_status_documents_changed_untrusted_disabled_and_removal_states() -> Non
     assert "preview-remove" in init and "HELPER remove" in init and "--approve" in init
     assert "preview-remove" in update and "HELPER remove" in update and "--approve" in update
     assert "does not authorize" in init and "does not authorize" in update
+    assert "warn before approval" in update
+    assert "must be restarted" in update
 
 
 def test_hooks_never_grant_permissions_or_invoke_shipping_actions() -> None:


### PR DESCRIPTION
## Summary

- keep self-improvement telemetry fail-open when its versioned hook script disappears
- keep Secrets masking fail-closed while identifying the plugin and restart remedy
- warn before hook-bearing upgrades, require affected-session restarts, and cover both policies with regression tests
- reconcile skill-contract and C4 generated artifacts

## Test plan

- focused plugin-hook and CxPP tests: 14 passed
- flow finish gate: lint, 528 tests, and security scan passed
- ignored-additions and strict worktree-leak guards passed

Closes #176