### PR TITLE
feat(project-next): Enrich operational reports (Closes #180)

### DIFF
--- a/.agents/skill-contracts.json
+++ b/.agents/skill-contracts.json
@@ -13,7 +13,7 @@
     "unpackaged_skills": 10,
     "marketplace_plugins": 16,
     "implicit_skills": 2,
-    "references": 654,
+    "references": 655,
     "unexplained_references": 0
   },
   "marketplace": {
@@ -2904,7 +2904,9 @@
           "state": "display_only"
         }
       ],
-      "dependencies": [],
+      "dependencies": [
+        "flow-auto"
+      ],
       "exclusion": {
         "state": "not_excluded",
         "owner": null,
@@ -10010,19 +10012,19 @@
       "id": "REF-0552"
     },
     {
-      "source_skill": "qa-help",
-      "path": "plugins/qa/skills/qa-help/SKILL.md",
-      "line": 8,
-      "token": "$qa-test",
+      "source_skill": "project-next",
+      "path": "plugins/project/skills/project-next/SKILL.md",
+      "line": 54,
+      "token": "$flow-auto",
       "kind": "skill",
-      "target": "qa-test",
+      "target": "flow-auto",
       "classification": "resolvable",
       "id": "REF-0553"
     },
     {
       "source_skill": "qa-help",
       "path": "plugins/qa/skills/qa-help/SKILL.md",
-      "line": 14,
+      "line": 8,
       "token": "$qa-test",
       "kind": "skill",
       "target": "qa-test",
@@ -10032,12 +10034,22 @@
     {
       "source_skill": "qa-help",
       "path": "plugins/qa/skills/qa-help/SKILL.md",
+      "line": 14,
+      "token": "$qa-test",
+      "kind": "skill",
+      "target": "qa-test",
+      "classification": "resolvable",
+      "id": "REF-0555"
+    },
+    {
+      "source_skill": "qa-help",
+      "path": "plugins/qa/skills/qa-help/SKILL.md",
       "line": 15,
       "token": "$github-issue-create",
       "kind": "skill",
       "target": "github-issue-create",
       "classification": "resolvable",
-      "id": "REF-0555"
+      "id": "REF-0556"
     },
     {
       "source_skill": "qa-help",
@@ -10047,7 +10059,7 @@
       "kind": "skill",
       "target": "cxpp-init",
       "classification": "resolvable",
-      "id": "REF-0556"
+      "id": "REF-0557"
     },
     {
       "source_skill": "qa-test",
@@ -10057,7 +10069,7 @@
       "kind": "skill",
       "target": "github-issue-create",
       "classification": "resolvable",
-      "id": "REF-0557"
+      "id": "REF-0558"
     },
     {
       "source_skill": "second-opinion-help",
@@ -10067,7 +10079,7 @@
       "kind": "skill",
       "target": "second-opinion-start",
       "classification": "resolvable",
-      "id": "REF-0558"
+      "id": "REF-0559"
     },
     {
       "source_skill": "second-opinion-help",
@@ -10077,7 +10089,7 @@
       "kind": "skill",
       "target": "second-opinion-models",
       "classification": "resolvable",
-      "id": "REF-0559"
+      "id": "REF-0560"
     },
     {
       "source_skill": "second-opinion-help",
@@ -10087,7 +10099,7 @@
       "kind": "skill",
       "target": "evaluate-issue",
       "classification": "resolvable",
-      "id": "REF-0560"
+      "id": "REF-0561"
     },
     {
       "source_skill": "second-opinion-help",
@@ -10097,7 +10109,7 @@
       "kind": "skill",
       "target": "cxpp-init",
       "classification": "resolvable",
-      "id": "REF-0561"
+      "id": "REF-0562"
     },
     {
       "source_skill": "second-opinion-models",
@@ -10107,7 +10119,7 @@
       "kind": "skill",
       "target": "second-opinion-start",
       "classification": "resolvable",
-      "id": "REF-0562"
+      "id": "REF-0563"
     },
     {
       "source_skill": "second-opinion-models",
@@ -10117,7 +10129,7 @@
       "kind": "skill",
       "target": "evaluate-issue",
       "classification": "resolvable",
-      "id": "REF-0563"
+      "id": "REF-0564"
     },
     {
       "source_skill": "second-opinion-start",
@@ -10127,7 +10139,7 @@
       "kind": "skill",
       "target": "second-opinion-help",
       "classification": "resolvable",
-      "id": "REF-0564"
+      "id": "REF-0565"
     },
     {
       "source_skill": "secrets-delete",
@@ -10137,7 +10149,7 @@
       "kind": "host_path",
       "target": ".claude/",
       "classification": "source_context",
-      "id": "REF-0565"
+      "id": "REF-0566"
     },
     {
       "source_skill": "secrets-delete",
@@ -10147,7 +10159,7 @@
       "kind": "skill",
       "target": "secrets-delete",
       "classification": "resolvable",
-      "id": "REF-0566"
+      "id": "REF-0567"
     },
     {
       "source_skill": "secrets-get",
@@ -10157,7 +10169,7 @@
       "kind": "host_path",
       "target": ".claude/",
       "classification": "source_context",
-      "id": "REF-0567"
+      "id": "REF-0568"
     },
     {
       "source_skill": "secrets-get",
@@ -10167,7 +10179,7 @@
       "kind": "skill",
       "target": "secrets-get",
       "classification": "resolvable",
-      "id": "REF-0568"
+      "id": "REF-0569"
     },
     {
       "source_skill": "secrets-help",
@@ -10177,7 +10189,7 @@
       "kind": "host_path",
       "target": ".claude/",
       "classification": "source_context",
-      "id": "REF-0569"
+      "id": "REF-0570"
     },
     {
       "source_skill": "secrets-help",
@@ -10187,7 +10199,7 @@
       "kind": "skill",
       "target": "secrets-get",
       "classification": "resolvable",
-      "id": "REF-0570"
+      "id": "REF-0571"
     },
     {
       "source_skill": "secrets-help",
@@ -10197,7 +10209,7 @@
       "kind": "skill",
       "target": "secrets-set",
       "classification": "resolvable",
-      "id": "REF-0571"
+      "id": "REF-0572"
     },
     {
       "source_skill": "secrets-help",
@@ -10207,7 +10219,7 @@
       "kind": "skill",
       "target": "secrets-delete",
       "classification": "resolvable",
-      "id": "REF-0572"
+      "id": "REF-0573"
     },
     {
       "source_skill": "secrets-help",
@@ -10217,7 +10229,7 @@
       "kind": "skill",
       "target": "secrets-list",
       "classification": "resolvable",
-      "id": "REF-0573"
+      "id": "REF-0574"
     },
     {
       "source_skill": "secrets-help",
@@ -10227,7 +10239,7 @@
       "kind": "skill",
       "target": "secrets-run",
       "classification": "resolvable",
-      "id": "REF-0574"
+      "id": "REF-0575"
     },
     {
       "source_skill": "secrets-help",
@@ -10237,7 +10249,7 @@
       "kind": "skill",
       "target": "secrets-validate",
       "classification": "resolvable",
-      "id": "REF-0575"
+      "id": "REF-0576"
     },
     {
       "source_skill": "secrets-help",
@@ -10247,7 +10259,7 @@
       "kind": "skill",
       "target": "secrets-ui",
       "classification": "resolvable",
-      "id": "REF-0576"
+      "id": "REF-0577"
     },
     {
       "source_skill": "secrets-help",
@@ -10257,7 +10269,7 @@
       "kind": "skill",
       "target": "secrets-rotate",
       "classification": "resolvable",
-      "id": "REF-0577"
+      "id": "REF-0578"
     },
     {
       "source_skill": "secrets-help",
@@ -10267,7 +10279,7 @@
       "kind": "skill",
       "target": "secrets-help",
       "classification": "resolvable",
-      "id": "REF-0578"
+      "id": "REF-0579"
     },
     {
       "source_skill": "secrets-list",
@@ -10277,7 +10289,7 @@
       "kind": "host_path",
       "target": ".claude/",
       "classification": "source_context",
-      "id": "REF-0579"
+      "id": "REF-0580"
     },
     {
       "source_skill": "secrets-list",
@@ -10287,7 +10299,7 @@
       "kind": "skill",
       "target": "secrets-list",
       "classification": "resolvable",
-      "id": "REF-0580"
+      "id": "REF-0581"
     },
     {
       "source_skill": "secrets-rotate",
@@ -10297,7 +10309,7 @@
       "kind": "host_path",
       "target": ".claude/",
       "classification": "source_context",
-      "id": "REF-0581"
+      "id": "REF-0582"
     },
     {
       "source_skill": "secrets-rotate",
@@ -10307,7 +10319,7 @@
       "kind": "skill",
       "target": "secrets-rotate",
       "classification": "resolvable",
-      "id": "REF-0582"
+      "id": "REF-0583"
     },
     {
       "source_skill": "secrets-run",
@@ -10317,7 +10329,7 @@
       "kind": "host_path",
       "target": ".claude/",
       "classification": "source_context",
-      "id": "REF-0583"
+      "id": "REF-0584"
     },
     {
       "source_skill": "secrets-run",
@@ -10327,7 +10339,7 @@
       "kind": "skill",
       "target": "secrets-run",
       "classification": "resolvable",
-      "id": "REF-0584"
+      "id": "REF-0585"
     },
     {
       "source_skill": "secrets-set",
@@ -10337,7 +10349,7 @@
       "kind": "host_path",
       "target": ".claude/",
       "classification": "source_context",
-      "id": "REF-0585"
+      "id": "REF-0586"
     },
     {
       "source_skill": "secrets-set",
@@ -10347,7 +10359,7 @@
       "kind": "skill",
       "target": "secrets-set",
       "classification": "resolvable",
-      "id": "REF-0586"
+      "id": "REF-0587"
     },
     {
       "source_skill": "secrets-ui",
@@ -10357,7 +10369,7 @@
       "kind": "host_path",
       "target": ".claude/",
       "classification": "source_context",
-      "id": "REF-0587"
+      "id": "REF-0588"
     },
     {
       "source_skill": "secrets-ui",
@@ -10367,7 +10379,7 @@
       "kind": "skill",
       "target": "secrets-ui",
       "classification": "resolvable",
-      "id": "REF-0588"
+      "id": "REF-0589"
     },
     {
       "source_skill": "secrets-validate",
@@ -10377,7 +10389,7 @@
       "kind": "host_path",
       "target": ".claude/",
       "classification": "source_context",
-      "id": "REF-0589"
+      "id": "REF-0590"
     },
     {
       "source_skill": "secrets-validate",
@@ -10387,7 +10399,7 @@
       "kind": "skill",
       "target": "secrets-validate",
       "classification": "resolvable",
-      "id": "REF-0590"
+      "id": "REF-0591"
     },
     {
       "source_skill": "security-explain",
@@ -10397,7 +10409,7 @@
       "kind": "host_path",
       "target": ".claude/",
       "classification": "source_context",
-      "id": "REF-0591"
+      "id": "REF-0592"
     },
     {
       "source_skill": "security-explain",
@@ -10407,7 +10419,7 @@
       "kind": "skill",
       "target": "security-explain",
       "classification": "resolvable",
-      "id": "REF-0592"
+      "id": "REF-0593"
     },
     {
       "source_skill": "security-help",
@@ -10417,7 +10429,7 @@
       "kind": "skill",
       "target": "security-quick",
       "classification": "resolvable",
-      "id": "REF-0593"
+      "id": "REF-0594"
     },
     {
       "source_skill": "security-help",
@@ -10427,7 +10439,7 @@
       "kind": "skill",
       "target": "security-scan",
       "classification": "resolvable",
-      "id": "REF-0594"
+      "id": "REF-0595"
     },
     {
       "source_skill": "security-help",
@@ -10437,7 +10449,7 @@
       "kind": "skill",
       "target": "security-deep",
       "classification": "resolvable",
-      "id": "REF-0595"
+      "id": "REF-0596"
     },
     {
       "source_skill": "security-permissions",
@@ -10447,7 +10459,7 @@
       "kind": "native_command",
       "target": "/fewer-permission-prompts",
       "classification": "native",
-      "id": "REF-0596"
+      "id": "REF-0597"
     },
     {
       "source_skill": "security-permissions",
@@ -10457,7 +10469,7 @@
       "kind": "host_path",
       "target": ".claude/",
       "classification": "source_context",
-      "id": "REF-0597"
+      "id": "REF-0598"
     },
     {
       "source_skill": "security-permissions",
@@ -10467,22 +10479,12 @@
       "kind": "native_command",
       "target": "/permissions",
       "classification": "native",
-      "id": "REF-0598"
-    },
-    {
-      "source_skill": "security-permissions",
-      "path": "plugins/security/skills/security-permissions/SKILL.md",
-      "line": 16,
-      "token": "/fewer-permission-prompts",
-      "kind": "native_command",
-      "target": "/fewer-permission-prompts",
-      "classification": "native",
       "id": "REF-0599"
     },
     {
       "source_skill": "security-permissions",
       "path": "plugins/security/skills/security-permissions/SKILL.md",
-      "line": 21,
+      "line": 16,
       "token": "/fewer-permission-prompts",
       "kind": "native_command",
       "target": "/fewer-permission-prompts",
@@ -10492,17 +10494,17 @@
     {
       "source_skill": "security-permissions",
       "path": "plugins/security/skills/security-permissions/SKILL.md",
-      "line": 42,
-      "token": ".claude/",
-      "kind": "host_path",
-      "target": ".claude/",
-      "classification": "adapted",
+      "line": 21,
+      "token": "/fewer-permission-prompts",
+      "kind": "native_command",
+      "target": "/fewer-permission-prompts",
+      "classification": "native",
       "id": "REF-0601"
     },
     {
       "source_skill": "security-permissions",
       "path": "plugins/security/skills/security-permissions/SKILL.md",
-      "line": 59,
+      "line": 42,
       "token": ".claude/",
       "kind": "host_path",
       "target": ".claude/",
@@ -10512,7 +10514,7 @@
     {
       "source_skill": "security-permissions",
       "path": "plugins/security/skills/security-permissions/SKILL.md",
-      "line": 60,
+      "line": 59,
       "token": ".claude/",
       "kind": "host_path",
       "target": ".claude/",
@@ -10522,12 +10524,22 @@
     {
       "source_skill": "security-permissions",
       "path": "plugins/security/skills/security-permissions/SKILL.md",
+      "line": 60,
+      "token": ".claude/",
+      "kind": "host_path",
+      "target": ".claude/",
+      "classification": "adapted",
+      "id": "REF-0604"
+    },
+    {
+      "source_skill": "security-permissions",
+      "path": "plugins/security/skills/security-permissions/SKILL.md",
       "line": 83,
       "token": "/fewer-permission-prompts",
       "kind": "native_command",
       "target": "/fewer-permission-prompts",
       "classification": "native",
-      "id": "REF-0604"
+      "id": "REF-0605"
     },
     {
       "source_skill": "security-permissions",
@@ -10537,7 +10549,7 @@
       "kind": "host_path",
       "target": ".claude/",
       "classification": "adapted",
-      "id": "REF-0605"
+      "id": "REF-0606"
     },
     {
       "source_skill": "security-scan",
@@ -10547,7 +10559,7 @@
       "kind": "skill",
       "target": "security-quick",
       "classification": "resolvable",
-      "id": "REF-0606"
+      "id": "REF-0607"
     },
     {
       "source_skill": "self-improvement-deployment",
@@ -10557,7 +10569,7 @@
       "kind": "host_path",
       "target": ".claude/",
       "classification": "source_context",
-      "id": "REF-0607"
+      "id": "REF-0608"
     },
     {
       "source_skill": "self-improvement-deployment",
@@ -10567,7 +10579,7 @@
       "kind": "host_path",
       "target": ".claude/",
       "classification": "source_context",
-      "id": "REF-0608"
+      "id": "REF-0609"
     },
     {
       "source_skill": "self-improvement-deployment",
@@ -10577,7 +10589,7 @@
       "kind": "skill",
       "target": "self-improvement-deployment",
       "classification": "resolvable",
-      "id": "REF-0609"
+      "id": "REF-0610"
     },
     {
       "source_skill": "self-improvement-deployment",
@@ -10587,7 +10599,7 @@
       "kind": "native_command",
       "target": "/skills",
       "classification": "native",
-      "id": "REF-0610"
+      "id": "REF-0611"
     },
     {
       "source_skill": "self-improvement-deployment",
@@ -10597,7 +10609,7 @@
       "kind": "skill",
       "target": "flow-finish",
       "classification": "resolvable",
-      "id": "REF-0611"
+      "id": "REF-0612"
     },
     {
       "source_skill": "self-improvement-deployment",
@@ -10607,7 +10619,7 @@
       "kind": "skill",
       "target": "flow-finish",
       "classification": "resolvable",
-      "id": "REF-0612"
+      "id": "REF-0613"
     },
     {
       "source_skill": "self-improvement-deployment",
@@ -10617,7 +10629,7 @@
       "kind": "skill",
       "target": "flow-finish",
       "classification": "resolvable",
-      "id": "REF-0613"
+      "id": "REF-0614"
     },
     {
       "source_skill": "self-improvement-deployment",
@@ -10627,7 +10639,7 @@
       "kind": "skill",
       "target": "flow-deploy",
       "classification": "resolvable",
-      "id": "REF-0614"
+      "id": "REF-0615"
     },
     {
       "source_skill": "self-improvement-deployment",
@@ -10637,7 +10649,7 @@
       "kind": "skill",
       "target": "flow-deploy",
       "classification": "resolvable",
-      "id": "REF-0615"
+      "id": "REF-0616"
     },
     {
       "source_skill": "self-improvement-deployment",
@@ -10647,7 +10659,7 @@
       "kind": "skill",
       "target": "flow-doctor",
       "classification": "resolvable",
-      "id": "REF-0616"
+      "id": "REF-0617"
     },
     {
       "source_skill": "self-improvement-help",
@@ -10657,7 +10669,7 @@
       "kind": "host_path",
       "target": ".claude/",
       "classification": "source_context",
-      "id": "REF-0617"
+      "id": "REF-0618"
     },
     {
       "source_skill": "self-improvement-help",
@@ -10667,7 +10679,7 @@
       "kind": "skill",
       "target": "self-improvement-retro",
       "classification": "resolvable",
-      "id": "REF-0618"
+      "id": "REF-0619"
     },
     {
       "source_skill": "self-improvement-help",
@@ -10677,7 +10689,7 @@
       "kind": "skill",
       "target": "self-improvement-deployment",
       "classification": "resolvable",
-      "id": "REF-0619"
+      "id": "REF-0620"
     },
     {
       "source_skill": "self-improvement-help",
@@ -10687,7 +10699,7 @@
       "kind": "skill",
       "target": "self-improvement-help",
       "classification": "resolvable",
-      "id": "REF-0620"
+      "id": "REF-0621"
     },
     {
       "source_skill": "self-improvement-help",
@@ -10697,7 +10709,7 @@
       "kind": "skill",
       "target": "self-improvement-retro",
       "classification": "resolvable",
-      "id": "REF-0621"
+      "id": "REF-0622"
     },
     {
       "source_skill": "self-improvement-help",
@@ -10707,7 +10719,7 @@
       "kind": "skill",
       "target": "flow-auto",
       "classification": "resolvable",
-      "id": "REF-0622"
+      "id": "REF-0623"
     },
     {
       "source_skill": "self-improvement-help",
@@ -10717,7 +10729,7 @@
       "kind": "skill",
       "target": "flow-merge",
       "classification": "resolvable",
-      "id": "REF-0623"
+      "id": "REF-0624"
     },
     {
       "source_skill": "self-improvement-help",
@@ -10727,7 +10739,7 @@
       "kind": "skill",
       "target": "self-improvement-retro",
       "classification": "resolvable",
-      "id": "REF-0624"
+      "id": "REF-0625"
     },
     {
       "source_skill": "self-improvement-help",
@@ -10737,7 +10749,7 @@
       "kind": "skill",
       "target": "self-improvement-deployment",
       "classification": "resolvable",
-      "id": "REF-0625"
+      "id": "REF-0626"
     },
     {
       "source_skill": "self-improvement-help",
@@ -10747,7 +10759,7 @@
       "kind": "skill",
       "target": "flow-auto",
       "classification": "resolvable",
-      "id": "REF-0626"
+      "id": "REF-0627"
     },
     {
       "source_skill": "self-improvement-help",
@@ -10757,7 +10769,7 @@
       "kind": "skill",
       "target": "self-improvement-retro",
       "classification": "resolvable",
-      "id": "REF-0627"
+      "id": "REF-0628"
     },
     {
       "source_skill": "self-improvement-help",
@@ -10767,7 +10779,7 @@
       "kind": "skill",
       "target": "flow-deploy",
       "classification": "resolvable",
-      "id": "REF-0628"
+      "id": "REF-0629"
     },
     {
       "source_skill": "self-improvement-help",
@@ -10777,7 +10789,7 @@
       "kind": "skill",
       "target": "self-improvement-deployment",
       "classification": "resolvable",
-      "id": "REF-0629"
+      "id": "REF-0630"
     },
     {
       "source_skill": "self-improvement-help",
@@ -10787,7 +10799,7 @@
       "kind": "skill",
       "target": "self-improvement-retro",
       "classification": "resolvable",
-      "id": "REF-0630"
+      "id": "REF-0631"
     },
     {
       "source_skill": "self-improvement-help",
@@ -10797,7 +10809,7 @@
       "kind": "skill",
       "target": "cicd-check",
       "classification": "resolvable",
-      "id": "REF-0631"
+      "id": "REF-0632"
     },
     {
       "source_skill": "self-improvement-help",
@@ -10807,7 +10819,7 @@
       "kind": "skill",
       "target": "cicd-init",
       "classification": "resolvable",
-      "id": "REF-0632"
+      "id": "REF-0633"
     },
     {
       "source_skill": "self-improvement-help",
@@ -10817,7 +10829,7 @@
       "kind": "skill",
       "target": "flow-doctor",
       "classification": "resolvable",
-      "id": "REF-0633"
+      "id": "REF-0634"
     },
     {
       "source_skill": "self-improvement-help",
@@ -10827,7 +10839,7 @@
       "kind": "skill",
       "target": "flow-deploy",
       "classification": "resolvable",
-      "id": "REF-0634"
+      "id": "REF-0635"
     },
     {
       "source_skill": "self-improvement-help",
@@ -10837,7 +10849,7 @@
       "kind": "skill",
       "target": "flow-finish",
       "classification": "resolvable",
-      "id": "REF-0635"
+      "id": "REF-0636"
     },
     {
       "source_skill": "self-improvement-help",
@@ -10847,7 +10859,7 @@
       "kind": "skill",
       "target": "security-scan",
       "classification": "resolvable",
-      "id": "REF-0636"
+      "id": "REF-0637"
     },
     {
       "source_skill": "self-improvement-retro",
@@ -10857,7 +10869,7 @@
       "kind": "host_path",
       "target": ".claude/",
       "classification": "source_context",
-      "id": "REF-0637"
+      "id": "REF-0638"
     },
     {
       "source_skill": "spec-adopt",
@@ -10867,7 +10879,7 @@
       "kind": "skill",
       "target": "spec-sync",
       "classification": "resolvable",
-      "id": "REF-0638"
+      "id": "REF-0639"
     },
     {
       "source_skill": "spec-adopt",
@@ -10877,7 +10889,7 @@
       "kind": "skill",
       "target": "spec-sync",
       "classification": "resolvable",
-      "id": "REF-0639"
+      "id": "REF-0640"
     },
     {
       "source_skill": "spec-adopt",
@@ -10887,7 +10899,7 @@
       "kind": "skill",
       "target": "flow-auto",
       "classification": "resolvable",
-      "id": "REF-0640"
+      "id": "REF-0641"
     },
     {
       "source_skill": "spec-sync",
@@ -10897,7 +10909,7 @@
       "kind": "skill",
       "target": "flow-auto",
       "classification": "resolvable",
-      "id": "REF-0641"
+      "id": "REF-0642"
     },
     {
       "source_skill": "woodpecker-help",
@@ -10907,7 +10919,7 @@
       "kind": "skill",
       "target": "woodpecker-status",
       "classification": "resolvable",
-      "id": "REF-0642"
+      "id": "REF-0643"
     },
     {
       "source_skill": "woodpecker-help",
@@ -10917,7 +10929,7 @@
       "kind": "skill",
       "target": "woodpecker-logs",
       "classification": "resolvable",
-      "id": "REF-0643"
+      "id": "REF-0644"
     },
     {
       "source_skill": "woodpecker-help",
@@ -10927,7 +10939,7 @@
       "kind": "skill",
       "target": "woodpecker-restart",
       "classification": "resolvable",
-      "id": "REF-0644"
+      "id": "REF-0645"
     },
     {
       "source_skill": "woodpecker-help",
@@ -10937,7 +10949,7 @@
       "kind": "skill",
       "target": "secrets-run",
       "classification": "resolvable",
-      "id": "REF-0645"
+      "id": "REF-0646"
     },
     {
       "source_skill": "woodpecker-logs",
@@ -10947,7 +10959,7 @@
       "kind": "skill",
       "target": "woodpecker-status",
       "classification": "resolvable",
-      "id": "REF-0646"
+      "id": "REF-0647"
     },
     {
       "source_skill": "woodpecker-logs",
@@ -10957,7 +10969,7 @@
       "kind": "skill",
       "target": "secrets-run",
       "classification": "resolvable",
-      "id": "REF-0647"
+      "id": "REF-0648"
     },
     {
       "source_skill": "woodpecker-logs",
@@ -10967,7 +10979,7 @@
       "kind": "skill",
       "target": "secrets-run",
       "classification": "resolvable",
-      "id": "REF-0648"
+      "id": "REF-0649"
     },
     {
       "source_skill": "woodpecker-restart",
@@ -10977,7 +10989,7 @@
       "kind": "skill",
       "target": "woodpecker-logs",
       "classification": "resolvable",
-      "id": "REF-0649"
+      "id": "REF-0650"
     },
     {
       "source_skill": "woodpecker-restart",
@@ -10987,7 +10999,7 @@
       "kind": "skill",
       "target": "woodpecker-status",
       "classification": "resolvable",
-      "id": "REF-0650"
+      "id": "REF-0651"
     },
     {
       "source_skill": "woodpecker-restart",
@@ -10997,7 +11009,7 @@
       "kind": "skill",
       "target": "secrets-run",
       "classification": "resolvable",
-      "id": "REF-0651"
+      "id": "REF-0652"
     },
     {
       "source_skill": "woodpecker-restart",
@@ -11007,7 +11019,7 @@
       "kind": "skill",
       "target": "secrets-run",
       "classification": "resolvable",
-      "id": "REF-0652"
+      "id": "REF-0653"
     },
     {
       "source_skill": "woodpecker-status",
@@ -11017,7 +11029,7 @@
       "kind": "skill",
       "target": "secrets-run",
       "classification": "resolvable",
-      "id": "REF-0653"
+      "id": "REF-0654"
     },
     {
       "source_skill": "woodpecker-status",
@@ -11027,7 +11039,7 @@
       "kind": "skill",
       "target": "secrets-run",
       "classification": "resolvable",
-      "id": "REF-0654"
+      "id": "REF-0655"
     }
   ],
   "gaps": [

--- a/.codex/skills/project-next/SKILL.md
+++ b/.codex/skills/project-next/SKILL.md
@@ -49,7 +49,12 @@ or repository/authentication suggestion.
 - Failing checks or requested review changes on active work outrank broad new
   work.
 - Unsynchronized spec tasks are surfaced but are not treated as GitHub issues.
-- Structured JSON and brief/compact/full renderers use contract version `1.1`.
+- Structured JSON and brief/compact/full renderers use contract version `1.2`.
+- Compact output shows at most three safe candidates with structured rank evidence,
+  a deterministic rationale, and a copyable `$flow-auto <issue>` command.
+- Full output adds categorized and tiered backlog state, Spec Kit readiness,
+  recent worktree commits, and evidence-based cleanup candidates. Renderers only
+  format engine-owned fields; they never reclassify or re-rank issues.
 - Spec Kit synchronization is trusted only through `spec-sync:v1` Issue Sync
   ledger mappings. Missing, stale, or ambiguous mappings remain explicit
   uncertainty and never make represented work appear safely startable.

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ desktop.ini
 !.agents/skill-contracts.schema.json
 !.agents/skill-evaluation-cases.json
 !.agents/skill-evaluation-cases.schema.json
+!tests/project_next/fixtures/golden/result.json
 !.agents/skill-evaluation-output.schema.json
 !.agents/skill-invocation-policy.json
 !.agents/skill-invocation-policy.schema.json

--- a/README.md
+++ b/README.md
@@ -175,7 +175,9 @@ CxPP-owned native adapter backed by the deterministic, harness-neutral
 `lib/project_next/` engine and [versioned behavioral contract](docs/project-next-contract.md).
 It returns both the top action now and the next new issue that is safe to start;
 brief, compact, full, and structured JSON modes share the same classification
-and ranking result. Refreshes preserve this adapter when CPP generates a skill
+and ranking result. Compact output explains up to three safe candidates; full
+output adds tiered backlog, Spec Kit readiness, detailed worktrees, and cleanup
+guidance from the same structured result. Refreshes preserve this adapter when CPP generates a skill
 with the same name, without preserving a competing prompt-only decision policy.
 
 **Do not hand-edit generated skill dirs.** The drift gate (`make codex-skills-check`)

--- a/docs/project-init-spec-kit-contract.md
+++ b/docs/project-init-spec-kit-contract.md
@@ -183,10 +183,11 @@ After a successful create or repair, `spec-sync` updates the selected
 and state. A partial write reports exactly which mappings remain unresolved and
 does not claim the ledger is synchronized.
 
-`project-next` contract version `1.1` consumes only these ledger identities.
-Task IDs found incidentally in issue prose are no longer synchronization
-evidence. Missing mappings recommend synchronization; stale or ambiguous
-mappings recommend repair and remain explicit uncertainty.
+`project-next` contract version `1.2` consumes only these ledger identities and
+reports each feature's `spec.md`, `plan.md`, `tasks.md`, aggregate mapping state,
+and next synchronization action. Task IDs found incidentally in issue prose are
+no longer synchronization evidence. Missing mappings recommend synchronization;
+stale or ambiguous mappings recommend repair and remain explicit uncertainty.
 
 ## Ownership and Rollout
 

--- a/docs/project-next-contract.md
+++ b/docs/project-next-contract.md
@@ -10,7 +10,7 @@ authoritative implementation. CPP adoption is tracked by
 
 ## Version and entry points
 
-Contract version `1.1` accepts a structured `RepositoryState` and emits a
+Contract version `1.2` accepts a structured `RepositoryState` and emits a
 structured `RecommendationResult`. Run it from a CxPP checkout with:
 
 ```bash
@@ -24,8 +24,8 @@ drift from the authoritative `lib/project_next/` package.
 ## Input contract
 
 Repository state includes open issues, open pull requests, local and remote
-branches, worktrees and dirtiness, review/check/merge state, stable Spec Kit
-ledger mappings, collection warnings, and whether the inventory is
+branches, worktrees, recent commits and dirtiness, review/check/merge state,
+Spec Kit file readiness and stable ledger mappings, collection warnings, and whether the inventory is
 complete. Fixture JSON can supply the same model without git, GitHub, or an LLM.
 
 The live collector performs batched GitHub queries. Authentication, rate-limit,
@@ -82,15 +82,26 @@ be the top action while a different issue is the safe next issue to start.
 
 - `--json` emits the complete versioned result and is authoritative.
 - `--brief` shows the top action, next safe issue, and inventory confidence.
-- compact mode adds state counts, alternatives, active, blocked, uncertain, and
-  warning sections.
-- `--full` adds exhaustive classifications, pull requests, worktrees, and
-  unsynchronized specification tasks.
+- compact mode shows at most three safe candidates. Each candidate carries its
+  priority, phase/wave, issue type, quick-win signal, stable rank tuple,
+  deterministic rationale, and `$flow-auto` command. Active, blocked,
+  uncertain, and critical non-startable work stays visibly separate.
+- `--full` adds mutually assigned operational tiers, categorized backlog counts,
+  pull requests, Spec Kit file and mapping readiness, worktrees with their
+  already-collected recent commits, and cleanup candidates for worktrees or
+  branches that do not map to an open issue.
+
+`RecommendationResult` owns all presentation decisions through structured
+`candidates`, `backlog_summary`, `backlog_tiers`, `spec_features`,
+`worktree_details`, and `cleanup_candidates` fields. Renderers format those
+fields and do not parse issue prose, classify work, or re-rank candidates.
+Incomplete inventory produces no candidates or startable tiers even when the
+partial inventory contains apparently available issues.
 
 Spec Kit work is represented only by the `spec-sync:v1` Issue Sync ledger.
 Task-ID searches in issue titles or bodies are not synchronization evidence.
 Missing mappings produce `sync_spec`; stale or ambiguous identities produce
 `resolve_spec_mapping`. Neither state is silently treated as completed work.
 
-All modes name the `1.1` contract. Missing prerequisites and incomplete state
+All modes name the `1.2` contract. Missing prerequisites and incomplete state
 are explicit failure states; they never become a confident recommendation.

--- a/docs/skill-contract-baseline.md
+++ b/docs/skill-contract-baseline.md
@@ -12,7 +12,7 @@
 | Unpackaged source skills | 10 |
 | Marketplace plugins | 16 |
 | Implicitly eligible packaged skills | 2 |
-| Extracted packaged-Markdown references | 654 |
+| Extracted packaged-Markdown references | 655 |
 | Unexplained reference occurrences | 0 |
 
 The machine-readable source of truth is [`.agents/skill-contracts.json`](../.agents/skill-contracts.json).
@@ -52,7 +52,7 @@ Prompt presence passed. Direct recall, indirect recall, and negative precision r
 
 | Classification | Occurrences | Meaning |
 |---|---:|---|
-| Resolvable | 411 | Explicit `$skill-name` resolves to a packaged skill. |
+| Resolvable | 412 | Explicit `$skill-name` resolves to a packaged skill. |
 | Native | 17 | Supported Codex host command. |
 | Adapted | 135 | The packaged skill carries an explicit Codex harness adaptation. |
 | Excluded | 24 | Target has a reviewed, owned, time-bound exclusion. |

--- a/lib/project_next/__init__.py
+++ b/lib/project_next/__init__.py
@@ -6,7 +6,7 @@ from .models import RepositoryState
 from .rank import recommend
 from .render import render_result
 
-CONTRACT_VERSION = "1.1"
+CONTRACT_VERSION = "1.2"
 
 __all__ = [
     "CONTRACT_VERSION",

--- a/lib/project_next/collect.py
+++ b/lib/project_next/collect.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from .config import ProjectNextConfig
-from .models import Branch, Issue, PullRequest, RepositoryState, SpecTask, Worktree
+from .models import Branch, Issue, PullRequest, RepositoryState, SpecFeature, SpecTask, Worktree
 
 CommandRunner = Callable[[list[str], Path], str]
 TASK = re.compile(r"^-\s*\[\s\]\s+(?:\*\*)?(?P<id>[A-Za-z]+\d+)(?:\*\*)?\s+(?P<title>.+)$")
@@ -108,12 +108,36 @@ def _parse_branches(output: str) -> tuple[Branch, ...]:
     return tuple(branches)
 
 
-def _spec_tasks(repository: Path, repository_name: str, warnings: list[str]) -> tuple[SpecTask, ...]:
+def _spec_inventory(
+    repository: Path, repository_name: str, warnings: list[str]
+) -> tuple[tuple[SpecTask, ...], tuple[SpecFeature, ...]]:
     specs = repository / ".specify" / "specs"
     if not specs.is_dir():
-        return ()
+        return (), ()
     tasks: list[SpecTask] = []
-    for path in sorted(specs.glob("*/tasks.md")):
+    features: list[SpecFeature] = []
+    for feature_path in sorted(path for path in specs.iterdir() if path.is_dir()):
+        path = feature_path / "tasks.md"
+        feature_tasks: list[SpecTask] = []
+        if not path.is_file():
+            has_spec = (feature_path / "spec.md").is_file()
+            has_plan = (feature_path / "plan.md").is_file()
+            if not has_spec:
+                action = "create spec.md"
+            elif not has_plan:
+                action = "create plan.md"
+            else:
+                action = "create tasks.md"
+            features.append(
+                SpecFeature(
+                    name=feature_path.name,
+                    path=feature_path.relative_to(repository).as_posix(),
+                    has_spec=has_spec,
+                    has_plan=has_plan,
+                    recommended_action=action,
+                )
+            )
+            continue
         try:
             lines = path.read_text(encoding="utf-8").splitlines()
         except OSError as exc:
@@ -174,7 +198,7 @@ def _spec_tasks(repository: Path, repository_name: str, warnings: list[str]) -> 
                 status = "mapped" if expected else "stale"
             if status != "mapped":
                 warnings.append(f"{relative}:{task_id}: spec-sync mapping is {status}")
-            tasks.append(
+            feature_tasks.append(
                 SpecTask(
                     task_id=task_id,
                     title=match.group("title").strip(),
@@ -188,7 +212,50 @@ def _spec_tasks(repository: Path, repository_name: str, warnings: list[str]) -> 
                     mapping_state=mapping_state,
                 )
             )
-    return tuple(tasks)
+        tasks.extend(feature_tasks)
+        statuses = {task.mapping_status for task in feature_tasks}
+        mapped = sum(task.synchronized for task in feature_tasks)
+        if not feature_tasks:
+            mapping_status = "not-applicable"
+            action = "add actionable tasks"
+        elif "ambiguous" in statuses:
+            mapping_status = "ambiguous"
+            action = "repair ambiguous issue mappings"
+        elif "stale" in statuses:
+            mapping_status = "stale"
+            action = "repair stale issue mappings"
+        elif mapped == len(feature_tasks):
+            mapping_status = "complete"
+            action = "none"
+        elif mapped:
+            mapping_status = "partial"
+            action = "sync remaining tasks to issues"
+        else:
+            mapping_status = "missing"
+            action = "sync tasks to issues"
+        if not (feature_path / "spec.md").is_file():
+            action = "create spec.md"
+        elif not (feature_path / "plan.md").is_file():
+            action = "create plan.md"
+        features.append(
+            SpecFeature(
+                name=feature_path.name,
+                path=feature_path.relative_to(repository).as_posix(),
+                has_spec=(feature_path / "spec.md").is_file(),
+                has_plan=(feature_path / "plan.md").is_file(),
+                has_tasks=True,
+                total_tasks=len(feature_tasks),
+                mapped_tasks=mapped,
+                mapping_status=mapping_status,
+                recommended_action=action,
+            )
+        )
+    return tuple(tasks), tuple(features)
+
+
+def _spec_tasks(repository: Path, repository_name: str, warnings: list[str]) -> tuple[SpecTask, ...]:
+    """Compatibility wrapper for callers that only need task mappings."""
+    return _spec_inventory(repository, repository_name, warnings)[0]
 
 
 def collect_repository(
@@ -312,7 +379,7 @@ def collect_repository(
         complete = False
         branches = ()
 
-    spec_tasks = _spec_tasks(repository, repo_name, warnings)
+    spec_tasks, spec_features = _spec_inventory(repository, repo_name, warnings)
     return RepositoryState(
         repository=repo_name,
         default_branch=default_branch,
@@ -322,6 +389,7 @@ def collect_repository(
         worktrees=worktrees,
         branches=branches,
         spec_tasks=spec_tasks,
+        spec_features=spec_features,
         inventory_complete=complete,
         collector_warnings=tuple(warnings),
         collector_errors=tuple(errors),

--- a/lib/project_next/models.py
+++ b/lib/project_next/models.py
@@ -142,6 +142,33 @@ class SpecTask:
 
 
 @dataclass(frozen=True)
+class SpecFeature:
+    name: str
+    path: str
+    has_spec: bool = False
+    has_plan: bool = False
+    has_tasks: bool = False
+    total_tasks: int = 0
+    mapped_tasks: int = 0
+    mapping_status: str = "not-applicable"
+    recommended_action: str = "none"
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SpecFeature:
+        return cls(
+            name=str(data["name"]),
+            path=str(data.get("path") or ""),
+            has_spec=bool(data.get("has_spec", False)),
+            has_plan=bool(data.get("has_plan", False)),
+            has_tasks=bool(data.get("has_tasks", False)),
+            total_tasks=int(data.get("total_tasks", 0)),
+            mapped_tasks=int(data.get("mapped_tasks", 0)),
+            mapping_status=str(data.get("mapping_status") or "not-applicable"),
+            recommended_action=str(data.get("recommended_action") or "none"),
+        )
+
+
+@dataclass(frozen=True)
 class RepositoryState:
     repository: str
     default_branch: str
@@ -151,6 +178,7 @@ class RepositoryState:
     worktrees: tuple[Worktree, ...] = ()
     branches: tuple[Branch, ...] = ()
     spec_tasks: tuple[SpecTask, ...] = ()
+    spec_features: tuple[SpecFeature, ...] = ()
     gate_status: str = "unknown"
     inventory_complete: bool = True
     collector_warnings: tuple[str, ...] = ()
@@ -167,6 +195,7 @@ class RepositoryState:
             worktrees=tuple(Worktree.from_dict(item) for item in data.get("worktrees", ())),
             branches=tuple(Branch.from_dict(item) for item in data.get("branches", ())),
             spec_tasks=tuple(SpecTask.from_dict(item) for item in data.get("spec_tasks", ())),
+            spec_features=tuple(SpecFeature.from_dict(item) for item in data.get("spec_features", ())),
             gate_status=str(data.get("gate_status") or "unknown"),
             inventory_complete=bool(data.get("inventory_complete", True)),
             collector_warnings=_tuple_of_strings(data.get("collector_warnings")),
@@ -207,6 +236,66 @@ class Action:
 
 
 @dataclass(frozen=True)
+class Candidate:
+    issue_number: int
+    rank_key: tuple[int, ...]
+    priority: str
+    phase: str
+    issue_type: str
+    quick_win: bool
+    critical: bool
+    stale: bool
+    rationale: str
+    command: str
+
+
+@dataclass(frozen=True)
+class BacklogSummary:
+    open: int = 0
+    critical: int = 0
+    bugs: int = 0
+    features: int = 0
+    docs: int = 0
+    tech_debt: int = 0
+    planning: int = 0
+    other: int = 0
+
+
+@dataclass(frozen=True)
+class BacklogTiers:
+    critical: tuple[int, ...] = ()
+    active: tuple[int, ...] = ()
+    blocked: tuple[int, ...] = ()
+    uncertain: tuple[int, ...] = ()
+    ready: tuple[int, ...] = ()
+    quick_wins: tuple[int, ...] = ()
+    planning: tuple[int, ...] = ()
+    pending_spec_sync: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class WorktreeDetail:
+    path: str
+    branch: str
+    issue_number: int | None
+    issue_state: str
+    dirty: bool
+    recent_commits: tuple[str, ...] = ()
+    cleanup_recommended: bool = False
+    cleanup_reason: str = ""
+
+
+@dataclass(frozen=True)
+class CleanupCandidate:
+    target_type: str
+    target: str
+    branch: str
+    issue_number: int | None
+    reason: str
+    action: str = "Review with $flow-cleanup"
+
+
+@dataclass(frozen=True)
 class RecommendationResult:
     contract_version: str
     repository: str
@@ -216,6 +305,12 @@ class RecommendationResult:
     top_action: Action | None
     next_startable_issue: int | None
     unsynchronized_spec_tasks: tuple[SpecTask, ...] = ()
+    candidates: tuple[Candidate, ...] = ()
+    backlog_summary: BacklogSummary = field(default_factory=BacklogSummary)
+    backlog_tiers: BacklogTiers = field(default_factory=BacklogTiers)
+    spec_features: tuple[SpecFeature, ...] = ()
+    worktree_details: tuple[WorktreeDetail, ...] = ()
+    cleanup_candidates: tuple[CleanupCandidate, ...] = ()
     warnings: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:

--- a/lib/project_next/rank.py
+++ b/lib/project_next/rank.py
@@ -5,11 +5,22 @@ from __future__ import annotations
 import re
 from datetime import datetime, timezone
 
-from .classify import classify_repository, pull_request_issue_numbers
+from .classify import classify_repository, issue_number_from_branch, pull_request_issue_numbers
 from .config import ProjectNextConfig
-from .models import Action, Classification, Issue, RecommendationResult, RepositoryState
+from .models import (
+    Action,
+    BacklogSummary,
+    BacklogTiers,
+    Candidate,
+    Classification,
+    CleanupCandidate,
+    Issue,
+    RecommendationResult,
+    RepositoryState,
+    WorktreeDetail,
+)
 
-CONTRACT_VERSION = "1.1"
+CONTRACT_VERSION = "1.2"
 PHASE = re.compile(r"\b(?:wave|phase)[-\s:]*(?P<number>\d+)\b", re.IGNORECASE)
 
 
@@ -73,6 +84,67 @@ def rank_key(issue: Issue, state: RepositoryState, config: ProjectNextConfig) ->
         quick_win,
         _staleness(issue, state, config),
         issue.number,
+    )
+
+
+def _is_critical(issue: Issue, config: ProjectNextConfig) -> bool:
+    labels = issue.normalized_labels
+    return bool(labels & set(config.critical_labels) or ("bug" in labels and _priority(issue, config) == 0))
+
+
+def _priority_evidence(issue: Issue, config: ProjectNextConfig) -> str:
+    labels = issue.normalized_labels
+    matched = sorted(labels & set(config.high_priority_labels))
+    if matched:
+        return f"high ({matched[0]})"
+    matched = sorted(labels & set(config.medium_priority_labels))
+    if matched:
+        return f"medium ({matched[0]})"
+    return "default"
+
+
+def _phase_evidence(issue: Issue) -> str:
+    phase = _phase(issue)
+    return f"wave/phase {phase}" if phase < 10_000 else "unspecified"
+
+
+def _type_evidence(issue: Issue, config: ProjectNextConfig) -> str:
+    labels = issue.normalized_labels
+    title = issue.title.casefold()
+    if labels & set(config.planning_labels) or re.search(r"\b(?:epic|tracking|planning)\b", title):
+        return "planning"
+    if "bug" in labels or re.search(r"\bfix\b", title):
+        return "bug"
+    if "task" in labels or re.search(r"\b(?:restore|implement)\b", title):
+        return "task"
+    if labels & set(config.quick_win_labels):
+        return "quick-win"
+    return "feature"
+
+
+def _candidate(issue: Issue, state: RepositoryState, config: ProjectNextConfig) -> Candidate:
+    critical = _is_critical(issue, config)
+    priority = _priority_evidence(issue, config)
+    phase = _phase_evidence(issue)
+    issue_type = _type_evidence(issue, config)
+    quick_win = bool(issue.normalized_labels & set(config.quick_win_labels))
+    stale = _staleness(issue, state, config) == 0
+    evidence = ["critical" if critical else priority, phase, issue_type]
+    if quick_win and issue_type != "quick-win":
+        evidence.append("quick win")
+    if stale:
+        evidence.append("stale")
+    return Candidate(
+        issue_number=issue.number,
+        rank_key=rank_key(issue, state, config),
+        priority=priority,
+        phase=phase,
+        issue_type=issue_type,
+        quick_win=quick_win,
+        critical=critical,
+        stale=stale,
+        rationale="; ".join(evidence) + "; ordered by the deterministic rank tuple",
+        command=f"$flow-auto {issue.number}",
     )
 
 
@@ -214,6 +286,154 @@ def _top_action(
     return None
 
 
+def _backlog_summary(issues: tuple[Issue, ...], config: ProjectNextConfig) -> BacklogSummary:
+    counts = {
+        "critical": 0,
+        "bugs": 0,
+        "features": 0,
+        "docs": 0,
+        "tech_debt": 0,
+        "planning": 0,
+        "other": 0,
+    }
+    for issue in issues:
+        labels = issue.normalized_labels
+        title = issue.title.casefold()
+        if _is_critical(issue, config):
+            category = "critical"
+        elif "bug" in labels or re.search(r"\bfix\b", title):
+            category = "bugs"
+        elif labels & {"documentation", "docs"}:
+            category = "docs"
+        elif labels & {"tech-debt", "technical-debt", "chore", "refactor"}:
+            category = "tech_debt"
+        elif labels & set(config.planning_labels) or re.search(r"\b(?:epic|tracking|planning)\b", title):
+            category = "planning"
+        elif labels & {"feature", "enhancement"} or re.search(r"\bfeat(?:ure)?\b", title):
+            category = "features"
+        else:
+            category = "other"
+        counts[category] += 1
+    return BacklogSummary(open=len(issues), **counts)
+
+
+def _backlog_tiers(
+    state: RepositoryState,
+    classification: Classification,
+    ranked: tuple[int, ...],
+    config: ProjectNextConfig,
+) -> BacklogTiers:
+    issues = {issue.number: issue for issue in state.issues}
+    critical = tuple(number for number in sorted(issues) if _is_critical(issues[number], config))
+    critical_set = set(critical)
+    active = tuple(number for number in classification.in_flight if number not in critical_set)
+    blocked = tuple(number for number in classification.blocked if number not in critical_set)
+    uncertain = tuple(number for number in classification.uncertain if number not in critical_set)
+    safe_inventory = state.inventory_complete and not state.collector_errors
+    available = [number for number in ranked if number not in critical_set] if safe_inventory else []
+    planning = tuple(number for number in available if _type_evidence(issues[number], config) == "planning")
+    planning_set = set(planning)
+    quick_wins = tuple(
+        number
+        for number in available
+        if number not in planning_set and bool(issues[number].normalized_labels & set(config.quick_win_labels))
+    )
+    quick_win_set = set(quick_wins)
+    ready = tuple(number for number in available if number not in (planning_set | quick_win_set))
+    pending_spec_sync = tuple(
+        feature.name for feature in state.spec_features if feature.recommended_action != "none"
+    )
+    return BacklogTiers(
+        critical=critical,
+        active=active,
+        blocked=blocked,
+        uncertain=uncertain,
+        ready=ready,
+        quick_wins=quick_wins,
+        planning=planning,
+        pending_spec_sync=pending_spec_sync,
+    )
+
+
+def _issue_state(number: int | None, state: RepositoryState, classification: Classification) -> str:
+    if number is None:
+        return "unmapped"
+    if number in classification.in_flight:
+        return "in-flight"
+    if number in classification.blocked:
+        return "blocked"
+    if number in classification.available:
+        return "available"
+    if number in classification.uncertain:
+        return "uncertain"
+    if number in {issue.number for issue in state.issues}:
+        return "unknown"
+    return "no-open-issue"
+
+
+def _worktree_report(
+    state: RepositoryState, classification: Classification
+) -> tuple[tuple[WorktreeDetail, ...], tuple[CleanupCandidate, ...]]:
+    details: list[WorktreeDetail] = []
+    cleanup: list[CleanupCandidate] = []
+    worktree_branches: set[str] = set()
+    for worktree in state.worktrees:
+        number = issue_number_from_branch(worktree.branch)
+        primary = worktree.branch == state.default_branch
+        issue_state = "default" if primary else _issue_state(number, state, classification)
+        cleanup_recommended = not primary and issue_state in {"unmapped", "no-open-issue"}
+        cleanup_reason = ""
+        if cleanup_recommended:
+            cleanup_reason = "branch does not map to an open issue; it may be merged, closed, or abandoned"
+            action = (
+                "Inspect uncommitted changes; do not remove automatically"
+                if worktree.dirty
+                else "Review with $flow-cleanup"
+            )
+            cleanup.append(
+                CleanupCandidate(
+                    target_type="worktree",
+                    target=worktree.path,
+                    branch=worktree.branch,
+                    issue_number=number,
+                    reason=cleanup_reason,
+                    action=action,
+                )
+            )
+        details.append(
+            WorktreeDetail(
+                path=worktree.path,
+                branch=worktree.branch,
+                issue_number=number,
+                issue_state=issue_state,
+                dirty=worktree.dirty,
+                recent_commits=worktree.recent_commits,
+                cleanup_recommended=cleanup_recommended,
+                cleanup_reason=cleanup_reason,
+            )
+        )
+        if worktree.branch:
+            worktree_branches.add(worktree.branch)
+
+    for branch in state.branches:
+        short_name = branch.name.removeprefix("remotes/").removeprefix("origin/")
+        if short_name == state.default_branch or short_name in worktree_branches:
+            continue
+        number = issue_number_from_branch(short_name)
+        if number is not None and _issue_state(number, state, classification) != "no-open-issue":
+            continue
+        cleanup.append(
+            CleanupCandidate(
+                target_type="remote branch" if branch.remote else "branch",
+                target=branch.name,
+                branch=short_name,
+                issue_number=number,
+                reason="branch does not map to an open issue; verify whether it is merged or abandoned",
+            )
+        )
+    return tuple(details), tuple(cleanup)
+
+
 def recommend(state: RepositoryState, config: ProjectNextConfig | None = None) -> RecommendationResult:
     config = config or ProjectNextConfig()
     classification = classify_repository(state)
@@ -230,6 +450,12 @@ def recommend(state: RepositoryState, config: ProjectNextConfig | None = None) -
     warnings = tuple(state.collector_warnings) + tuple(state.collector_errors)
     if classification.unmapped_worktrees:
         warnings += tuple(f"unmapped worktree: {item}" for item in classification.unmapped_worktrees)
+    candidates = (
+        tuple(_candidate(issues[number], state, config) for number in ranked)
+        if next_startable is not None
+        else ()
+    )
+    worktree_details, cleanup_candidates = _worktree_report(state, classification)
     return RecommendationResult(
         contract_version=CONTRACT_VERSION,
         repository=state.repository,
@@ -239,5 +465,11 @@ def recommend(state: RepositoryState, config: ProjectNextConfig | None = None) -
         top_action=_top_action(state, classification, ranked, config),
         next_startable_issue=next_startable,
         unsynchronized_spec_tasks=pending,
+        candidates=candidates,
+        backlog_summary=_backlog_summary(state.issues, config),
+        backlog_tiers=_backlog_tiers(state, classification, ranked, config),
+        spec_features=state.spec_features,
+        worktree_details=worktree_details,
+        cleanup_candidates=cleanup_candidates,
         warnings=warnings,
     )

--- a/lib/project_next/render.py
+++ b/lib/project_next/render.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .models import Action, RecommendationResult, RepositoryState
+from .models import Action, Candidate, RecommendationResult, RepositoryState
 
 
 def _action(action: Action | None) -> str:
@@ -14,7 +14,8 @@ def _action(action: Action | None) -> str:
     if action.pull_request_number is not None:
         refs.append(f"PR #{action.pull_request_number}")
     suffix = f" ({', '.join(refs)})" if refs else ""
-    return f"{action.kind}: {action.title}{suffix} — {action.reason}"
+    evidence = f" Evidence: {', '.join(action.evidence)}." if action.evidence else ""
+    return f"{action.kind}: {action.title}{suffix} — {action.reason}{evidence}"
 
 
 def _next_issue(result: RecommendationResult, state: RepositoryState) -> str:
@@ -22,6 +23,30 @@ def _next_issue(result: RecommendationResult, state: RepositoryState) -> str:
         return "None"
     issue = next(issue for issue in state.issues if issue.number == result.next_startable_issue)
     return f"#{issue.number} {issue.title}"
+
+
+def _candidate_lines(candidate: Candidate, title: str, position: int | None = None) -> list[str]:
+    prefix = f"{position}." if position is not None else "-"
+    evidence = (
+        f"priority {candidate.priority}; phase {candidate.phase}; type {candidate.issue_type}; "
+        f"quick win {'yes' if candidate.quick_win else 'no'}"
+    )
+    return [
+        f"{prefix} #{candidate.issue_number} {title} [{evidence}]",
+        f"   {candidate.rationale} → `{candidate.command}`",
+    ]
+
+
+def _classification_state(number: int, result: RecommendationResult) -> str:
+    if number in result.classification.in_flight:
+        return "in-flight"
+    if number in result.classification.blocked:
+        return "blocked"
+    if number in result.classification.uncertain:
+        return "uncertain"
+    if number in result.classification.available:
+        return "available"
+    return "unknown"
 
 
 def render_brief(result: RecommendationResult, state: RepositoryState) -> str:
@@ -49,10 +74,22 @@ def render_compact(result: RecommendationResult, state: RepositoryState) -> str:
             f"inventory {'complete' if result.inventory_complete else 'incomplete'}"
         ),
     ]
-    alternatives = result.ranked_available[1:4]
-    if alternatives:
-        lines.extend(("", "### Other available issues"))
-        lines.extend(f"- #{number} {issues[number].title}" for number in alternatives)
+    if result.next_startable_issue is not None:
+        lines.extend(("", "### Ready to start (top 3)"))
+        for position, candidate in enumerate(result.candidates[:3], start=1):
+            lines.extend(_candidate_lines(candidate, issues[candidate.issue_number].title, position))
+    else:
+        lines.extend(("", "### Ready to start", "- None — a complete safe recommendation is unavailable."))
+
+    critical_non_startable = tuple(
+        number
+        for number in result.backlog_tiers.critical
+        if number not in result.classification.available
+    )
+    if critical_non_startable:
+        lines.extend(("", "### Critical work (not startable)"))
+        for number in critical_non_startable:
+            lines.append(f"- #{number} {issues[number].title} — {_classification_state(number, result)}")
     if result.classification.in_flight:
         lines.extend(("", "### Active work (not startable)"))
         lines.extend(
@@ -78,17 +115,76 @@ def render_compact(result: RecommendationResult, state: RepositoryState) -> str:
     return "\n".join(lines)
 
 
-def render_full(result: RecommendationResult, state: RepositoryState) -> str:
+def _tier_issue_lines(
+    numbers: tuple[int, ...], result: RecommendationResult, state: RepositoryState
+) -> list[str]:
     issues = {issue.number: issue for issue in state.issues}
-    lines = [render_compact(result, state), "", "### Complete classification"]
-    for name, numbers in (
-        ("In flight", result.classification.in_flight),
-        ("Blocked", result.classification.blocked),
-        ("Available", result.classification.available),
-        ("Uncertain", result.classification.uncertain),
-    ):
-        rendered = ", ".join(f"#{number} {issues[number].title}" for number in numbers) or "none"
-        lines.append(f"- {name}: {rendered}")
+    candidates = {candidate.issue_number: candidate for candidate in result.candidates}
+    lines: list[str] = []
+    for number in numbers:
+        state_name = _classification_state(number, result)
+        suffix = ""
+        if number in candidates and state_name == "available":
+            suffix = f"; {candidates[number].rationale} → `{candidates[number].command}`"
+        lines.append(f"- #{number} {issues[number].title} — {state_name}{suffix}")
+    return lines or ["- none"]
+
+
+def render_full(result: RecommendationResult, state: RepositoryState) -> str:
+    summary = result.backlog_summary
+    lines = [
+        render_compact(result, state),
+        "",
+        "### Categorized backlog summary",
+        (
+            f"- {summary.open} open | {summary.critical} critical | {summary.bugs} bugs | "
+            f"{summary.features} features | {summary.docs} docs | {summary.tech_debt} tech debt | "
+            f"{summary.planning} planning | {summary.other} other"
+        ),
+        "",
+        "### Tier 1 — Critical work",
+        *_tier_issue_lines(result.backlog_tiers.critical, result, state),
+        "",
+        "### Tier 2 — Active work",
+        *_tier_issue_lines(result.backlog_tiers.active, result, state),
+        "",
+        "### Blocked work (not actionable)",
+        *_tier_issue_lines(result.backlog_tiers.blocked, result, state),
+        "",
+        "### Uncertain work (not actionable)",
+        *_tier_issue_lines(result.backlog_tiers.uncertain, result, state),
+        "",
+        "### Tier 3 — Ready to start",
+        *_tier_issue_lines(result.backlog_tiers.ready, result, state),
+        "",
+        "### Tier 3b — Pending specification sync",
+    ]
+    lines.extend(f"- {name}" for name in result.backlog_tiers.pending_spec_sync)
+    if not result.backlog_tiers.pending_spec_sync:
+        lines.append("- none")
+    lines.extend(("", "### Tier 4 — Quick wins"))
+    lines.extend(_tier_issue_lines(result.backlog_tiers.quick_wins, result, state))
+    lines.extend(("", "### Tier 5 — Planning and discussion"))
+    lines.extend(_tier_issue_lines(result.backlog_tiers.planning, result, state))
+
+    lines.extend(("", "### Spec Kit readiness"))
+    if result.spec_features:
+        lines.extend(
+            (
+                "| Feature | spec.md | plan.md | tasks.md | Mapping | Recommended action |",
+                "|---|---:|---:|---:|---|---|",
+            )
+        )
+        lines.extend(
+            f"| {feature.name} | {'yes' if feature.has_spec else 'no'} | "
+            f"{'yes' if feature.has_plan else 'no'} | {'yes' if feature.has_tasks else 'no'} | "
+            f"{feature.mapped_tasks}/{feature.total_tasks} ({feature.mapping_status}) | "
+            f"{feature.recommended_action} |"
+            for feature in result.spec_features
+        )
+    else:
+        lines.append("- no Spec Kit features found")
+
     lines.extend(("", "### Pull requests"))
     lines.extend(
         f"- #{pr.number} {pr.title} — head {pr.head_ref}; checks {pr.checks_state}; "
@@ -97,16 +193,32 @@ def render_full(result: RecommendationResult, state: RepositoryState) -> str:
     )
     if not state.pull_requests:
         lines.append("- none")
-    lines.extend(("", "### Worktrees"))
-    lines.extend(
-        f"- {worktree.path} — {worktree.branch or '(detached)'}; {'dirty' if worktree.dirty else 'clean'}"
-        for worktree in state.worktrees
-    )
-    if not state.worktrees:
+
+    lines.extend(("", "### Worktree detail"))
+    if result.worktree_details:
+        lines.extend(
+            (
+                "| Path | Branch | Issue | State | Dirty | Recent commits |",
+                "|---|---|---:|---|---:|---|",
+            )
+        )
+        for worktree in result.worktree_details:
+            issue = f"#{worktree.issue_number}" if worktree.issue_number is not None else "—"
+            commits = "<br>".join(worktree.recent_commits) or "none"
+            lines.append(
+                f"| {worktree.path} | {worktree.branch or '(detached)'} | {issue} | "
+                f"{worktree.issue_state} | {'yes' if worktree.dirty else 'no'} | {commits} |"
+            )
+    else:
         lines.append("- none")
-    lines.extend(("", "### Unsynchronized specification tasks"))
-    lines.extend(f"- {task.task_id} {task.title} — {task.source}" for task in result.unsynchronized_spec_tasks)
-    if not result.unsynchronized_spec_tasks:
+
+    lines.extend(("", "### Cleanup guidance"))
+    lines.extend(
+        f"- {candidate.target_type} `{candidate.target}` ({candidate.branch or 'detached'}) — "
+        f"{candidate.reason}. {candidate.action}."
+        for candidate in result.cleanup_candidates
+    )
+    if not result.cleanup_candidates:
         lines.append("- none")
     return "\n".join(lines)
 

--- a/plugins/project/lib/project_next/__init__.py
+++ b/plugins/project/lib/project_next/__init__.py
@@ -6,7 +6,7 @@ from .models import RepositoryState
 from .rank import recommend
 from .render import render_result
 
-CONTRACT_VERSION = "1.1"
+CONTRACT_VERSION = "1.2"
 
 __all__ = [
     "CONTRACT_VERSION",

--- a/plugins/project/lib/project_next/collect.py
+++ b/plugins/project/lib/project_next/collect.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from .config import ProjectNextConfig
-from .models import Branch, Issue, PullRequest, RepositoryState, SpecTask, Worktree
+from .models import Branch, Issue, PullRequest, RepositoryState, SpecFeature, SpecTask, Worktree
 
 CommandRunner = Callable[[list[str], Path], str]
 TASK = re.compile(r"^-\s*\[\s\]\s+(?:\*\*)?(?P<id>[A-Za-z]+\d+)(?:\*\*)?\s+(?P<title>.+)$")
@@ -108,12 +108,36 @@ def _parse_branches(output: str) -> tuple[Branch, ...]:
     return tuple(branches)
 
 
-def _spec_tasks(repository: Path, repository_name: str, warnings: list[str]) -> tuple[SpecTask, ...]:
+def _spec_inventory(
+    repository: Path, repository_name: str, warnings: list[str]
+) -> tuple[tuple[SpecTask, ...], tuple[SpecFeature, ...]]:
     specs = repository / ".specify" / "specs"
     if not specs.is_dir():
-        return ()
+        return (), ()
     tasks: list[SpecTask] = []
-    for path in sorted(specs.glob("*/tasks.md")):
+    features: list[SpecFeature] = []
+    for feature_path in sorted(path for path in specs.iterdir() if path.is_dir()):
+        path = feature_path / "tasks.md"
+        feature_tasks: list[SpecTask] = []
+        if not path.is_file():
+            has_spec = (feature_path / "spec.md").is_file()
+            has_plan = (feature_path / "plan.md").is_file()
+            if not has_spec:
+                action = "create spec.md"
+            elif not has_plan:
+                action = "create plan.md"
+            else:
+                action = "create tasks.md"
+            features.append(
+                SpecFeature(
+                    name=feature_path.name,
+                    path=feature_path.relative_to(repository).as_posix(),
+                    has_spec=has_spec,
+                    has_plan=has_plan,
+                    recommended_action=action,
+                )
+            )
+            continue
         try:
             lines = path.read_text(encoding="utf-8").splitlines()
         except OSError as exc:
@@ -174,7 +198,7 @@ def _spec_tasks(repository: Path, repository_name: str, warnings: list[str]) -> 
                 status = "mapped" if expected else "stale"
             if status != "mapped":
                 warnings.append(f"{relative}:{task_id}: spec-sync mapping is {status}")
-            tasks.append(
+            feature_tasks.append(
                 SpecTask(
                     task_id=task_id,
                     title=match.group("title").strip(),
@@ -188,7 +212,50 @@ def _spec_tasks(repository: Path, repository_name: str, warnings: list[str]) -> 
                     mapping_state=mapping_state,
                 )
             )
-    return tuple(tasks)
+        tasks.extend(feature_tasks)
+        statuses = {task.mapping_status for task in feature_tasks}
+        mapped = sum(task.synchronized for task in feature_tasks)
+        if not feature_tasks:
+            mapping_status = "not-applicable"
+            action = "add actionable tasks"
+        elif "ambiguous" in statuses:
+            mapping_status = "ambiguous"
+            action = "repair ambiguous issue mappings"
+        elif "stale" in statuses:
+            mapping_status = "stale"
+            action = "repair stale issue mappings"
+        elif mapped == len(feature_tasks):
+            mapping_status = "complete"
+            action = "none"
+        elif mapped:
+            mapping_status = "partial"
+            action = "sync remaining tasks to issues"
+        else:
+            mapping_status = "missing"
+            action = "sync tasks to issues"
+        if not (feature_path / "spec.md").is_file():
+            action = "create spec.md"
+        elif not (feature_path / "plan.md").is_file():
+            action = "create plan.md"
+        features.append(
+            SpecFeature(
+                name=feature_path.name,
+                path=feature_path.relative_to(repository).as_posix(),
+                has_spec=(feature_path / "spec.md").is_file(),
+                has_plan=(feature_path / "plan.md").is_file(),
+                has_tasks=True,
+                total_tasks=len(feature_tasks),
+                mapped_tasks=mapped,
+                mapping_status=mapping_status,
+                recommended_action=action,
+            )
+        )
+    return tuple(tasks), tuple(features)
+
+
+def _spec_tasks(repository: Path, repository_name: str, warnings: list[str]) -> tuple[SpecTask, ...]:
+    """Compatibility wrapper for callers that only need task mappings."""
+    return _spec_inventory(repository, repository_name, warnings)[0]
 
 
 def collect_repository(
@@ -312,7 +379,7 @@ def collect_repository(
         complete = False
         branches = ()
 
-    spec_tasks = _spec_tasks(repository, repo_name, warnings)
+    spec_tasks, spec_features = _spec_inventory(repository, repo_name, warnings)
     return RepositoryState(
         repository=repo_name,
         default_branch=default_branch,
@@ -322,6 +389,7 @@ def collect_repository(
         worktrees=worktrees,
         branches=branches,
         spec_tasks=spec_tasks,
+        spec_features=spec_features,
         inventory_complete=complete,
         collector_warnings=tuple(warnings),
         collector_errors=tuple(errors),

--- a/plugins/project/lib/project_next/models.py
+++ b/plugins/project/lib/project_next/models.py
@@ -142,6 +142,33 @@ class SpecTask:
 
 
 @dataclass(frozen=True)
+class SpecFeature:
+    name: str
+    path: str
+    has_spec: bool = False
+    has_plan: bool = False
+    has_tasks: bool = False
+    total_tasks: int = 0
+    mapped_tasks: int = 0
+    mapping_status: str = "not-applicable"
+    recommended_action: str = "none"
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> SpecFeature:
+        return cls(
+            name=str(data["name"]),
+            path=str(data.get("path") or ""),
+            has_spec=bool(data.get("has_spec", False)),
+            has_plan=bool(data.get("has_plan", False)),
+            has_tasks=bool(data.get("has_tasks", False)),
+            total_tasks=int(data.get("total_tasks", 0)),
+            mapped_tasks=int(data.get("mapped_tasks", 0)),
+            mapping_status=str(data.get("mapping_status") or "not-applicable"),
+            recommended_action=str(data.get("recommended_action") or "none"),
+        )
+
+
+@dataclass(frozen=True)
 class RepositoryState:
     repository: str
     default_branch: str
@@ -151,6 +178,7 @@ class RepositoryState:
     worktrees: tuple[Worktree, ...] = ()
     branches: tuple[Branch, ...] = ()
     spec_tasks: tuple[SpecTask, ...] = ()
+    spec_features: tuple[SpecFeature, ...] = ()
     gate_status: str = "unknown"
     inventory_complete: bool = True
     collector_warnings: tuple[str, ...] = ()
@@ -167,6 +195,7 @@ class RepositoryState:
             worktrees=tuple(Worktree.from_dict(item) for item in data.get("worktrees", ())),
             branches=tuple(Branch.from_dict(item) for item in data.get("branches", ())),
             spec_tasks=tuple(SpecTask.from_dict(item) for item in data.get("spec_tasks", ())),
+            spec_features=tuple(SpecFeature.from_dict(item) for item in data.get("spec_features", ())),
             gate_status=str(data.get("gate_status") or "unknown"),
             inventory_complete=bool(data.get("inventory_complete", True)),
             collector_warnings=_tuple_of_strings(data.get("collector_warnings")),
@@ -207,6 +236,66 @@ class Action:
 
 
 @dataclass(frozen=True)
+class Candidate:
+    issue_number: int
+    rank_key: tuple[int, ...]
+    priority: str
+    phase: str
+    issue_type: str
+    quick_win: bool
+    critical: bool
+    stale: bool
+    rationale: str
+    command: str
+
+
+@dataclass(frozen=True)
+class BacklogSummary:
+    open: int = 0
+    critical: int = 0
+    bugs: int = 0
+    features: int = 0
+    docs: int = 0
+    tech_debt: int = 0
+    planning: int = 0
+    other: int = 0
+
+
+@dataclass(frozen=True)
+class BacklogTiers:
+    critical: tuple[int, ...] = ()
+    active: tuple[int, ...] = ()
+    blocked: tuple[int, ...] = ()
+    uncertain: tuple[int, ...] = ()
+    ready: tuple[int, ...] = ()
+    quick_wins: tuple[int, ...] = ()
+    planning: tuple[int, ...] = ()
+    pending_spec_sync: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class WorktreeDetail:
+    path: str
+    branch: str
+    issue_number: int | None
+    issue_state: str
+    dirty: bool
+    recent_commits: tuple[str, ...] = ()
+    cleanup_recommended: bool = False
+    cleanup_reason: str = ""
+
+
+@dataclass(frozen=True)
+class CleanupCandidate:
+    target_type: str
+    target: str
+    branch: str
+    issue_number: int | None
+    reason: str
+    action: str = "Review with $flow-cleanup"
+
+
+@dataclass(frozen=True)
 class RecommendationResult:
     contract_version: str
     repository: str
@@ -216,6 +305,12 @@ class RecommendationResult:
     top_action: Action | None
     next_startable_issue: int | None
     unsynchronized_spec_tasks: tuple[SpecTask, ...] = ()
+    candidates: tuple[Candidate, ...] = ()
+    backlog_summary: BacklogSummary = field(default_factory=BacklogSummary)
+    backlog_tiers: BacklogTiers = field(default_factory=BacklogTiers)
+    spec_features: tuple[SpecFeature, ...] = ()
+    worktree_details: tuple[WorktreeDetail, ...] = ()
+    cleanup_candidates: tuple[CleanupCandidate, ...] = ()
     warnings: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:

--- a/plugins/project/lib/project_next/rank.py
+++ b/plugins/project/lib/project_next/rank.py
@@ -5,11 +5,22 @@ from __future__ import annotations
 import re
 from datetime import datetime, timezone
 
-from .classify import classify_repository, pull_request_issue_numbers
+from .classify import classify_repository, issue_number_from_branch, pull_request_issue_numbers
 from .config import ProjectNextConfig
-from .models import Action, Classification, Issue, RecommendationResult, RepositoryState
+from .models import (
+    Action,
+    BacklogSummary,
+    BacklogTiers,
+    Candidate,
+    Classification,
+    CleanupCandidate,
+    Issue,
+    RecommendationResult,
+    RepositoryState,
+    WorktreeDetail,
+)
 
-CONTRACT_VERSION = "1.1"
+CONTRACT_VERSION = "1.2"
 PHASE = re.compile(r"\b(?:wave|phase)[-\s:]*(?P<number>\d+)\b", re.IGNORECASE)
 
 
@@ -73,6 +84,67 @@ def rank_key(issue: Issue, state: RepositoryState, config: ProjectNextConfig) ->
         quick_win,
         _staleness(issue, state, config),
         issue.number,
+    )
+
+
+def _is_critical(issue: Issue, config: ProjectNextConfig) -> bool:
+    labels = issue.normalized_labels
+    return bool(labels & set(config.critical_labels) or ("bug" in labels and _priority(issue, config) == 0))
+
+
+def _priority_evidence(issue: Issue, config: ProjectNextConfig) -> str:
+    labels = issue.normalized_labels
+    matched = sorted(labels & set(config.high_priority_labels))
+    if matched:
+        return f"high ({matched[0]})"
+    matched = sorted(labels & set(config.medium_priority_labels))
+    if matched:
+        return f"medium ({matched[0]})"
+    return "default"
+
+
+def _phase_evidence(issue: Issue) -> str:
+    phase = _phase(issue)
+    return f"wave/phase {phase}" if phase < 10_000 else "unspecified"
+
+
+def _type_evidence(issue: Issue, config: ProjectNextConfig) -> str:
+    labels = issue.normalized_labels
+    title = issue.title.casefold()
+    if labels & set(config.planning_labels) or re.search(r"\b(?:epic|tracking|planning)\b", title):
+        return "planning"
+    if "bug" in labels or re.search(r"\bfix\b", title):
+        return "bug"
+    if "task" in labels or re.search(r"\b(?:restore|implement)\b", title):
+        return "task"
+    if labels & set(config.quick_win_labels):
+        return "quick-win"
+    return "feature"
+
+
+def _candidate(issue: Issue, state: RepositoryState, config: ProjectNextConfig) -> Candidate:
+    critical = _is_critical(issue, config)
+    priority = _priority_evidence(issue, config)
+    phase = _phase_evidence(issue)
+    issue_type = _type_evidence(issue, config)
+    quick_win = bool(issue.normalized_labels & set(config.quick_win_labels))
+    stale = _staleness(issue, state, config) == 0
+    evidence = ["critical" if critical else priority, phase, issue_type]
+    if quick_win and issue_type != "quick-win":
+        evidence.append("quick win")
+    if stale:
+        evidence.append("stale")
+    return Candidate(
+        issue_number=issue.number,
+        rank_key=rank_key(issue, state, config),
+        priority=priority,
+        phase=phase,
+        issue_type=issue_type,
+        quick_win=quick_win,
+        critical=critical,
+        stale=stale,
+        rationale="; ".join(evidence) + "; ordered by the deterministic rank tuple",
+        command=f"$flow-auto {issue.number}",
     )
 
 
@@ -214,6 +286,154 @@ def _top_action(
     return None
 
 
+def _backlog_summary(issues: tuple[Issue, ...], config: ProjectNextConfig) -> BacklogSummary:
+    counts = {
+        "critical": 0,
+        "bugs": 0,
+        "features": 0,
+        "docs": 0,
+        "tech_debt": 0,
+        "planning": 0,
+        "other": 0,
+    }
+    for issue in issues:
+        labels = issue.normalized_labels
+        title = issue.title.casefold()
+        if _is_critical(issue, config):
+            category = "critical"
+        elif "bug" in labels or re.search(r"\bfix\b", title):
+            category = "bugs"
+        elif labels & {"documentation", "docs"}:
+            category = "docs"
+        elif labels & {"tech-debt", "technical-debt", "chore", "refactor"}:
+            category = "tech_debt"
+        elif labels & set(config.planning_labels) or re.search(r"\b(?:epic|tracking|planning)\b", title):
+            category = "planning"
+        elif labels & {"feature", "enhancement"} or re.search(r"\bfeat(?:ure)?\b", title):
+            category = "features"
+        else:
+            category = "other"
+        counts[category] += 1
+    return BacklogSummary(open=len(issues), **counts)
+
+
+def _backlog_tiers(
+    state: RepositoryState,
+    classification: Classification,
+    ranked: tuple[int, ...],
+    config: ProjectNextConfig,
+) -> BacklogTiers:
+    issues = {issue.number: issue for issue in state.issues}
+    critical = tuple(number for number in sorted(issues) if _is_critical(issues[number], config))
+    critical_set = set(critical)
+    active = tuple(number for number in classification.in_flight if number not in critical_set)
+    blocked = tuple(number for number in classification.blocked if number not in critical_set)
+    uncertain = tuple(number for number in classification.uncertain if number not in critical_set)
+    safe_inventory = state.inventory_complete and not state.collector_errors
+    available = [number for number in ranked if number not in critical_set] if safe_inventory else []
+    planning = tuple(number for number in available if _type_evidence(issues[number], config) == "planning")
+    planning_set = set(planning)
+    quick_wins = tuple(
+        number
+        for number in available
+        if number not in planning_set and bool(issues[number].normalized_labels & set(config.quick_win_labels))
+    )
+    quick_win_set = set(quick_wins)
+    ready = tuple(number for number in available if number not in (planning_set | quick_win_set))
+    pending_spec_sync = tuple(
+        feature.name for feature in state.spec_features if feature.recommended_action != "none"
+    )
+    return BacklogTiers(
+        critical=critical,
+        active=active,
+        blocked=blocked,
+        uncertain=uncertain,
+        ready=ready,
+        quick_wins=quick_wins,
+        planning=planning,
+        pending_spec_sync=pending_spec_sync,
+    )
+
+
+def _issue_state(number: int | None, state: RepositoryState, classification: Classification) -> str:
+    if number is None:
+        return "unmapped"
+    if number in classification.in_flight:
+        return "in-flight"
+    if number in classification.blocked:
+        return "blocked"
+    if number in classification.available:
+        return "available"
+    if number in classification.uncertain:
+        return "uncertain"
+    if number in {issue.number for issue in state.issues}:
+        return "unknown"
+    return "no-open-issue"
+
+
+def _worktree_report(
+    state: RepositoryState, classification: Classification
+) -> tuple[tuple[WorktreeDetail, ...], tuple[CleanupCandidate, ...]]:
+    details: list[WorktreeDetail] = []
+    cleanup: list[CleanupCandidate] = []
+    worktree_branches: set[str] = set()
+    for worktree in state.worktrees:
+        number = issue_number_from_branch(worktree.branch)
+        primary = worktree.branch == state.default_branch
+        issue_state = "default" if primary else _issue_state(number, state, classification)
+        cleanup_recommended = not primary and issue_state in {"unmapped", "no-open-issue"}
+        cleanup_reason = ""
+        if cleanup_recommended:
+            cleanup_reason = "branch does not map to an open issue; it may be merged, closed, or abandoned"
+            action = (
+                "Inspect uncommitted changes; do not remove automatically"
+                if worktree.dirty
+                else "Review with $flow-cleanup"
+            )
+            cleanup.append(
+                CleanupCandidate(
+                    target_type="worktree",
+                    target=worktree.path,
+                    branch=worktree.branch,
+                    issue_number=number,
+                    reason=cleanup_reason,
+                    action=action,
+                )
+            )
+        details.append(
+            WorktreeDetail(
+                path=worktree.path,
+                branch=worktree.branch,
+                issue_number=number,
+                issue_state=issue_state,
+                dirty=worktree.dirty,
+                recent_commits=worktree.recent_commits,
+                cleanup_recommended=cleanup_recommended,
+                cleanup_reason=cleanup_reason,
+            )
+        )
+        if worktree.branch:
+            worktree_branches.add(worktree.branch)
+
+    for branch in state.branches:
+        short_name = branch.name.removeprefix("remotes/").removeprefix("origin/")
+        if short_name == state.default_branch or short_name in worktree_branches:
+            continue
+        number = issue_number_from_branch(short_name)
+        if number is not None and _issue_state(number, state, classification) != "no-open-issue":
+            continue
+        cleanup.append(
+            CleanupCandidate(
+                target_type="remote branch" if branch.remote else "branch",
+                target=branch.name,
+                branch=short_name,
+                issue_number=number,
+                reason="branch does not map to an open issue; verify whether it is merged or abandoned",
+            )
+        )
+    return tuple(details), tuple(cleanup)
+
+
 def recommend(state: RepositoryState, config: ProjectNextConfig | None = None) -> RecommendationResult:
     config = config or ProjectNextConfig()
     classification = classify_repository(state)
@@ -230,6 +450,12 @@ def recommend(state: RepositoryState, config: ProjectNextConfig | None = None) -
     warnings = tuple(state.collector_warnings) + tuple(state.collector_errors)
     if classification.unmapped_worktrees:
         warnings += tuple(f"unmapped worktree: {item}" for item in classification.unmapped_worktrees)
+    candidates = (
+        tuple(_candidate(issues[number], state, config) for number in ranked)
+        if next_startable is not None
+        else ()
+    )
+    worktree_details, cleanup_candidates = _worktree_report(state, classification)
     return RecommendationResult(
         contract_version=CONTRACT_VERSION,
         repository=state.repository,
@@ -239,5 +465,11 @@ def recommend(state: RepositoryState, config: ProjectNextConfig | None = None) -
         top_action=_top_action(state, classification, ranked, config),
         next_startable_issue=next_startable,
         unsynchronized_spec_tasks=pending,
+        candidates=candidates,
+        backlog_summary=_backlog_summary(state.issues, config),
+        backlog_tiers=_backlog_tiers(state, classification, ranked, config),
+        spec_features=state.spec_features,
+        worktree_details=worktree_details,
+        cleanup_candidates=cleanup_candidates,
         warnings=warnings,
     )

--- a/plugins/project/lib/project_next/render.py
+++ b/plugins/project/lib/project_next/render.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .models import Action, RecommendationResult, RepositoryState
+from .models import Action, Candidate, RecommendationResult, RepositoryState
 
 
 def _action(action: Action | None) -> str:
@@ -14,7 +14,8 @@ def _action(action: Action | None) -> str:
     if action.pull_request_number is not None:
         refs.append(f"PR #{action.pull_request_number}")
     suffix = f" ({', '.join(refs)})" if refs else ""
-    return f"{action.kind}: {action.title}{suffix} — {action.reason}"
+    evidence = f" Evidence: {', '.join(action.evidence)}." if action.evidence else ""
+    return f"{action.kind}: {action.title}{suffix} — {action.reason}{evidence}"
 
 
 def _next_issue(result: RecommendationResult, state: RepositoryState) -> str:
@@ -22,6 +23,30 @@ def _next_issue(result: RecommendationResult, state: RepositoryState) -> str:
         return "None"
     issue = next(issue for issue in state.issues if issue.number == result.next_startable_issue)
     return f"#{issue.number} {issue.title}"
+
+
+def _candidate_lines(candidate: Candidate, title: str, position: int | None = None) -> list[str]:
+    prefix = f"{position}." if position is not None else "-"
+    evidence = (
+        f"priority {candidate.priority}; phase {candidate.phase}; type {candidate.issue_type}; "
+        f"quick win {'yes' if candidate.quick_win else 'no'}"
+    )
+    return [
+        f"{prefix} #{candidate.issue_number} {title} [{evidence}]",
+        f"   {candidate.rationale} → `{candidate.command}`",
+    ]
+
+
+def _classification_state(number: int, result: RecommendationResult) -> str:
+    if number in result.classification.in_flight:
+        return "in-flight"
+    if number in result.classification.blocked:
+        return "blocked"
+    if number in result.classification.uncertain:
+        return "uncertain"
+    if number in result.classification.available:
+        return "available"
+    return "unknown"
 
 
 def render_brief(result: RecommendationResult, state: RepositoryState) -> str:
@@ -49,10 +74,22 @@ def render_compact(result: RecommendationResult, state: RepositoryState) -> str:
             f"inventory {'complete' if result.inventory_complete else 'incomplete'}"
         ),
     ]
-    alternatives = result.ranked_available[1:4]
-    if alternatives:
-        lines.extend(("", "### Other available issues"))
-        lines.extend(f"- #{number} {issues[number].title}" for number in alternatives)
+    if result.next_startable_issue is not None:
+        lines.extend(("", "### Ready to start (top 3)"))
+        for position, candidate in enumerate(result.candidates[:3], start=1):
+            lines.extend(_candidate_lines(candidate, issues[candidate.issue_number].title, position))
+    else:
+        lines.extend(("", "### Ready to start", "- None — a complete safe recommendation is unavailable."))
+
+    critical_non_startable = tuple(
+        number
+        for number in result.backlog_tiers.critical
+        if number not in result.classification.available
+    )
+    if critical_non_startable:
+        lines.extend(("", "### Critical work (not startable)"))
+        for number in critical_non_startable:
+            lines.append(f"- #{number} {issues[number].title} — {_classification_state(number, result)}")
     if result.classification.in_flight:
         lines.extend(("", "### Active work (not startable)"))
         lines.extend(
@@ -78,17 +115,76 @@ def render_compact(result: RecommendationResult, state: RepositoryState) -> str:
     return "\n".join(lines)
 
 
-def render_full(result: RecommendationResult, state: RepositoryState) -> str:
+def _tier_issue_lines(
+    numbers: tuple[int, ...], result: RecommendationResult, state: RepositoryState
+) -> list[str]:
     issues = {issue.number: issue for issue in state.issues}
-    lines = [render_compact(result, state), "", "### Complete classification"]
-    for name, numbers in (
-        ("In flight", result.classification.in_flight),
-        ("Blocked", result.classification.blocked),
-        ("Available", result.classification.available),
-        ("Uncertain", result.classification.uncertain),
-    ):
-        rendered = ", ".join(f"#{number} {issues[number].title}" for number in numbers) or "none"
-        lines.append(f"- {name}: {rendered}")
+    candidates = {candidate.issue_number: candidate for candidate in result.candidates}
+    lines: list[str] = []
+    for number in numbers:
+        state_name = _classification_state(number, result)
+        suffix = ""
+        if number in candidates and state_name == "available":
+            suffix = f"; {candidates[number].rationale} → `{candidates[number].command}`"
+        lines.append(f"- #{number} {issues[number].title} — {state_name}{suffix}")
+    return lines or ["- none"]
+
+
+def render_full(result: RecommendationResult, state: RepositoryState) -> str:
+    summary = result.backlog_summary
+    lines = [
+        render_compact(result, state),
+        "",
+        "### Categorized backlog summary",
+        (
+            f"- {summary.open} open | {summary.critical} critical | {summary.bugs} bugs | "
+            f"{summary.features} features | {summary.docs} docs | {summary.tech_debt} tech debt | "
+            f"{summary.planning} planning | {summary.other} other"
+        ),
+        "",
+        "### Tier 1 — Critical work",
+        *_tier_issue_lines(result.backlog_tiers.critical, result, state),
+        "",
+        "### Tier 2 — Active work",
+        *_tier_issue_lines(result.backlog_tiers.active, result, state),
+        "",
+        "### Blocked work (not actionable)",
+        *_tier_issue_lines(result.backlog_tiers.blocked, result, state),
+        "",
+        "### Uncertain work (not actionable)",
+        *_tier_issue_lines(result.backlog_tiers.uncertain, result, state),
+        "",
+        "### Tier 3 — Ready to start",
+        *_tier_issue_lines(result.backlog_tiers.ready, result, state),
+        "",
+        "### Tier 3b — Pending specification sync",
+    ]
+    lines.extend(f"- {name}" for name in result.backlog_tiers.pending_spec_sync)
+    if not result.backlog_tiers.pending_spec_sync:
+        lines.append("- none")
+    lines.extend(("", "### Tier 4 — Quick wins"))
+    lines.extend(_tier_issue_lines(result.backlog_tiers.quick_wins, result, state))
+    lines.extend(("", "### Tier 5 — Planning and discussion"))
+    lines.extend(_tier_issue_lines(result.backlog_tiers.planning, result, state))
+
+    lines.extend(("", "### Spec Kit readiness"))
+    if result.spec_features:
+        lines.extend(
+            (
+                "| Feature | spec.md | plan.md | tasks.md | Mapping | Recommended action |",
+                "|---|---:|---:|---:|---|---|",
+            )
+        )
+        lines.extend(
+            f"| {feature.name} | {'yes' if feature.has_spec else 'no'} | "
+            f"{'yes' if feature.has_plan else 'no'} | {'yes' if feature.has_tasks else 'no'} | "
+            f"{feature.mapped_tasks}/{feature.total_tasks} ({feature.mapping_status}) | "
+            f"{feature.recommended_action} |"
+            for feature in result.spec_features
+        )
+    else:
+        lines.append("- no Spec Kit features found")
+
     lines.extend(("", "### Pull requests"))
     lines.extend(
         f"- #{pr.number} {pr.title} — head {pr.head_ref}; checks {pr.checks_state}; "
@@ -97,16 +193,32 @@ def render_full(result: RecommendationResult, state: RepositoryState) -> str:
     )
     if not state.pull_requests:
         lines.append("- none")
-    lines.extend(("", "### Worktrees"))
-    lines.extend(
-        f"- {worktree.path} — {worktree.branch or '(detached)'}; {'dirty' if worktree.dirty else 'clean'}"
-        for worktree in state.worktrees
-    )
-    if not state.worktrees:
+
+    lines.extend(("", "### Worktree detail"))
+    if result.worktree_details:
+        lines.extend(
+            (
+                "| Path | Branch | Issue | State | Dirty | Recent commits |",
+                "|---|---|---:|---|---:|---|",
+            )
+        )
+        for worktree in result.worktree_details:
+            issue = f"#{worktree.issue_number}" if worktree.issue_number is not None else "—"
+            commits = "<br>".join(worktree.recent_commits) or "none"
+            lines.append(
+                f"| {worktree.path} | {worktree.branch or '(detached)'} | {issue} | "
+                f"{worktree.issue_state} | {'yes' if worktree.dirty else 'no'} | {commits} |"
+            )
+    else:
         lines.append("- none")
-    lines.extend(("", "### Unsynchronized specification tasks"))
-    lines.extend(f"- {task.task_id} {task.title} — {task.source}" for task in result.unsynchronized_spec_tasks)
-    if not result.unsynchronized_spec_tasks:
+
+    lines.extend(("", "### Cleanup guidance"))
+    lines.extend(
+        f"- {candidate.target_type} `{candidate.target}` ({candidate.branch or 'detached'}) — "
+        f"{candidate.reason}. {candidate.action}."
+        for candidate in result.cleanup_candidates
+    )
+    if not result.cleanup_candidates:
         lines.append("- none")
     return "\n".join(lines)
 

--- a/plugins/project/skills/project-next/SKILL.md
+++ b/plugins/project/skills/project-next/SKILL.md
@@ -49,7 +49,12 @@ or repository/authentication suggestion.
 - Failing checks or requested review changes on active work outrank broad new
   work.
 - Unsynchronized spec tasks are surfaced but are not treated as GitHub issues.
-- Structured JSON and brief/compact/full renderers use contract version `1.1`.
+- Structured JSON and brief/compact/full renderers use contract version `1.2`.
+- Compact output shows at most three safe candidates with structured rank evidence,
+  a deterministic rationale, and a copyable `$flow-auto <issue>` command.
+- Full output adds categorized and tiered backlog state, Spec Kit readiness,
+  recent worktree commits, and evidence-based cleanup candidates. Renderers only
+  format engine-owned fields; they never reclassify or re-rank issues.
 - Spec Kit synchronization is trusted only through `spec-sync:v1` Issue Sync
   ledger mappings. Missing, stale, or ambiguous mappings remain explicit
   uncertainty and never make represented work appear safely startable.

--- a/tests/project_next/fixtures/golden/brief.txt
+++ b/tests/project_next/fixtures/golden/brief.txt
@@ -1,0 +1,4 @@
+Project Next 1.2 — brief
+Top action: continue_pr: Build active foundation (issue #2, PR #20) — PR #20 is active and should be completed before broad new work. Evidence: head:issue-2-active-foundation, checks:pending, review:unknown.
+Next safe issue: #3 Wave 1 feature
+Inventory: complete

--- a/tests/project_next/fixtures/golden/compact.md
+++ b/tests/project_next/fixtures/golden/compact.md
@@ -1,0 +1,28 @@
+## example/operations — Project Next 1.2
+
+**Top action:** continue_pr: Build active foundation (issue #2, PR #20) — PR #20 is active and should be completed before broad new work. Evidence: head:issue-2-active-foundation, checks:pending, review:unknown.
+**Next safe issue:** #3 Wave 1 feature
+**State:** 6 open | 1 in-flight | 1 blocked | 1 uncertain | inventory complete
+
+### Ready to start (top 3)
+1. #3 Wave 1 feature [priority high (p1); phase wave/phase 1; type feature; quick win no]
+   high (p1); wave/phase 1; feature; ordered by the deterministic rank tuple → `$flow-auto 3`
+2. #4 Document setup [priority default; phase unspecified; type quick-win; quick win yes]
+   default; unspecified; quick-win; ordered by the deterministic rank tuple → `$flow-auto 4`
+3. #5 Planning epic [priority default; phase unspecified; type planning; quick win no]
+   default; unspecified; planning; ordered by the deterministic rank tuple → `$flow-auto 5`
+
+### Critical work (not startable)
+- #1 Critical security repair — blocked
+
+### Active work (not startable)
+- #2 Active foundation — local-branch:issue-2-active-foundation, pr:#20, worktree:/repo-issue-2:dirty
+
+### Blocked (not startable)
+- #1 Critical security repair — blocked by #2
+
+### Uncertain (not startable)
+- #6 Choose storage — ambiguous dependency wording: Blocked by design review
+
+### Warnings
+- unmapped worktree: /repo-issue-99 (issue-99-old-work)

--- a/tests/project_next/fixtures/golden/full.md
+++ b/tests/project_next/fixtures/golden/full.md
@@ -1,0 +1,74 @@
+## example/operations — Project Next 1.2
+
+**Top action:** continue_pr: Build active foundation (issue #2, PR #20) — PR #20 is active and should be completed before broad new work. Evidence: head:issue-2-active-foundation, checks:pending, review:unknown.
+**Next safe issue:** #3 Wave 1 feature
+**State:** 6 open | 1 in-flight | 1 blocked | 1 uncertain | inventory complete
+
+### Ready to start (top 3)
+1. #3 Wave 1 feature [priority high (p1); phase wave/phase 1; type feature; quick win no]
+   high (p1); wave/phase 1; feature; ordered by the deterministic rank tuple → `$flow-auto 3`
+2. #4 Document setup [priority default; phase unspecified; type quick-win; quick win yes]
+   default; unspecified; quick-win; ordered by the deterministic rank tuple → `$flow-auto 4`
+3. #5 Planning epic [priority default; phase unspecified; type planning; quick win no]
+   default; unspecified; planning; ordered by the deterministic rank tuple → `$flow-auto 5`
+
+### Critical work (not startable)
+- #1 Critical security repair — blocked
+
+### Active work (not startable)
+- #2 Active foundation — local-branch:issue-2-active-foundation, pr:#20, worktree:/repo-issue-2:dirty
+
+### Blocked (not startable)
+- #1 Critical security repair — blocked by #2
+
+### Uncertain (not startable)
+- #6 Choose storage — ambiguous dependency wording: Blocked by design review
+
+### Warnings
+- unmapped worktree: /repo-issue-99 (issue-99-old-work)
+
+### Categorized backlog summary
+- 6 open | 1 critical | 0 bugs | 1 features | 1 docs | 0 tech debt | 1 planning | 2 other
+
+### Tier 1 — Critical work
+- #1 Critical security repair — blocked
+
+### Tier 2 — Active work
+- #2 Active foundation — in-flight
+
+### Blocked work (not actionable)
+- none
+
+### Uncertain work (not actionable)
+- #6 Choose storage — uncertain
+
+### Tier 3 — Ready to start
+- #3 Wave 1 feature — available; high (p1); wave/phase 1; feature; ordered by the deterministic rank tuple → `$flow-auto 3`
+
+### Tier 3b — Pending specification sync
+- checkout
+
+### Tier 4 — Quick wins
+- #4 Document setup — available; default; unspecified; quick-win; ordered by the deterministic rank tuple → `$flow-auto 4`
+
+### Tier 5 — Planning and discussion
+- #5 Planning epic — available; default; unspecified; planning; ordered by the deterministic rank tuple → `$flow-auto 5`
+
+### Spec Kit readiness
+| Feature | spec.md | plan.md | tasks.md | Mapping | Recommended action |
+|---|---:|---:|---:|---|---|
+| checkout | yes | yes | yes | 1/2 (partial) | sync remaining tasks to issues |
+
+### Pull requests
+- #20 Build active foundation — head issue-2-active-foundation; checks pending; review unknown; merge BLOCKED
+
+### Worktree detail
+| Path | Branch | Issue | State | Dirty | Recent commits |
+|---|---|---:|---|---:|---|
+| /repo | main | — | default | no | aaa main commit |
+| /repo-issue-2 | issue-2-active-foundation | #2 | in-flight | yes | bbb active work<br>aaa main commit |
+| /repo-issue-99 | issue-99-old-work | #99 | no-open-issue | no | ccc old work |
+
+### Cleanup guidance
+- worktree `/repo-issue-99` (issue-99-old-work) — branch does not map to an open issue; it may be merged, closed, or abandoned. Review with $flow-cleanup.
+- remote branch `origin/issue-88-abandoned` (issue-88-abandoned) — branch does not map to an open issue; verify whether it is merged or abandoned. Review with $flow-cleanup.

--- a/tests/project_next/fixtures/golden/result.json
+++ b/tests/project_next/fixtures/golden/result.json
@@ -1,0 +1,45 @@
+{
+  "backlog_summary": {
+    "bugs": 0,
+    "critical": 0,
+    "docs": 0,
+    "features": 0,
+    "open": 0,
+    "other": 0,
+    "planning": 0,
+    "tech_debt": 0
+  },
+  "backlog_tiers": {
+    "active": [],
+    "blocked": [],
+    "critical": [],
+    "pending_spec_sync": [],
+    "planning": [],
+    "quick_wins": [],
+    "ready": [],
+    "uncertain": []
+  },
+  "candidates": [],
+  "classification": {
+    "available": [],
+    "blocked": [],
+    "blocked_by": {},
+    "dependency_map": {},
+    "in_flight": [],
+    "in_flight_evidence": {},
+    "uncertain": [],
+    "uncertainty": {},
+    "unmapped_worktrees": []
+  },
+  "cleanup_candidates": [],
+  "contract_version": "1.2",
+  "inventory_complete": true,
+  "next_startable_issue": null,
+  "ranked_available": [],
+  "repository": "example/empty",
+  "spec_features": [],
+  "top_action": null,
+  "unsynchronized_spec_tasks": [],
+  "warnings": [],
+  "worktree_details": []
+}

--- a/tests/project_next/fixtures/scenarios.json
+++ b/tests/project_next/fixtures/scenarios.json
@@ -169,5 +169,117 @@
       "available": [701],
       "uncertain": []
     }
+  },
+  "empty_repository": {
+    "state": {
+      "repository": "example/empty",
+      "default_branch": "main",
+      "collected_at": "2026-08-07T13:00:00Z"
+    },
+    "expected": {
+      "top_action": null,
+      "top_issue": null,
+      "next_startable": null,
+      "in_flight": [],
+      "blocked": [],
+      "available": [],
+      "uncertain": []
+    }
+  },
+  "operational_report": {
+    "state": {
+      "repository": "example/operations",
+      "default_branch": "main",
+      "collected_at": "2026-08-07T13:00:00Z",
+      "issues": [
+        {
+          "number": 1,
+          "title": "Critical security repair",
+          "body": "Blocked by #2",
+          "labels": ["security", "p0"]
+        },
+        {"number": 2, "title": "Active foundation", "labels": ["p1", "task"]},
+        {"number": 3, "title": "Wave 1 feature", "labels": ["p1", "feature"]},
+        {"number": 4, "title": "Document setup", "labels": ["documentation", "size-s"]},
+        {"number": 5, "title": "Planning epic", "labels": ["planning"]},
+        {"number": 6, "title": "Choose storage", "body": "Blocked by design review"}
+      ],
+      "pull_requests": [
+        {
+          "number": 20,
+          "title": "Build active foundation",
+          "head_ref": "issue-2-active-foundation",
+          "closing_issue_numbers": [2],
+          "checks_state": "pending",
+          "merge_state": "BLOCKED"
+        }
+      ],
+      "worktrees": [
+        {
+          "path": "/repo",
+          "branch": "main",
+          "dirty": false,
+          "recent_commits": ["aaa main commit"]
+        },
+        {
+          "path": "/repo-issue-2",
+          "branch": "issue-2-active-foundation",
+          "dirty": true,
+          "recent_commits": ["bbb active work", "aaa main commit"]
+        },
+        {
+          "path": "/repo-issue-99",
+          "branch": "issue-99-old-work",
+          "dirty": false,
+          "recent_commits": ["ccc old work"]
+        }
+      ],
+      "branches": [
+        {"name": "main", "upstream": "origin/main"},
+        {"name": "issue-2-active-foundation", "upstream": "origin/issue-2-active-foundation"},
+        {"name": "issue-99-old-work"},
+        {"name": "origin/issue-88-abandoned", "remote": true}
+      ],
+      "spec_tasks": [
+        {
+          "task_id": "T001",
+          "title": "Mapped task",
+          "feature": "checkout",
+          "source": ".specify/specs/checkout/tasks.md",
+          "issue_numbers": [3],
+          "synchronized": true,
+          "mapping_status": "mapped"
+        },
+        {
+          "task_id": "T002",
+          "title": "Pending task",
+          "feature": "checkout",
+          "source": ".specify/specs/checkout/tasks.md",
+          "mapping_status": "missing"
+        }
+      ],
+      "spec_features": [
+        {
+          "name": "checkout",
+          "path": ".specify/specs/checkout",
+          "has_spec": true,
+          "has_plan": true,
+          "has_tasks": true,
+          "total_tasks": 2,
+          "mapped_tasks": 1,
+          "mapping_status": "partial",
+          "recommended_action": "sync remaining tasks to issues"
+        }
+      ]
+    },
+    "expected": {
+      "top_action": "continue_pr",
+      "top_issue": 2,
+      "next_startable": 3,
+      "in_flight": [2],
+      "blocked": [1],
+      "available": [3, 4, 5],
+      "uncertain": [6]
+    }
   }
 }

--- a/tests/project_next/test_collection.py
+++ b/tests/project_next/test_collection.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from lib.project_next.collect import CollectionError, _spec_tasks, collect_repository
+from lib.project_next.collect import CollectionError, _spec_inventory, _spec_tasks, collect_repository
 from lib.project_next.config import ProjectNextConfig
 
 
@@ -156,3 +156,33 @@ def test_missing_stale_and_ambiguous_spec_mappings_are_uncertain(tmp_path: Path)
     assert tasks["T002"].mapping_status == "ambiguous"
     assert tasks["T003"].mapping_status == "missing"
     assert len(warnings) == 3
+
+
+def test_spec_inventory_reports_file_readiness_and_partial_sync(tmp_path: Path) -> None:
+    feature = tmp_path / ".specify" / "specs" / "checkout"
+    feature.mkdir(parents=True)
+    (feature / "spec.md").write_text("# Checkout\n")
+    (feature / "plan.md").write_text("# Plan\n")
+    source = ".specify/specs/checkout/tasks.md"
+    identity = f"spec-sync:v1:example/repo:{source}:stage-1"
+    (feature / "tasks.md").write_text(
+        f"""- [ ] **T001** Implement checkout.
+- [ ] **T002** Test checkout.
+
+| Stable identity | Granularity | Group | Tasks | Issue | URL | State |
+|---|---|---|---|---:|---|---|
+| `{identity}` | stage | `stage-1` | T001 | #42 | https://github.com/example/repo/issues/42 | OPEN |
+"""
+    )
+    warnings: list[str] = []
+
+    tasks, features = _spec_inventory(tmp_path, "example/repo", warnings)
+
+    assert [task.mapping_status for task in tasks] == ["mapped", "missing"]
+    assert len(warnings) == 1
+    assert len(features) == 1
+    readiness = features[0]
+    assert (readiness.has_spec, readiness.has_plan, readiness.has_tasks) == (True, True, True)
+    assert (readiness.mapped_tasks, readiness.total_tasks) == (1, 2)
+    assert readiness.mapping_status == "partial"
+    assert readiness.recommended_action == "sync remaining tasks to issues"

--- a/tests/project_next/test_output_contract.py
+++ b/tests/project_next/test_output_contract.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
+from lib.project_next import CONTRACT_VERSION
 from lib.project_next.models import RepositoryState
 from lib.project_next.rank import recommend
 from lib.project_next.render import render_result
+
+GOLDEN = Path(__file__).parent / "fixtures" / "golden"
 
 
 def test_all_human_modes_are_versioned_and_separate_both_decisions(project_next_scenarios: dict[str, Any]) -> None:
@@ -14,7 +18,7 @@ def test_all_human_modes_are_versioned_and_separate_both_decisions(project_next_
 
     for mode in ("brief", "compact", "full"):
         rendered = render_result(result, state, mode)
-        assert "1.1" in rendered
+        assert "1.2" in rendered
         assert "Top action" in rendered
         assert "Next safe issue" in rendered
         assert "#1" in rendered
@@ -25,7 +29,33 @@ def test_structured_output_is_versioned_and_json_serializable(project_next_scena
     state = RepositoryState.from_dict(project_next_scenarios["active_pr_and_safe_issue"]["state"])
     payload = recommend(state).to_dict()
 
-    assert payload["contract_version"] == "1.1"
+    assert CONTRACT_VERSION == "1.2"
+    assert payload["contract_version"] == CONTRACT_VERSION
     assert payload["top_action"]["issue_number"] == 1
     assert payload["next_startable_issue"] == 2
     assert json.loads(json.dumps(payload, sort_keys=True)) == payload
+
+
+def test_human_modes_match_golden_operational_report(project_next_scenarios: dict[str, Any]) -> None:
+    state = RepositoryState.from_dict(project_next_scenarios["operational_report"]["state"])
+    result = recommend(state)
+
+    for mode, filename in (("brief", "brief.txt"), ("compact", "compact.md"), ("full", "full.md")):
+        expected = (GOLDEN / filename).read_text(encoding="utf-8").rstrip("\n")
+        assert render_result(result, state, mode) == expected
+
+
+def test_json_mode_matches_golden_empty_repository_contract(project_next_scenarios: dict[str, Any]) -> None:
+    state = RepositoryState.from_dict(project_next_scenarios["empty_repository"]["state"])
+    rendered = json.dumps(recommend(state).to_dict(), indent=2, sort_keys=True)
+
+    assert rendered == (GOLDEN / "result.json").read_text(encoding="utf-8").rstrip("\n")
+
+
+def test_compact_has_at_most_three_safe_candidates(project_next_scenarios: dict[str, Any]) -> None:
+    state = RepositoryState.from_dict(project_next_scenarios["operational_report"]["state"])
+    rendered = render_result(recommend(state), state, "compact")
+
+    assert rendered.count("`$flow-auto ") == 3
+    assert "#1 Critical security repair — blocked" in rendered
+    assert "`$flow-auto 1`" not in rendered

--- a/tests/project_next/test_ranking.py
+++ b/tests/project_next/test_ranking.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from lib.project_next.models import Issue, RepositoryState, SpecTask
+from lib.project_next.models import Issue, RepositoryState, SpecTask, Worktree
 from lib.project_next.rank import recommend
 
 
@@ -83,3 +83,66 @@ def test_missing_mapping_recommends_spec_sync_group() -> None:
     assert result.top_action is not None
     assert result.top_action.kind == "sync_spec"
     assert "stage-1" in result.top_action.title
+
+
+def test_operational_report_keeps_critical_blocked_work_out_of_startable_tiers(
+    project_next_scenarios: dict[str, Any],
+) -> None:
+    state = RepositoryState.from_dict(project_next_scenarios["operational_report"]["state"])
+
+    result = recommend(state)
+
+    assert [candidate.issue_number for candidate in result.candidates] == [3, 4, 5]
+    assert result.candidates[0].priority == "high (p1)"
+    assert result.candidates[0].phase == "wave/phase 1"
+    assert result.candidates[0].command == "$flow-auto 3"
+    assert result.backlog_tiers.critical == (1,)
+    assert result.backlog_tiers.active == (2,)
+    assert result.backlog_tiers.ready == (3,)
+    assert result.backlog_tiers.quick_wins == (4,)
+    assert result.backlog_tiers.planning == (5,)
+    assert result.backlog_tiers.uncertain == (6,)
+    assert 1 not in {candidate.issue_number for candidate in result.candidates}
+
+
+def test_incomplete_inventory_exposes_no_startable_candidates_or_tiers(
+    project_next_scenarios: dict[str, Any],
+) -> None:
+    state = RepositoryState.from_dict(project_next_scenarios["incomplete_inventory"]["state"])
+
+    result = recommend(state)
+
+    assert result.candidates == ()
+    assert result.backlog_tiers.ready == ()
+    assert result.backlog_tiers.quick_wins == ()
+    assert result.backlog_tiers.planning == ()
+
+
+def test_worktree_report_maps_active_work_and_marks_only_unmapped_cleanup(
+    project_next_scenarios: dict[str, Any],
+) -> None:
+    state = RepositoryState.from_dict(project_next_scenarios["operational_report"]["state"])
+
+    result = recommend(state)
+
+    details = {worktree.branch: worktree for worktree in result.worktree_details}
+    assert details["issue-2-active-foundation"].issue_state == "in-flight"
+    assert details["issue-2-active-foundation"].recent_commits == ("bbb active work", "aaa main commit")
+    assert details["issue-99-old-work"].cleanup_recommended is True
+    assert {(item.target_type, item.target) for item in result.cleanup_candidates} == {
+        ("worktree", "/repo-issue-99"),
+        ("remote branch", "origin/issue-88-abandoned"),
+    }
+
+
+def test_dirty_unmapped_worktree_cleanup_requires_inspection() -> None:
+    state = RepositoryState(
+        repository="example/repo",
+        default_branch="main",
+        collected_at="2026-08-07T13:00:00Z",
+        worktrees=(Worktree("/repo-topic", "topic", dirty=True),),
+    )
+
+    candidate = recommend(state).cleanup_candidates[0]
+
+    assert candidate.action == "Inspect uncommitted changes; do not remove automatically"

--- a/tests/test_project_next_skill.py
+++ b/tests/test_project_next_skill.py
@@ -23,7 +23,7 @@ def test_project_next_delegates_selection_to_the_deterministic_runtime() -> None
         "next_startable_issue",
         "Only `available` issues can be named as safe to start.",
         "In-flight, blocked, cyclic, and uncertain issues remain non-startable.",
-        "contract version `1.1`",
+        "contract version `1.2`",
         "scripts/project-next.py",
     )
 


### PR DESCRIPTION
## Summary
- add structured rank evidence, operational backlog tiers, Spec Kit readiness, and worktree cleanup guidance to project-next contract 1.2
- enrich compact output with up to three safe candidates and full output with categorized operational detail
- add golden fixtures and safety coverage while keeping native and packaged runtimes synchronized

## Test plan
- `make verify` (542 tests passed, mypy passed across 168 files, sync/lint/contract/evaluation gates passed)
- live `project-next --compact` and `--full` dogfood runs

Closes #180