### PR TITLE
Add masked repository reader

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,9 @@ tool integrations, with client-side pointers documented in `docs/HOST_MANAGED.md
 - Use `docs/release-process.md` for release PRs, signed tag or SHA installs,
   upgrade transcripts, rollback refs, and changelog discipline.
 - prefer `rg` for repo search
+- When credential-shaped repository fixtures must be inspected, use
+  `python -m lib.creds masked-read PATH [PATH...]`; never print the raw file as
+  an intermediate step.
 
 ## Notes
 

--- a/lib/creds/__main__.py
+++ b/lib/creds/__main__.py
@@ -5,6 +5,7 @@ Usage:
     python -m lib.creds set KEY VALUE [--project PROJECT]
     python -m lib.creds list [--project PROJECT]
     python -m lib.creds run -- COMMAND [ARGS...]
+    python -m lib.creds masked-read PATH [PATH...]
     python -m lib.creds validate [OPTIONS]
     python -m lib.creds ui [--port PORT]
     python -m lib.creds rotate KEY [--project PROJECT]
@@ -14,6 +15,7 @@ Examples:
     python -m lib.creds set DB_PASSWORD my-secret
     python -m lib.creds list
     python -m lib.creds run -- make deploy
+    python -m lib.creds masked-read tests/fixtures/config.txt
     python -m lib.creds ui
     python -m lib.creds validate --dotenv
 """

--- a/lib/creds/cli.py
+++ b/lib/creds/cli.py
@@ -6,6 +6,7 @@ Usage:
     python -m lib.creds delete KEY [--project PROJECT] [--force]
     python -m lib.creds list [--project PROJECT]
     python -m lib.creds run -- COMMAND [ARGS...]
+    python -m lib.creds masked-read PATH [PATH...]
     python -m lib.creds validate [OPTIONS]
     python -m lib.creds ui [--port PORT]
     python -m lib.creds rotate KEY [--project PROJECT]
@@ -184,6 +185,13 @@ def cmd_run(args: argparse.Namespace) -> int:
         project_id=args.project,
         provider_name=args.provider,
     )
+
+
+def cmd_masked_read(args: argparse.Namespace) -> int:
+    """Read selected repository files without emitting raw secret-shaped text."""
+    from .masked_read import read_masked_paths
+
+    return read_masked_paths(args.paths)
 
 
 def cmd_ui(args: argparse.Namespace) -> int:
@@ -564,6 +572,20 @@ def create_parser() -> argparse.ArgumentParser:
         help="Command to run (use -- before command)",
     )
 
+    masked_read_parser = subparsers.add_parser(
+        "masked-read",
+        help="Read repository files through the shared output masker",
+        description=(
+            "Read selected text files, mask credential-shaped values in memory, "
+            "and emit only sanitized content."
+        ),
+    )
+    masked_read_parser.add_argument(
+        "paths",
+        nargs="+",
+        help="Text files to read through the masker",
+    )
+
     # 'validate' subcommand
     validate_parser = subparsers.add_parser(
         "validate",
@@ -651,6 +673,7 @@ def main(argv: list[str] | None = None) -> int:
         "delete": cmd_delete,
         "list": cmd_list,
         "run": cmd_run,
+        "masked-read": cmd_masked_read,
         "validate": cmd_validate,
         "ui": cmd_ui,
         "rotate": cmd_rotate,

--- a/lib/creds/masked_read.py
+++ b/lib/creds/masked_read.py
@@ -1,0 +1,68 @@
+"""Read repository text through the shared secret masker before emitting it."""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import TextIO
+
+from .masking import OutputMasker
+
+
+def read_masked_paths(
+    paths: Sequence[str | Path],
+    *,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+    masker: OutputMasker | None = None,
+) -> int:
+    """Mask selected files in memory and emit only the sanitized result."""
+    output_masker = masker or OutputMasker()
+    output_stream = stdout if stdout is not None else sys.stdout
+    error_stream = stderr if stderr is not None else sys.stderr
+    multiple = len(paths) > 1
+    rendered: list[tuple[str, str]] = []
+
+    for index, raw_path in enumerate(paths):
+        path = Path(raw_path)
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            print(
+                f"masked-read: file {index + 1} could not be read",
+                file=error_stream,
+            )
+            return 2
+
+        masked = output_masker.mask(text)
+        masked_path = output_masker.mask(str(path))
+        if _has_detection_only_match(masked, output_masker) or _has_detection_only_match(
+            masked_path, output_masker
+        ):
+            print(
+                f"masked-read: file {index + 1} still contains an unmaskable "
+                "secret-shaped value; no content was emitted",
+                file=error_stream,
+            )
+            return 3
+        rendered.append((masked_path, masked))
+
+    for index, (masked_path, masked) in enumerate(rendered):
+        if multiple:
+            if index:
+                output_stream.write("\n")
+            output_stream.write(f"==> {masked_path} <==\n")
+        output_stream.write(masked)
+        if masked and not masked.endswith("\n"):
+            output_stream.write("\n")
+
+    return 0
+
+
+def _has_detection_only_match(text: str, masker: OutputMasker) -> bool:
+    return any(
+        replacement is None and re.search(pattern, text, re.IGNORECASE)
+        for pattern, replacement in masker.patterns
+    )

--- a/tests/test_masked_read.py
+++ b/tests/test_masked_read.py
@@ -1,0 +1,95 @@
+"""Canary tests for repository reads containing credential-shaped fixtures."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+from typing import Any
+
+from lib.creds.cli import main
+from lib.creds.masked_read import read_masked_paths
+
+
+def _join(*parts: str) -> str:
+    return "".join(parts)
+
+
+def test_masked_read_redacts_database_and_assignment_shapes(tmp_path: Path) -> None:
+    database_value = _join("fixture", "-database", "-value")
+    assigned_value = _join("fixture", "-assigned", "-value")
+    source = tmp_path / "config.txt"
+    source.write_text(
+        "postgresql://reader:"
+        + database_value
+        + "@db.invalid/example\n"
+        + "password = "
+        + assigned_value
+        + "\n",
+        encoding="utf-8",
+    )
+    stdout = io.StringIO()
+
+    assert read_masked_paths([source], stdout=stdout) == 0
+
+    output = stdout.getvalue()
+    assert database_value not in output
+    assert assigned_value not in output
+    assert output.count("****") == 2
+
+
+def test_masked_read_handles_multiple_files_without_raw_values(tmp_path: Path) -> None:
+    first_value = _join("first", "-fixture", "-value")
+    second_value = _join("second", "-fixture", "-value")
+    first = tmp_path / "first.txt"
+    second = tmp_path / "second.txt"
+    first.write_text(f"api_key={first_value}\n", encoding="utf-8")
+    second.write_text(f"auth_token={second_value}\n", encoding="utf-8")
+    stdout = io.StringIO()
+
+    assert read_masked_paths([first, second], stdout=stdout) == 0
+
+    output = stdout.getvalue()
+    assert first_value not in output
+    assert second_value not in output
+    assert str(first) in output
+    assert str(second) in output
+
+
+def test_masked_read_fails_closed_for_detection_only_shape(tmp_path: Path) -> None:
+    detection_only_value = _join("a1b2c3d4", "e5f60718", "192a3b4c", "5d6e7f80")
+    safe_source = tmp_path / "safe.txt"
+    source = tmp_path / "opaque.txt"
+    safe_source.write_text("public context\n", encoding="utf-8")
+    source.write_text(f"opaque={detection_only_value}\n", encoding="utf-8")
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    assert read_masked_paths([safe_source, source], stdout=stdout, stderr=stderr) == 3
+
+    assert stdout.getvalue() == ""
+    assert detection_only_value not in stderr.getvalue()
+    assert "no content was emitted" in stderr.getvalue()
+
+
+def test_masked_read_reports_missing_file_without_path_details(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.txt"
+    stderr = io.StringIO()
+
+    assert read_masked_paths([missing], stderr=stderr) == 2
+
+    assert str(missing) not in stderr.getvalue()
+    assert "file 1 could not be read" in stderr.getvalue()
+
+
+def test_masked_read_cli_routes_through_the_safe_reader(
+    tmp_path: Path, capsys: Any
+) -> None:
+    value = _join("cli", "-fixture", "-value")
+    source = tmp_path / "cli.txt"
+    source.write_text(f"secret={value}\n", encoding="utf-8")
+
+    assert main(["masked-read", str(source)]) == 0
+
+    output = capsys.readouterr()
+    assert value not in output.out
+    assert "****" in output.out


### PR DESCRIPTION
## What changed

- add an atomic, fail-closed masked repository reader
- expose it as `python -m lib.creds masked-read PATH [PATH...]`
- avoid emitting raw file paths on read errors
- add canary coverage and durable repository guidance

## Why

Credential-shaped repository fixtures need a supported inspection path that sanitizes content before anything is emitted and refuses output when a detection-only secret shape remains.

## Validation

- `make verify`
- 532 tests passed
- Ruff, mypy, generated-skill sync, contract, and harness checks passed