### PR TITLE
fix(friction): Avoid unsupported retro proposals

### DIFF
--- a/docs/friction-retro-e2e.md
+++ b/docs/friction-retro-e2e.md
@@ -17,9 +17,10 @@ returned one non-sensitive proposal:
 - action: add a deterministic preflight or canary check to the Makefile and CI.
 
 Legacy rows can have changing, hook-provided wording. The analyzer therefore
-uses exact fingerprints when available and falls back to a repeated allowlisted
-failure class only when no exact match is found. It never includes source summaries
-or any other raw event content in its proposal.
+uses masked fingerprints and requires the same fingerprint to repeat before it
+proposes a deterministic gate. It does not conflate unrelated failures merely
+because they share an allowlisted failure class. It never includes source
+summaries or any other raw event content in its proposal.
 
 The proposal is advisory. Applying a gate remains an explicit user decision;
 the retro command does not modify the ledger, Makefile, CI, or any workflow.
@@ -31,3 +32,15 @@ make verify
 ```
 
 completed successfully after the run.
+
+## Precision follow-up
+
+The retrospective after `flow:auto #176` initially proposed a validation gate
+from 33 unrelated `red-output` records and an admin bootstrap blocker from two
+ordinary dependency-bootstrap records. Review found no repeated fingerprint and
+no admin-only, IAM, permission, or manual-apply prerequisite.
+
+The confirmed learning is that a deterministic gate requires the same masked
+failure fingerprint at least twice, while a blocking bootstrap proposal requires
+explicit admin-only or manual IAM, permission, or apply evidence. No workflow
+gate was added because these records did not satisfy either evidence threshold.

--- a/lib/friction/retro.py
+++ b/lib/friction/retro.py
@@ -12,7 +12,10 @@ from typing import Any, Iterable, Mapping
 from .models import FrictionEvent, FrictionEventError
 
 REPEATED_FAILURE_TYPES = {"command_failure", "gate_failure", "tool_error", "red_output"}
-BOOTSTRAP_PATTERN = re.compile(r"\b(admin[- ]only|bootstrap|manual (?:iam|permission|apply))\b", re.IGNORECASE)
+ADMIN_BOOTSTRAP_PATTERN = re.compile(
+    r"\b(?:admin[- ]only|manual (?:iam|permission|apply))\b",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -59,31 +62,7 @@ def analyze_events(events: Iterable[Mapping[str, Any]], repeat_threshold: int = 
             )
             break
 
-    # Exact fingerprints are the strongest same-root-cause signal. Some legacy
-    # hooks, however, attach volatile wording to every failure. When a failure
-    # class itself repeats, propose a generic preflight/triage gate without
-    # pretending the individual summaries are identical or exposing them.
-    if not any(proposal.kind == "validation-gate" for proposal in proposals):
-        type_counts: dict[str, int] = {}
-        for event in normalized:
-            if event.event_type in REPEATED_FAILURE_TYPES:
-                type_counts[event.event_type] = type_counts.get(event.event_type, 0) + 1
-        for event_type, count in type_counts.items():
-            if count >= repeat_threshold:
-                proposals.append(
-                    RetroProposal(
-                        kind="validation-gate",
-                        title=f"Add a preflight gate for repeated {event_type.replace('_', ' ')} events",
-                        action=(
-                            "Add a deterministic preflight or canary check to the Makefile and "
-                            "make CI run it before the affected workflow."
-                        ),
-                        evidence_count=count,
-                    )
-                )
-                break
-
-    bootstrap_count = sum(1 for event in normalized if BOOTSTRAP_PATTERN.search(event.summary))
+    bootstrap_count = sum(1 for event in normalized if ADMIN_BOOTSTRAP_PATTERN.search(event.summary))
     if bootstrap_count:
         proposals.append(
             RetroProposal(

--- a/tests/test_friction_retro.py
+++ b/tests/test_friction_retro.py
@@ -34,6 +34,14 @@ def test_admin_bootstrap_dependency_proposes_blocking_reminder() -> None:
     assert "exits non-zero" in proposal.action
 
 
+def test_dependency_bootstrap_does_not_propose_admin_reminder() -> None:
+    proposals = analyze_events([
+        _event("dependency bootstrap needs a populated uv cache", "manual_intervention"),
+    ])
+
+    assert not any(item.kind == "bootstrap-reminder" for item in proposals)
+
+
 def test_retro_never_returns_secret_bearing_summary() -> None:
     proposals = analyze_events([
         _event("bootstrap blocked password=supersecret"),
@@ -69,14 +77,13 @@ def test_retro_ignores_invalid_utf8_rows_without_stopping_analysis(tmp_path) -> 
     assert any(item.kind == "validation-gate" for item in proposals)
 
 
-def test_repeated_failure_class_proposes_gate_when_legacy_summaries_vary() -> None:
+def test_repeated_failure_class_does_not_conflate_distinct_summaries() -> None:
     proposals = analyze_events([
         _event("first volatile failure"),
         _event("second volatile failure"),
     ])
 
-    proposal = next(item for item in proposals if item.kind == "validation-gate")
-    assert proposal.evidence_count == 2
+    assert not any(item.kind == "validation-gate" for item in proposals)
 
 
 def test_retro_skill_uses_codex_queue_and_requires_confirmation() -> None:

--- a/tests/test_friction_retro_e2e.py
+++ b/tests/test_friction_retro_e2e.py
@@ -5,9 +5,12 @@ from pathlib import Path
 
 def test_friction_retro_dogfood_records_safe_real_ledger_result() -> None:
     text = (Path(__file__).resolve().parents[1] / "docs" / "friction-retro-e2e.md").read_text()
+    normalized = " ".join(text.split())
 
     assert ".claude/friction.jsonl" in text
     assert "`8`" in text
     assert "validation-gate" in text
     assert "explicit user decision" in text
-    assert "source summaries" in text
+    assert "source summaries" in normalized
+    assert "same masked" in normalized
+    assert "No workflow" in normalized


### PR DESCRIPTION
## What changed

- require the same masked failure fingerprint to repeat before proposing a deterministic validation gate
- require explicit admin-only or manual IAM, permission, or apply evidence before proposing a blocking bootstrap check
- add regression coverage for unrelated failure summaries and ordinary dependency bootstrapping
- record the confirmed masked learning from the flow-auto #176 retrospective

## Why

The retro analyzer grouped 33 unrelated red-output records into one validation proposal and treated two ordinary uv dependency-bootstrap records as admin prerequisites. Neither proposal had enough evidence to justify a workflow blocker.

## Impact

Retrospectives now remain proposal-free when telemetry does not identify a repeated root cause or a genuine admin prerequisite, reducing false workflow gates without exposing source summaries.

## Validation

- focused friction-retro suite: 9 passed
- post-main-sync make verify: lint passed, 534 tests passed, mypy passed, generated-skill and contract checks passed, project-next bundle current, 26 deterministic evaluations passed