### PR TITLE
fix(project-next): restore decision signal to the engine

### DIFF
--- a/.codex/skills/project-next/SKILL.md
+++ b/.codex/skills/project-next/SKILL.md
@@ -49,12 +49,22 @@ or repository/authentication suggestion.
 - Failing checks or requested review changes on active work outrank broad new
   work.
 - Unsynchronized spec tasks are surfaced but are not treated as GitHub issues.
-- Structured JSON and brief/compact/full renderers use contract version `1.2`.
+- Structured JSON and brief/compact/full renderers use contract version `1.3`.
 - Compact output shows at most three safe candidates with structured rank evidence,
   a deterministic rationale, and a copyable `$flow-auto <issue>` command.
 - Full output adds categorized and tiered backlog state, Spec Kit readiness,
   recent worktree commits, and evidence-based cleanup candidates. Renderers only
   format engine-owned fields; they never reclassify or re-rank issues.
+- Dependencies are parsed from lead-in phrases with their punctuation and Markdown
+  intact (`**Depends on:** #12`, `Blocked by: #12, #13`, `(depends on T004)`).
+  Ordinary sequencing prose such as "run this after the release" is not a blocker,
+  and code blocks declare nothing.
 - Spec Kit synchronization is trusted only through `spec-sync:v1` Issue Sync
   ledger mappings. Missing, stale, or ambiguous mappings remain explicit
-  uncertainty and never make represented work appear safely startable.
+  uncertainty and never make represented work appear safely startable. Task IDs
+  additionally resolve dependency references through issue titles, which is not
+  synchronization evidence.
+- A warning, not a silent fallback, reports a backlog whose labels match no
+  configured ranking vocabulary; report it so the user can add `.project-next.json`.
+- Untracked files alone are never "work in progress"; only tracked modifications
+  produce `continue_work`.

--- a/docs/project-next-contract.md
+++ b/docs/project-next-contract.md
@@ -10,7 +10,7 @@ authoritative implementation. CPP adoption is tracked by
 
 ## Version and entry points
 
-Contract version `1.2` accepts a structured `RepositoryState` and emits a
+Contract version `1.3` accepts a structured `RepositoryState` and emits a
 structured `RecommendationResult`. Run it from a CxPP checkout with:
 
 ```bash
@@ -41,10 +41,35 @@ Every open issue appears in exactly one disjoint set:
 - `uncertain`: dependency wording or dependency state cannot be resolved;
 - `available`: belongs to none of the preceding sets.
 
-Only explicit `Depends on #N`, `Blocked by #N`, `Requires #N`, or `After #N`
-relationships are executable dependencies. Ambiguous wording is uncertainty,
-not availability. In-flight issues remain in the dependency graph so their
-dependents stay blocked.
+A dependency is a lead-in phrase followed immediately by one or more references.
+The phrase tolerates the punctuation and Markdown emphasis real issue bodies
+use, so `Depends on #12`, `**Depends on:** #12`, `Blocked by: #12, #13`,
+`**Depends on:** #367, #369–#371`, and `(depends on T004)` are all executable.
+Reference runs accept comma, `and`, and dash-range separators; a range wider
+than fifty issues collapses to its first endpoint.
+
+Phrases are graded, because English sequencing is not a declaration:
+
+- strong (`depends on`, `depends upon`, `blocked by`, and the field-label forms
+  `Blockers:` / `Prerequisites:`) assert a blocker, so a strong phrase that
+  names no resolvable reference is uncertainty;
+- weak (`requires`, `needs`, `after`, `follows`) counts only when a reference
+  actually follows, and never raises uncertainty on its own. "Run this after
+  the v0.2.0 release" is prose, not a blocker.
+
+Fenced code blocks and inline code spans are removed before any of this runs,
+so a comment such as `# starts after the label gutter` declares nothing.
+
+Spec task IDs resolve to issues through the `spec-sync:v1` Issue Sync ledger
+first, then through an open issue whose title begins with that task ID; a task
+ID claimed by two open issues resolves to neither. Task IDs an issue defines
+itself describe its own internal ordering and are not blockers. An unresolved
+task ID with a complete inventory is read the same way as a reference to a
+closed issue — already satisfied — and becomes uncertainty only when the
+inventory is incomplete.
+
+In-flight issues remain in the dependency graph so their dependents stay
+blocked.
 
 The engine validates that the sets are exhaustive and non-overlapping. Neither
 the top action's `start_issue` variant nor `next_startable_issue` may reference
@@ -66,13 +91,26 @@ The collected timestamp makes fixture ranking repeatable. Repository policy can
 override label aliases, limits, mode, and staleness in `.project-next.json`,
 validated against `templates/project-next.schema.json`.
 
+Labels are matched after separator normalization, so `priority:high`,
+`priority/high`, `priority_high`, and `Priority High` all reach the
+`priority-high` entry. When no open issue carries a label in any configured
+vocabulary, ranking has no priority signal and degenerates to issue type, age,
+and issue number. The engine says so in a warning naming the labels actually in
+use rather than presenting issue order as a ranking.
+
 ## Top action and next startable issue
 
 `top_action` answers what should happen now. In priority order it restores an
 incomplete inventory, fixes failing PR checks, addresses requested changes,
 merges a ready PR, continues active work, repairs a known repository gate,
-starts the highest-ranked available issue, or synchronizes a specification
-task.
+starts the highest-ranked available issue, reviews untracked files, or
+synchronizes a specification task.
+
+`continue_work` requires tracked modifications. Untracked files alone are not
+work in progress: a worktree holding only untracked files is reported as
+`untracked_only` and surfaces as `review_untracked` only after every real
+recommendation is exhausted, so a stray build artifact never becomes the
+headline of the report.
 
 `next_startable_issue` is a separate field. It is the highest-ranked available
 issue only when the repository inventory is complete. Active work may therefore
@@ -98,10 +136,22 @@ fields and do not parse issue prose, classify work, or re-rank candidates.
 Incomplete inventory produces no candidates or startable tiers even when the
 partial inventory contains apparently available issues.
 
-Spec Kit work is represented only by the `spec-sync:v1` Issue Sync ledger.
-Task-ID searches in issue titles or bodies are not synchronization evidence.
+Spec Kit *synchronization* is represented only by the `spec-sync:v1` Issue Sync
+ledger. Task-ID searches in issue titles or bodies are not synchronization
+evidence; they resolve dependency references only, and never mark a task
+synchronized or a specification group complete.
 Missing mappings produce `sync_spec`; stale or ambiguous identities produce
 `resolve_spec_mapping`. Neither state is silently treated as completed work.
 
-All modes name the `1.2` contract. Missing prerequisites and incomplete state
+All modes name the `1.3` contract. Missing prerequisites and incomplete state
 are explicit failure states; they never become a confident recommendation.
+
+Renderers cap long collector output: warnings list the first five entries and
+per-issue uncertainty lists the first two reasons, each truncated. `--json`
+always carries the complete lists.
+
+## Compatibility notes
+
+`1.3` keeps every `1.2` field and adds `untracked_only` to worktree state and
+worktree details, plus the `review_untracked` top-action kind. Consumers that
+ignore unknown fields and unknown action kinds read `1.3` payloads unchanged.

--- a/lib/project_next/__init__.py
+++ b/lib/project_next/__init__.py
@@ -3,10 +3,8 @@
 from .classify import classify_repository
 from .config import ConfigError, ProjectNextConfig, load_config
 from .models import RepositoryState
-from .rank import recommend
+from .rank import CONTRACT_VERSION, recommend
 from .render import render_result
-
-CONTRACT_VERSION = "1.2"
 
 __all__ = [
     "CONTRACT_VERSION",

--- a/lib/project_next/classify.py
+++ b/lib/project_next/classify.py
@@ -8,16 +8,36 @@ from collections import defaultdict
 from .models import Classification, Issue, PullRequest, RepositoryState
 
 ISSUE_BRANCH = re.compile(r"(?:^|/)issue-(?P<number>\d+)(?:-|$)", re.IGNORECASE)
-DEPENDENCY = re.compile(
-    r"\b(?:depends\s+on|blocked\s+by|requires|after)\s+#(?P<number>\d+)\b",
+
+# A declaration is only a dependency when a lead-in phrase is immediately followed by a
+# reference. "Strong" phrases assert a blocker outright, so a strong phrase that names no
+# machine-readable target is genuine uncertainty. "Weak" phrases are ordinary English that
+# happens to read like sequencing ("run after the release"), so they only count when a
+# reference actually follows and never raise uncertainty on their own.
+# "Blocker" and "prerequisite" are ordinary nouns, so they only count as a declaration in
+# their field-label form ("**Blockers:** #12"), never mid-sentence ("heavy blocker overlap").
+STRONG_DEPENDENCY_LEAD = re.compile(
+    r"\b(?:depends?\s+(?:on|upon)|depending\s+on|blocked\s+by)\b|\b(?:blockers?|prerequisites?)\b(?=[\s*_]*[:\-])",
     re.IGNORECASE,
 )
-DEPENDENCY_WORDS = re.compile(r"\b(?:depends\s+on|blocked\s+by|requires|after)\b", re.IGNORECASE)
+WEAK_DEPENDENCY_LEAD = re.compile(r"\b(?:requires?|required\s+by|needs|after|follows)\b", re.IGNORECASE)
+# Markdown emphasis and punctuation routinely sit between the phrase and its references,
+# as in "**Depends on:** #367" or "(depends on T004)".
+REFERENCE_CONNECTOR = re.compile(r"[\s:*_>()\[\]]*")
+ISSUE_REFERENCE = re.compile(r"#(?P<start>\d+)(?:\s*[-–—]\s*#?(?P<end>\d+))?")
+TASK_REFERENCE = re.compile(r"(?P<task>[A-Z]{1,4}(?:-[A-Z]{1,4})?\d{2,4})\b")
+REFERENCE_SEPARATOR = re.compile(r"[\s,;&/–—-]*(?:and|plus|then)?[\s]*", re.IGNORECASE)
+DANGLING_REFERENCE = re.compile(r"#(?!\d)")
+CODE_FENCE = re.compile(r"^\s*(?:```|~~~)")
+INLINE_CODE = re.compile(r"`[^`\n]*`")
+DECLARED_TASK = re.compile(r"^-\s*\[[ xX]\]\s+(?:\*\*)?(?P<id>[A-Za-z]{1,4}(?:-[A-Za-z]{1,4})?\d{1,4})(?:\*\*)?\b")
 CHECKLIST_ISSUE = re.compile(r"^-\s*\[\s\]\s+.*?#(?P<number>\d+)\b", re.IGNORECASE)
 EXPLICIT_PR_ISSUE = re.compile(
     r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|issue)\s*:?[\s#]+(?P<number>\d+)\b",
     re.IGNORECASE,
 )
+# Guards an "#367-#376" style range from expanding into an implausible span.
+MAX_REFERENCE_RANGE = 50
 
 
 def issue_number_from_branch(branch: str) -> int | None:
@@ -34,19 +54,119 @@ def pull_request_issue_numbers(pr: PullRequest) -> tuple[int, ...]:
     return tuple(sorted(numbers))
 
 
-def _dependencies(issue: Issue) -> tuple[set[int], list[str]]:
-    dependencies = {int(match.group("number")) for match in DEPENDENCY.finditer(issue.body)}
-    for line in issue.body.splitlines():
+def strip_code(text: str) -> str:
+    """Drop fenced blocks and inline spans so code never reads as dependency prose."""
+    kept: list[str] = []
+    fenced = False
+    for line in text.splitlines():
+        if CODE_FENCE.match(line):
+            fenced = not fenced
+            continue
+        kept.append("" if fenced else INLINE_CODE.sub(" ", line))
+    return "\n".join(kept)
+
+
+def _skip(pattern: re.Pattern[str], line: str, position: int) -> int:
+    match = pattern.match(line, position)
+    return match.end() if match else position
+
+
+def _reference_list(line: str, position: int) -> tuple[set[int], set[str], int]:
+    """Consume a comma/range separated run of issue and task references at `position`."""
+    issues: set[int] = set()
+    tasks: set[str] = set()
+    consumed = 0
+    while position < len(line):
+        issue_match = ISSUE_REFERENCE.match(line, position)
+        task_match = None if issue_match else TASK_REFERENCE.match(line, position)
+        if issue_match:
+            start = int(issue_match.group("start"))
+            end = int(issue_match.group("end") or start)
+            span = end - start
+            issues.update(range(start, end + 1) if 0 < span <= MAX_REFERENCE_RANGE else (start,))
+            position = issue_match.end()
+        elif task_match:
+            tasks.add(task_match.group("task").upper())
+            position = task_match.end()
+        else:
+            break
+        consumed += 1
+        position = _skip(REFERENCE_SEPARATOR, line, position)
+    return issues, tasks, consumed
+
+
+def _line_references(line: str) -> tuple[set[int], set[str], list[str]]:
+    issues: set[int] = set()
+    tasks: set[str] = set()
+    unresolved: list[str] = []
+    for pattern, strong in ((STRONG_DEPENDENCY_LEAD, True), (WEAK_DEPENDENCY_LEAD, False)):
+        for lead in pattern.finditer(line):
+            start = _skip(REFERENCE_CONNECTOR, line, lead.end())
+            found_issues, found_tasks, consumed = _reference_list(line, start)
+            issues |= found_issues
+            tasks |= found_tasks
+            if consumed or not strong:
+                continue
+            detail = "an issue reference is present but not attached to the phrase"
+            if not ISSUE_REFERENCE.search(line) and not DANGLING_REFERENCE.search(line):
+                detail = "the blocker names no issue or spec task"
+            unresolved.append(f"'{lead.group(0).strip()}' declares a dependency but {detail}: {line.strip()}")
+    return issues, tasks, unresolved
+
+
+def _dependencies(issue: Issue, task_issues: dict[str, set[int]]) -> tuple[set[int], list[str], set[str]]:
+    text = strip_code(f"{issue.title}\n{issue.body}")
+    lines = text.splitlines()
+    declared_tasks = set()
+    for line in lines:
+        match = DECLARED_TASK.match(line.strip())
+        if match:
+            declared_tasks.add(match.group("id").upper())
+
+    dependencies: set[int] = set()
+    referenced_tasks: set[str] = set()
+    uncertainty: list[str] = []
+    for line in lines:
+        found_issues, found_tasks, unresolved = _line_references(line)
+        dependencies |= found_issues
+        referenced_tasks |= found_tasks
+        uncertainty.extend(unresolved)
+
+    for line in lines:
         match = CHECKLIST_ISSUE.search(line.strip())
         if match and re.search(r"\b(?:wave|phase|epic|parent)\b", issue.title, re.IGNORECASE):
             dependencies.add(int(match.group("number")))
 
-    uncertainty: list[str] = []
-    for line in issue.body.splitlines():
-        if DEPENDENCY_WORDS.search(line) and not DEPENDENCY.search(line):
-            uncertainty.append(f"ambiguous dependency wording: {line.strip()}")
+    # Task IDs the issue defines itself describe its own internal ordering, not a blocker.
+    unresolved_tasks: set[str] = set()
+    for task in sorted(referenced_tasks - declared_tasks):
+        mapped = task_issues.get(task)
+        if mapped:
+            dependencies |= mapped
+        else:
+            unresolved_tasks.add(task)
+
     dependencies.discard(issue.number)
-    return dependencies, uncertainty
+    return dependencies, uncertainty, unresolved_tasks
+
+
+def _task_issue_index(state: RepositoryState) -> dict[str, set[int]]:
+    """Map spec task IDs onto open issues via the Issue Sync ledger, then issue titles."""
+    from_titles: dict[str, set[int]] = defaultdict(set)
+    for issue in state.issues:
+        match = TASK_REFERENCE.match(issue.title.strip())
+        if match and re.match(r"[\s:.·|—-]", issue.title.strip()[match.end() : match.end() + 1] or " "):
+            from_titles[match.group("task").upper()].add(issue.number)
+
+    index: dict[str, set[int]] = defaultdict(set)
+    # A task ID claimed by two open issues identifies nothing, so it stays unresolved.
+    for task, numbers in from_titles.items():
+        if len(numbers) == 1:
+            index[task].update(numbers)
+    for task in state.spec_tasks:
+        if task.issue_numbers and task.mapping_status not in {"stale", "ambiguous"}:
+            index[task.task_id.upper()] = set(task.issue_numbers)
+    return dict(index)
 
 
 def _cycle_members(graph: dict[int, set[int]]) -> set[int]:
@@ -115,10 +235,11 @@ def classify_repository(state: RepositoryState) -> Classification:
             if number in issue_numbers:
                 evidence[number].add(f"pr:#{pr.number}")
 
+    task_issues = _task_issue_index(state)
     dependency_map: dict[int, set[int]] = {}
     uncertainty: dict[int, list[str]] = defaultdict(list)
     for issue in state.issues:
-        dependencies, reasons = _dependencies(issue)
+        dependencies, reasons, unresolved_tasks = _dependencies(issue, task_issues)
         dependency_map[issue.number] = dependencies
         uncertainty[issue.number].extend(reasons)
         if not state.inventory_complete:
@@ -126,6 +247,12 @@ def classify_repository(state: RepositoryState) -> Classification:
             if unknown:
                 uncertainty[issue.number].append(
                     "dependency state unavailable for " + ", ".join(f"#{number}" for number in unknown)
+                )
+            # With a complete inventory an unmatched task ID means the work is not an open
+            # issue, which is the same "already satisfied" reading a closed #reference gets.
+            if unresolved_tasks:
+                uncertainty[issue.number].append(
+                    "dependency state unavailable for spec " + ", ".join(sorted(unresolved_tasks))
                 )
 
     cycles = _cycle_members(dependency_map)

--- a/lib/project_next/collect.py
+++ b/lib/project_next/collect.py
@@ -90,8 +90,18 @@ def _parse_worktrees(output: str, repository: Path, runner: CommandRunner, warni
             warnings.append(str(exc))
             status = ""
             commits = []
+        entries_changed = [line for line in status.splitlines() if line.strip()]
+        # A stray untracked file is not work in progress, so it must not outrank a real
+        # recommendation the way a tracked modification does.
+        tracked = [line for line in entries_changed if not line.startswith("??")]
         worktrees.append(
-            Worktree(path=str(path), branch=branch, dirty=bool(status.strip()), recent_commits=tuple(commits))
+            Worktree(
+                path=str(path),
+                branch=branch,
+                dirty=bool(tracked),
+                untracked_only=bool(entries_changed) and not tracked,
+                recent_commits=tuple(commits),
+            )
         )
     return tuple(worktrees)
 
@@ -196,8 +206,6 @@ def _spec_inventory(
                     and candidate["url"].endswith(f"/issues/{issue_numbers[0]}")
                 )
                 status = "mapped" if expected else "stale"
-            if status != "mapped":
-                warnings.append(f"{relative}:{task_id}: spec-sync mapping is {status}")
             feature_tasks.append(
                 SpecTask(
                     task_id=task_id,
@@ -212,6 +220,17 @@ def _spec_inventory(
                     mapping_state=mapping_state,
                 )
             )
+        # One warning per file and status; a per-task warning buries everything else.
+        unmapped: dict[str, list[str]] = {}
+        for task in feature_tasks:
+            if task.mapping_status != "mapped":
+                unmapped.setdefault(task.mapping_status, []).append(task.task_id)
+        for status, task_ids in sorted(unmapped.items()):
+            listed = ", ".join(task_ids[:6])
+            if len(task_ids) > 6:
+                listed += f", and {len(task_ids) - 6} more"
+            warnings.append(f"{relative}: spec-sync mapping is {status} for {len(task_ids)} task(s): {listed}")
+
         tasks.extend(feature_tasks)
         statuses = {task.mapping_status for task in feature_tasks}
         mapped = sum(task.synchronized for task in feature_tasks)

--- a/lib/project_next/config.py
+++ b/lib/project_next/config.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any
 
+from .models import normalize_label
+
 
 class ConfigError(ValueError):
     """Raised when project-next configuration is invalid."""
@@ -16,12 +18,33 @@ class ConfigError(ValueError):
 class ProjectNextConfig:
     issue_limit: int = 200
     default_mode: str = "compact"
-    critical_labels: tuple[str, ...] = ("security", "blocker")
-    high_priority_labels: tuple[str, ...] = ("p0", "p1", "priority-high")
-    medium_priority_labels: tuple[str, ...] = ("p2", "priority-medium")
-    quick_win_labels: tuple[str, ...] = ("documentation", "docs", "chore", "small", "size-s")
-    planning_labels: tuple[str, ...] = ("epic", "planning", "discussion")
+    # Vocabularies are matched against normalize_label() output, so `priority:high`,
+    # `priority/high`, and `Priority High` all reach the `priority-high` entry.
+    critical_labels: tuple[str, ...] = ("security", "blocker", "critical", "urgent", "sev-1", "p0")
+    high_priority_labels: tuple[str, ...] = ("p0", "p1", "priority-high", "high-priority", "high")
+    medium_priority_labels: tuple[str, ...] = ("p2", "priority-medium", "medium-priority", "medium")
+    quick_win_labels: tuple[str, ...] = (
+        "documentation",
+        "docs",
+        "chore",
+        "small",
+        "size-s",
+        "good-first-issue",
+        "quick-win",
+        "easy",
+    )
+    planning_labels: tuple[str, ...] = ("epic", "planning", "discussion", "tracking", "meta")
     stale_after_days: int = 30
+
+    @property
+    def known_labels(self) -> frozenset[str]:
+        return frozenset(
+            self.critical_labels
+            + self.high_priority_labels
+            + self.medium_priority_labels
+            + self.quick_win_labels
+            + self.planning_labels
+        )
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ProjectNextConfig:
@@ -44,7 +67,7 @@ class ProjectNextConfig:
                 value = values[name]
                 if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
                     raise ConfigError(f"{name} must be an array of strings")
-                values[name] = tuple(item.casefold() for item in value)
+                values[name] = tuple(normalize_label(item) for item in value)
 
         issue_limit = values.get("issue_limit", cls.issue_limit)
         if not isinstance(issue_limit, int) or isinstance(issue_limit, bool) or issue_limit < 1:

--- a/lib/project_next/models.py
+++ b/lib/project_next/models.py
@@ -2,8 +2,16 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import asdict, dataclass, field
 from typing import Any
+
+LABEL_SEPARATOR = re.compile(r"[\s:/_]+")
+
+
+def normalize_label(label: str) -> str:
+    """Fold `priority:high`, `priority/high`, and `Priority High` onto one spelling."""
+    return LABEL_SEPARATOR.sub("-", str(label).strip().casefold()).strip("-")
 
 
 def _tuple_of_strings(value: Any) -> tuple[str, ...]:
@@ -48,7 +56,7 @@ class Issue:
 
     @property
     def normalized_labels(self) -> frozenset[str]:
-        return frozenset(label.casefold() for label in self.labels)
+        return frozenset(normalize_label(label) for label in self.labels)
 
 
 @dataclass(frozen=True)
@@ -85,6 +93,7 @@ class Worktree:
     path: str
     branch: str
     dirty: bool = False
+    untracked_only: bool = False
     recent_commits: tuple[str, ...] = ()
 
     @classmethod
@@ -93,6 +102,7 @@ class Worktree:
             path=str(data["path"]),
             branch=str(data.get("branch") or ""),
             dirty=bool(data.get("dirty", False)),
+            untracked_only=bool(data.get("untracked_only", False)),
             recent_commits=_tuple_of_strings(data.get("recent_commits")),
         )
 
@@ -280,6 +290,7 @@ class WorktreeDetail:
     issue_number: int | None
     issue_state: str
     dirty: bool
+    untracked_only: bool = False
     recent_commits: tuple[str, ...] = ()
     cleanup_recommended: bool = False
     cleanup_reason: str = ""

--- a/lib/project_next/rank.py
+++ b/lib/project_next/rank.py
@@ -20,7 +20,7 @@ from .models import (
     WorktreeDetail,
 )
 
-CONTRACT_VERSION = "1.2"
+CONTRACT_VERSION = "1.3"
 PHASE = re.compile(r"\b(?:wave|phase)[-\s:]*(?P<number>\d+)\b", re.IGNORECASE)
 
 
@@ -264,6 +264,16 @@ def _top_action(
             issue_number=issue_number,
         )
 
+    untracked = [worktree for worktree in state.worktrees if worktree.untracked_only]
+    if untracked:
+        worktree = min(untracked, key=lambda item: item.path)
+        return Action(
+            kind="review_untracked",
+            title=f"Review untracked files in {worktree.branch or worktree.path}",
+            reason="No issue is startable and a worktree holds untracked files that may be unfinished work.",
+            evidence=(f"worktree:{worktree.path}", "untracked_only:true"),
+        )
+
     invalid_mappings = tuple(task for task in state.spec_tasks if task.mapping_status in {"stale", "ambiguous"})
     if invalid_mappings:
         task = invalid_mappings[0]
@@ -407,6 +417,7 @@ def _worktree_report(
                 issue_number=number,
                 issue_state=issue_state,
                 dirty=worktree.dirty,
+                untracked_only=worktree.untracked_only,
                 recent_commits=worktree.recent_commits,
                 cleanup_recommended=cleanup_recommended,
                 cleanup_reason=cleanup_reason,
@@ -434,6 +445,19 @@ def _worktree_report(
     return tuple(details), tuple(cleanup)
 
 
+def _vocabulary_warnings(state: RepositoryState, config: ProjectNextConfig) -> tuple[str, ...]:
+    """Say so when ranking has no label signal, instead of presenting issue order as rank."""
+    used = {label for issue in state.issues for label in issue.normalized_labels}
+    if not used or used & config.known_labels:
+        return ()
+    sample = ", ".join(sorted(used)[:8])
+    return (
+        "no issue label matches the configured priority, quick-win, or planning vocabulary, "
+        f"so ranking falls back to issue type and age (labels in use: {sample}). "
+        "Map this repository's labels in .project-next.json to restore priority ranking.",
+    )
+
+
 def recommend(state: RepositoryState, config: ProjectNextConfig | None = None) -> RecommendationResult:
     config = config or ProjectNextConfig()
     classification = classify_repository(state)
@@ -447,7 +471,10 @@ def recommend(state: RepositoryState, config: ProjectNextConfig | None = None) -
     )
     next_startable = ranked[0] if ranked and state.inventory_complete and not state.collector_errors else None
     pending = tuple(task for task in state.spec_tasks if not task.synchronized)
-    warnings = tuple(state.collector_warnings) + tuple(state.collector_errors)
+    # Engine-level advice first: it is what the reader can act on, and collector warnings
+    # can run long enough to push it past the rendered cap.
+    warnings = _vocabulary_warnings(state, config) + tuple(state.collector_errors)
+    warnings += tuple(state.collector_warnings)
     if classification.unmapped_worktrees:
         warnings += tuple(f"unmapped worktree: {item}" for item in classification.unmapped_worktrees)
     candidates = (

--- a/lib/project_next/render.py
+++ b/lib/project_next/render.py
@@ -4,6 +4,27 @@ from __future__ import annotations
 
 from .models import Action, Candidate, RecommendationResult, RepositoryState
 
+MAX_LISTED_WARNINGS = 5
+MAX_UNCERTAINTY_REASONS = 2
+MAX_REASON_CHARS = 160
+
+
+def _capped(items: tuple[str, ...], limit: int) -> list[str]:
+    listed = [f"- {item}" for item in items[:limit]]
+    if len(items) > limit:
+        listed.append(f"- …and {len(items) - limit} more (use `--json` for the full list)")
+    return listed
+
+
+def _reasons(reasons: tuple[str, ...]) -> str:
+    shown = [
+        reason if len(reason) <= MAX_REASON_CHARS else f"{reason[:MAX_REASON_CHARS].rstrip()}…"
+        for reason in reasons[:MAX_UNCERTAINTY_REASONS]
+    ]
+    if len(reasons) > MAX_UNCERTAINTY_REASONS:
+        shown.append(f"and {len(reasons) - MAX_UNCERTAINTY_REASONS} more")
+    return "; ".join(shown)
+
 
 def _action(action: Action | None) -> str:
     if action is None:
@@ -106,12 +127,12 @@ def render_compact(result: RecommendationResult, state: RepositoryState) -> str:
     if result.classification.uncertain:
         lines.extend(("", "### Uncertain (not startable)"))
         lines.extend(
-            f"- #{number} {issues[number].title} — {'; '.join(result.classification.uncertainty[number])}"
+            f"- #{number} {issues[number].title} — {_reasons(result.classification.uncertainty[number])}"
             for number in result.classification.uncertain
         )
     if result.warnings:
         lines.extend(("", "### Warnings"))
-        lines.extend(f"- {warning}" for warning in result.warnings)
+        lines.extend(_capped(result.warnings, MAX_LISTED_WARNINGS))
     return "\n".join(lines)
 
 
@@ -198,16 +219,22 @@ def render_full(result: RecommendationResult, state: RepositoryState) -> str:
     if result.worktree_details:
         lines.extend(
             (
-                "| Path | Branch | Issue | State | Dirty | Recent commits |",
-                "|---|---|---:|---|---:|---|",
+                "| Path | Branch | Issue | State | Working tree | Recent commits |",
+                "|---|---|---:|---|---|---|",
             )
         )
         for worktree in result.worktree_details:
             issue = f"#{worktree.issue_number}" if worktree.issue_number is not None else "—"
             commits = "<br>".join(worktree.recent_commits) or "none"
+            if worktree.dirty:
+                tree = "modified"
+            elif worktree.untracked_only:
+                tree = "untracked only"
+            else:
+                tree = "clean"
             lines.append(
                 f"| {worktree.path} | {worktree.branch or '(detached)'} | {issue} | "
-                f"{worktree.issue_state} | {'yes' if worktree.dirty else 'no'} | {commits} |"
+                f"{worktree.issue_state} | {tree} | {commits} |"
             )
     else:
         lines.append("- none")

--- a/plugins/project/lib/project_next/__init__.py
+++ b/plugins/project/lib/project_next/__init__.py
@@ -3,10 +3,8 @@
 from .classify import classify_repository
 from .config import ConfigError, ProjectNextConfig, load_config
 from .models import RepositoryState
-from .rank import recommend
+from .rank import CONTRACT_VERSION, recommend
 from .render import render_result
-
-CONTRACT_VERSION = "1.2"
 
 __all__ = [
     "CONTRACT_VERSION",

--- a/plugins/project/lib/project_next/classify.py
+++ b/plugins/project/lib/project_next/classify.py
@@ -8,16 +8,36 @@ from collections import defaultdict
 from .models import Classification, Issue, PullRequest, RepositoryState
 
 ISSUE_BRANCH = re.compile(r"(?:^|/)issue-(?P<number>\d+)(?:-|$)", re.IGNORECASE)
-DEPENDENCY = re.compile(
-    r"\b(?:depends\s+on|blocked\s+by|requires|after)\s+#(?P<number>\d+)\b",
+
+# A declaration is only a dependency when a lead-in phrase is immediately followed by a
+# reference. "Strong" phrases assert a blocker outright, so a strong phrase that names no
+# machine-readable target is genuine uncertainty. "Weak" phrases are ordinary English that
+# happens to read like sequencing ("run after the release"), so they only count when a
+# reference actually follows and never raise uncertainty on their own.
+# "Blocker" and "prerequisite" are ordinary nouns, so they only count as a declaration in
+# their field-label form ("**Blockers:** #12"), never mid-sentence ("heavy blocker overlap").
+STRONG_DEPENDENCY_LEAD = re.compile(
+    r"\b(?:depends?\s+(?:on|upon)|depending\s+on|blocked\s+by)\b|\b(?:blockers?|prerequisites?)\b(?=[\s*_]*[:\-])",
     re.IGNORECASE,
 )
-DEPENDENCY_WORDS = re.compile(r"\b(?:depends\s+on|blocked\s+by|requires|after)\b", re.IGNORECASE)
+WEAK_DEPENDENCY_LEAD = re.compile(r"\b(?:requires?|required\s+by|needs|after|follows)\b", re.IGNORECASE)
+# Markdown emphasis and punctuation routinely sit between the phrase and its references,
+# as in "**Depends on:** #367" or "(depends on T004)".
+REFERENCE_CONNECTOR = re.compile(r"[\s:*_>()\[\]]*")
+ISSUE_REFERENCE = re.compile(r"#(?P<start>\d+)(?:\s*[-–—]\s*#?(?P<end>\d+))?")
+TASK_REFERENCE = re.compile(r"(?P<task>[A-Z]{1,4}(?:-[A-Z]{1,4})?\d{2,4})\b")
+REFERENCE_SEPARATOR = re.compile(r"[\s,;&/–—-]*(?:and|plus|then)?[\s]*", re.IGNORECASE)
+DANGLING_REFERENCE = re.compile(r"#(?!\d)")
+CODE_FENCE = re.compile(r"^\s*(?:```|~~~)")
+INLINE_CODE = re.compile(r"`[^`\n]*`")
+DECLARED_TASK = re.compile(r"^-\s*\[[ xX]\]\s+(?:\*\*)?(?P<id>[A-Za-z]{1,4}(?:-[A-Za-z]{1,4})?\d{1,4})(?:\*\*)?\b")
 CHECKLIST_ISSUE = re.compile(r"^-\s*\[\s\]\s+.*?#(?P<number>\d+)\b", re.IGNORECASE)
 EXPLICIT_PR_ISSUE = re.compile(
     r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|issue)\s*:?[\s#]+(?P<number>\d+)\b",
     re.IGNORECASE,
 )
+# Guards an "#367-#376" style range from expanding into an implausible span.
+MAX_REFERENCE_RANGE = 50
 
 
 def issue_number_from_branch(branch: str) -> int | None:
@@ -34,19 +54,119 @@ def pull_request_issue_numbers(pr: PullRequest) -> tuple[int, ...]:
     return tuple(sorted(numbers))
 
 
-def _dependencies(issue: Issue) -> tuple[set[int], list[str]]:
-    dependencies = {int(match.group("number")) for match in DEPENDENCY.finditer(issue.body)}
-    for line in issue.body.splitlines():
+def strip_code(text: str) -> str:
+    """Drop fenced blocks and inline spans so code never reads as dependency prose."""
+    kept: list[str] = []
+    fenced = False
+    for line in text.splitlines():
+        if CODE_FENCE.match(line):
+            fenced = not fenced
+            continue
+        kept.append("" if fenced else INLINE_CODE.sub(" ", line))
+    return "\n".join(kept)
+
+
+def _skip(pattern: re.Pattern[str], line: str, position: int) -> int:
+    match = pattern.match(line, position)
+    return match.end() if match else position
+
+
+def _reference_list(line: str, position: int) -> tuple[set[int], set[str], int]:
+    """Consume a comma/range separated run of issue and task references at `position`."""
+    issues: set[int] = set()
+    tasks: set[str] = set()
+    consumed = 0
+    while position < len(line):
+        issue_match = ISSUE_REFERENCE.match(line, position)
+        task_match = None if issue_match else TASK_REFERENCE.match(line, position)
+        if issue_match:
+            start = int(issue_match.group("start"))
+            end = int(issue_match.group("end") or start)
+            span = end - start
+            issues.update(range(start, end + 1) if 0 < span <= MAX_REFERENCE_RANGE else (start,))
+            position = issue_match.end()
+        elif task_match:
+            tasks.add(task_match.group("task").upper())
+            position = task_match.end()
+        else:
+            break
+        consumed += 1
+        position = _skip(REFERENCE_SEPARATOR, line, position)
+    return issues, tasks, consumed
+
+
+def _line_references(line: str) -> tuple[set[int], set[str], list[str]]:
+    issues: set[int] = set()
+    tasks: set[str] = set()
+    unresolved: list[str] = []
+    for pattern, strong in ((STRONG_DEPENDENCY_LEAD, True), (WEAK_DEPENDENCY_LEAD, False)):
+        for lead in pattern.finditer(line):
+            start = _skip(REFERENCE_CONNECTOR, line, lead.end())
+            found_issues, found_tasks, consumed = _reference_list(line, start)
+            issues |= found_issues
+            tasks |= found_tasks
+            if consumed or not strong:
+                continue
+            detail = "an issue reference is present but not attached to the phrase"
+            if not ISSUE_REFERENCE.search(line) and not DANGLING_REFERENCE.search(line):
+                detail = "the blocker names no issue or spec task"
+            unresolved.append(f"'{lead.group(0).strip()}' declares a dependency but {detail}: {line.strip()}")
+    return issues, tasks, unresolved
+
+
+def _dependencies(issue: Issue, task_issues: dict[str, set[int]]) -> tuple[set[int], list[str], set[str]]:
+    text = strip_code(f"{issue.title}\n{issue.body}")
+    lines = text.splitlines()
+    declared_tasks = set()
+    for line in lines:
+        match = DECLARED_TASK.match(line.strip())
+        if match:
+            declared_tasks.add(match.group("id").upper())
+
+    dependencies: set[int] = set()
+    referenced_tasks: set[str] = set()
+    uncertainty: list[str] = []
+    for line in lines:
+        found_issues, found_tasks, unresolved = _line_references(line)
+        dependencies |= found_issues
+        referenced_tasks |= found_tasks
+        uncertainty.extend(unresolved)
+
+    for line in lines:
         match = CHECKLIST_ISSUE.search(line.strip())
         if match and re.search(r"\b(?:wave|phase|epic|parent)\b", issue.title, re.IGNORECASE):
             dependencies.add(int(match.group("number")))
 
-    uncertainty: list[str] = []
-    for line in issue.body.splitlines():
-        if DEPENDENCY_WORDS.search(line) and not DEPENDENCY.search(line):
-            uncertainty.append(f"ambiguous dependency wording: {line.strip()}")
+    # Task IDs the issue defines itself describe its own internal ordering, not a blocker.
+    unresolved_tasks: set[str] = set()
+    for task in sorted(referenced_tasks - declared_tasks):
+        mapped = task_issues.get(task)
+        if mapped:
+            dependencies |= mapped
+        else:
+            unresolved_tasks.add(task)
+
     dependencies.discard(issue.number)
-    return dependencies, uncertainty
+    return dependencies, uncertainty, unresolved_tasks
+
+
+def _task_issue_index(state: RepositoryState) -> dict[str, set[int]]:
+    """Map spec task IDs onto open issues via the Issue Sync ledger, then issue titles."""
+    from_titles: dict[str, set[int]] = defaultdict(set)
+    for issue in state.issues:
+        match = TASK_REFERENCE.match(issue.title.strip())
+        if match and re.match(r"[\s:.·|—-]", issue.title.strip()[match.end() : match.end() + 1] or " "):
+            from_titles[match.group("task").upper()].add(issue.number)
+
+    index: dict[str, set[int]] = defaultdict(set)
+    # A task ID claimed by two open issues identifies nothing, so it stays unresolved.
+    for task, numbers in from_titles.items():
+        if len(numbers) == 1:
+            index[task].update(numbers)
+    for task in state.spec_tasks:
+        if task.issue_numbers and task.mapping_status not in {"stale", "ambiguous"}:
+            index[task.task_id.upper()] = set(task.issue_numbers)
+    return dict(index)
 
 
 def _cycle_members(graph: dict[int, set[int]]) -> set[int]:
@@ -115,10 +235,11 @@ def classify_repository(state: RepositoryState) -> Classification:
             if number in issue_numbers:
                 evidence[number].add(f"pr:#{pr.number}")
 
+    task_issues = _task_issue_index(state)
     dependency_map: dict[int, set[int]] = {}
     uncertainty: dict[int, list[str]] = defaultdict(list)
     for issue in state.issues:
-        dependencies, reasons = _dependencies(issue)
+        dependencies, reasons, unresolved_tasks = _dependencies(issue, task_issues)
         dependency_map[issue.number] = dependencies
         uncertainty[issue.number].extend(reasons)
         if not state.inventory_complete:
@@ -126,6 +247,12 @@ def classify_repository(state: RepositoryState) -> Classification:
             if unknown:
                 uncertainty[issue.number].append(
                     "dependency state unavailable for " + ", ".join(f"#{number}" for number in unknown)
+                )
+            # With a complete inventory an unmatched task ID means the work is not an open
+            # issue, which is the same "already satisfied" reading a closed #reference gets.
+            if unresolved_tasks:
+                uncertainty[issue.number].append(
+                    "dependency state unavailable for spec " + ", ".join(sorted(unresolved_tasks))
                 )
 
     cycles = _cycle_members(dependency_map)

--- a/plugins/project/lib/project_next/collect.py
+++ b/plugins/project/lib/project_next/collect.py
@@ -90,8 +90,18 @@ def _parse_worktrees(output: str, repository: Path, runner: CommandRunner, warni
             warnings.append(str(exc))
             status = ""
             commits = []
+        entries_changed = [line for line in status.splitlines() if line.strip()]
+        # A stray untracked file is not work in progress, so it must not outrank a real
+        # recommendation the way a tracked modification does.
+        tracked = [line for line in entries_changed if not line.startswith("??")]
         worktrees.append(
-            Worktree(path=str(path), branch=branch, dirty=bool(status.strip()), recent_commits=tuple(commits))
+            Worktree(
+                path=str(path),
+                branch=branch,
+                dirty=bool(tracked),
+                untracked_only=bool(entries_changed) and not tracked,
+                recent_commits=tuple(commits),
+            )
         )
     return tuple(worktrees)
 
@@ -196,8 +206,6 @@ def _spec_inventory(
                     and candidate["url"].endswith(f"/issues/{issue_numbers[0]}")
                 )
                 status = "mapped" if expected else "stale"
-            if status != "mapped":
-                warnings.append(f"{relative}:{task_id}: spec-sync mapping is {status}")
             feature_tasks.append(
                 SpecTask(
                     task_id=task_id,
@@ -212,6 +220,17 @@ def _spec_inventory(
                     mapping_state=mapping_state,
                 )
             )
+        # One warning per file and status; a per-task warning buries everything else.
+        unmapped: dict[str, list[str]] = {}
+        for task in feature_tasks:
+            if task.mapping_status != "mapped":
+                unmapped.setdefault(task.mapping_status, []).append(task.task_id)
+        for status, task_ids in sorted(unmapped.items()):
+            listed = ", ".join(task_ids[:6])
+            if len(task_ids) > 6:
+                listed += f", and {len(task_ids) - 6} more"
+            warnings.append(f"{relative}: spec-sync mapping is {status} for {len(task_ids)} task(s): {listed}")
+
         tasks.extend(feature_tasks)
         statuses = {task.mapping_status for task in feature_tasks}
         mapped = sum(task.synchronized for task in feature_tasks)

--- a/plugins/project/lib/project_next/config.py
+++ b/plugins/project/lib/project_next/config.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any
 
+from .models import normalize_label
+
 
 class ConfigError(ValueError):
     """Raised when project-next configuration is invalid."""
@@ -16,12 +18,33 @@ class ConfigError(ValueError):
 class ProjectNextConfig:
     issue_limit: int = 200
     default_mode: str = "compact"
-    critical_labels: tuple[str, ...] = ("security", "blocker")
-    high_priority_labels: tuple[str, ...] = ("p0", "p1", "priority-high")
-    medium_priority_labels: tuple[str, ...] = ("p2", "priority-medium")
-    quick_win_labels: tuple[str, ...] = ("documentation", "docs", "chore", "small", "size-s")
-    planning_labels: tuple[str, ...] = ("epic", "planning", "discussion")
+    # Vocabularies are matched against normalize_label() output, so `priority:high`,
+    # `priority/high`, and `Priority High` all reach the `priority-high` entry.
+    critical_labels: tuple[str, ...] = ("security", "blocker", "critical", "urgent", "sev-1", "p0")
+    high_priority_labels: tuple[str, ...] = ("p0", "p1", "priority-high", "high-priority", "high")
+    medium_priority_labels: tuple[str, ...] = ("p2", "priority-medium", "medium-priority", "medium")
+    quick_win_labels: tuple[str, ...] = (
+        "documentation",
+        "docs",
+        "chore",
+        "small",
+        "size-s",
+        "good-first-issue",
+        "quick-win",
+        "easy",
+    )
+    planning_labels: tuple[str, ...] = ("epic", "planning", "discussion", "tracking", "meta")
     stale_after_days: int = 30
+
+    @property
+    def known_labels(self) -> frozenset[str]:
+        return frozenset(
+            self.critical_labels
+            + self.high_priority_labels
+            + self.medium_priority_labels
+            + self.quick_win_labels
+            + self.planning_labels
+        )
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> ProjectNextConfig:
@@ -44,7 +67,7 @@ class ProjectNextConfig:
                 value = values[name]
                 if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
                     raise ConfigError(f"{name} must be an array of strings")
-                values[name] = tuple(item.casefold() for item in value)
+                values[name] = tuple(normalize_label(item) for item in value)
 
         issue_limit = values.get("issue_limit", cls.issue_limit)
         if not isinstance(issue_limit, int) or isinstance(issue_limit, bool) or issue_limit < 1:

--- a/plugins/project/lib/project_next/models.py
+++ b/plugins/project/lib/project_next/models.py
@@ -2,8 +2,16 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import asdict, dataclass, field
 from typing import Any
+
+LABEL_SEPARATOR = re.compile(r"[\s:/_]+")
+
+
+def normalize_label(label: str) -> str:
+    """Fold `priority:high`, `priority/high`, and `Priority High` onto one spelling."""
+    return LABEL_SEPARATOR.sub("-", str(label).strip().casefold()).strip("-")
 
 
 def _tuple_of_strings(value: Any) -> tuple[str, ...]:
@@ -48,7 +56,7 @@ class Issue:
 
     @property
     def normalized_labels(self) -> frozenset[str]:
-        return frozenset(label.casefold() for label in self.labels)
+        return frozenset(normalize_label(label) for label in self.labels)
 
 
 @dataclass(frozen=True)
@@ -85,6 +93,7 @@ class Worktree:
     path: str
     branch: str
     dirty: bool = False
+    untracked_only: bool = False
     recent_commits: tuple[str, ...] = ()
 
     @classmethod
@@ -93,6 +102,7 @@ class Worktree:
             path=str(data["path"]),
             branch=str(data.get("branch") or ""),
             dirty=bool(data.get("dirty", False)),
+            untracked_only=bool(data.get("untracked_only", False)),
             recent_commits=_tuple_of_strings(data.get("recent_commits")),
         )
 
@@ -280,6 +290,7 @@ class WorktreeDetail:
     issue_number: int | None
     issue_state: str
     dirty: bool
+    untracked_only: bool = False
     recent_commits: tuple[str, ...] = ()
     cleanup_recommended: bool = False
     cleanup_reason: str = ""

--- a/plugins/project/lib/project_next/rank.py
+++ b/plugins/project/lib/project_next/rank.py
@@ -20,7 +20,7 @@ from .models import (
     WorktreeDetail,
 )
 
-CONTRACT_VERSION = "1.2"
+CONTRACT_VERSION = "1.3"
 PHASE = re.compile(r"\b(?:wave|phase)[-\s:]*(?P<number>\d+)\b", re.IGNORECASE)
 
 
@@ -264,6 +264,16 @@ def _top_action(
             issue_number=issue_number,
         )
 
+    untracked = [worktree for worktree in state.worktrees if worktree.untracked_only]
+    if untracked:
+        worktree = min(untracked, key=lambda item: item.path)
+        return Action(
+            kind="review_untracked",
+            title=f"Review untracked files in {worktree.branch or worktree.path}",
+            reason="No issue is startable and a worktree holds untracked files that may be unfinished work.",
+            evidence=(f"worktree:{worktree.path}", "untracked_only:true"),
+        )
+
     invalid_mappings = tuple(task for task in state.spec_tasks if task.mapping_status in {"stale", "ambiguous"})
     if invalid_mappings:
         task = invalid_mappings[0]
@@ -407,6 +417,7 @@ def _worktree_report(
                 issue_number=number,
                 issue_state=issue_state,
                 dirty=worktree.dirty,
+                untracked_only=worktree.untracked_only,
                 recent_commits=worktree.recent_commits,
                 cleanup_recommended=cleanup_recommended,
                 cleanup_reason=cleanup_reason,
@@ -434,6 +445,19 @@ def _worktree_report(
     return tuple(details), tuple(cleanup)
 
 
+def _vocabulary_warnings(state: RepositoryState, config: ProjectNextConfig) -> tuple[str, ...]:
+    """Say so when ranking has no label signal, instead of presenting issue order as rank."""
+    used = {label for issue in state.issues for label in issue.normalized_labels}
+    if not used or used & config.known_labels:
+        return ()
+    sample = ", ".join(sorted(used)[:8])
+    return (
+        "no issue label matches the configured priority, quick-win, or planning vocabulary, "
+        f"so ranking falls back to issue type and age (labels in use: {sample}). "
+        "Map this repository's labels in .project-next.json to restore priority ranking.",
+    )
+
+
 def recommend(state: RepositoryState, config: ProjectNextConfig | None = None) -> RecommendationResult:
     config = config or ProjectNextConfig()
     classification = classify_repository(state)
@@ -447,7 +471,10 @@ def recommend(state: RepositoryState, config: ProjectNextConfig | None = None) -
     )
     next_startable = ranked[0] if ranked and state.inventory_complete and not state.collector_errors else None
     pending = tuple(task for task in state.spec_tasks if not task.synchronized)
-    warnings = tuple(state.collector_warnings) + tuple(state.collector_errors)
+    # Engine-level advice first: it is what the reader can act on, and collector warnings
+    # can run long enough to push it past the rendered cap.
+    warnings = _vocabulary_warnings(state, config) + tuple(state.collector_errors)
+    warnings += tuple(state.collector_warnings)
     if classification.unmapped_worktrees:
         warnings += tuple(f"unmapped worktree: {item}" for item in classification.unmapped_worktrees)
     candidates = (

--- a/plugins/project/lib/project_next/render.py
+++ b/plugins/project/lib/project_next/render.py
@@ -4,6 +4,27 @@ from __future__ import annotations
 
 from .models import Action, Candidate, RecommendationResult, RepositoryState
 
+MAX_LISTED_WARNINGS = 5
+MAX_UNCERTAINTY_REASONS = 2
+MAX_REASON_CHARS = 160
+
+
+def _capped(items: tuple[str, ...], limit: int) -> list[str]:
+    listed = [f"- {item}" for item in items[:limit]]
+    if len(items) > limit:
+        listed.append(f"- …and {len(items) - limit} more (use `--json` for the full list)")
+    return listed
+
+
+def _reasons(reasons: tuple[str, ...]) -> str:
+    shown = [
+        reason if len(reason) <= MAX_REASON_CHARS else f"{reason[:MAX_REASON_CHARS].rstrip()}…"
+        for reason in reasons[:MAX_UNCERTAINTY_REASONS]
+    ]
+    if len(reasons) > MAX_UNCERTAINTY_REASONS:
+        shown.append(f"and {len(reasons) - MAX_UNCERTAINTY_REASONS} more")
+    return "; ".join(shown)
+
 
 def _action(action: Action | None) -> str:
     if action is None:
@@ -106,12 +127,12 @@ def render_compact(result: RecommendationResult, state: RepositoryState) -> str:
     if result.classification.uncertain:
         lines.extend(("", "### Uncertain (not startable)"))
         lines.extend(
-            f"- #{number} {issues[number].title} — {'; '.join(result.classification.uncertainty[number])}"
+            f"- #{number} {issues[number].title} — {_reasons(result.classification.uncertainty[number])}"
             for number in result.classification.uncertain
         )
     if result.warnings:
         lines.extend(("", "### Warnings"))
-        lines.extend(f"- {warning}" for warning in result.warnings)
+        lines.extend(_capped(result.warnings, MAX_LISTED_WARNINGS))
     return "\n".join(lines)
 
 
@@ -198,16 +219,22 @@ def render_full(result: RecommendationResult, state: RepositoryState) -> str:
     if result.worktree_details:
         lines.extend(
             (
-                "| Path | Branch | Issue | State | Dirty | Recent commits |",
-                "|---|---|---:|---|---:|---|",
+                "| Path | Branch | Issue | State | Working tree | Recent commits |",
+                "|---|---|---:|---|---|---|",
             )
         )
         for worktree in result.worktree_details:
             issue = f"#{worktree.issue_number}" if worktree.issue_number is not None else "—"
             commits = "<br>".join(worktree.recent_commits) or "none"
+            if worktree.dirty:
+                tree = "modified"
+            elif worktree.untracked_only:
+                tree = "untracked only"
+            else:
+                tree = "clean"
             lines.append(
                 f"| {worktree.path} | {worktree.branch or '(detached)'} | {issue} | "
-                f"{worktree.issue_state} | {'yes' if worktree.dirty else 'no'} | {commits} |"
+                f"{worktree.issue_state} | {tree} | {commits} |"
             )
     else:
         lines.append("- none")

--- a/plugins/project/skills/project-next/SKILL.md
+++ b/plugins/project/skills/project-next/SKILL.md
@@ -49,12 +49,22 @@ or repository/authentication suggestion.
 - Failing checks or requested review changes on active work outrank broad new
   work.
 - Unsynchronized spec tasks are surfaced but are not treated as GitHub issues.
-- Structured JSON and brief/compact/full renderers use contract version `1.2`.
+- Structured JSON and brief/compact/full renderers use contract version `1.3`.
 - Compact output shows at most three safe candidates with structured rank evidence,
   a deterministic rationale, and a copyable `$flow-auto <issue>` command.
 - Full output adds categorized and tiered backlog state, Spec Kit readiness,
   recent worktree commits, and evidence-based cleanup candidates. Renderers only
   format engine-owned fields; they never reclassify or re-rank issues.
+- Dependencies are parsed from lead-in phrases with their punctuation and Markdown
+  intact (`**Depends on:** #12`, `Blocked by: #12, #13`, `(depends on T004)`).
+  Ordinary sequencing prose such as "run this after the release" is not a blocker,
+  and code blocks declare nothing.
 - Spec Kit synchronization is trusted only through `spec-sync:v1` Issue Sync
   ledger mappings. Missing, stale, or ambiguous mappings remain explicit
-  uncertainty and never make represented work appear safely startable.
+  uncertainty and never make represented work appear safely startable. Task IDs
+  additionally resolve dependency references through issue titles, which is not
+  synchronization evidence.
+- A warning, not a silent fallback, reports a backlog whose labels match no
+  configured ranking vocabulary; report it so the user can add `.project-next.json`.
+- Untracked files alone are never "work in progress"; only tracked modifications
+  produce `continue_work`.

--- a/templates/project-next.json.example
+++ b/templates/project-next.json.example
@@ -2,10 +2,19 @@
   "$schema": "https://github.com/cooneycw/codex-power-pack/blob/main/templates/project-next.schema.json",
   "issue_limit": 200,
   "default_mode": "compact",
-  "critical_labels": ["security", "blocker"],
-  "high_priority_labels": ["p0", "p1", "priority-high"],
-  "medium_priority_labels": ["p2", "priority-medium"],
-  "quick_win_labels": ["documentation", "docs", "chore", "small", "size-s"],
-  "planning_labels": ["epic", "planning", "discussion"],
+  "critical_labels": ["security", "blocker", "critical", "urgent", "sev-1", "p0"],
+  "high_priority_labels": ["p0", "p1", "priority-high", "high-priority", "high"],
+  "medium_priority_labels": ["p2", "priority-medium", "medium-priority", "medium"],
+  "quick_win_labels": [
+    "documentation",
+    "docs",
+    "chore",
+    "small",
+    "size-s",
+    "good-first-issue",
+    "quick-win",
+    "easy"
+  ],
+  "planning_labels": ["epic", "planning", "discussion", "tracking", "meta"],
   "stale_after_days": 30
 }

--- a/tests/project_next/fixtures/golden/brief.txt
+++ b/tests/project_next/fixtures/golden/brief.txt
@@ -1,4 +1,4 @@
-Project Next 1.2 — brief
+Project Next 1.3 — brief
 Top action: continue_pr: Build active foundation (issue #2, PR #20) — PR #20 is active and should be completed before broad new work. Evidence: head:issue-2-active-foundation, checks:pending, review:unknown.
 Next safe issue: #3 Wave 1 feature
 Inventory: complete

--- a/tests/project_next/fixtures/golden/compact.md
+++ b/tests/project_next/fixtures/golden/compact.md
@@ -1,4 +1,4 @@
-## example/operations — Project Next 1.2
+## example/operations — Project Next 1.3
 
 **Top action:** continue_pr: Build active foundation (issue #2, PR #20) — PR #20 is active and should be completed before broad new work. Evidence: head:issue-2-active-foundation, checks:pending, review:unknown.
 **Next safe issue:** #3 Wave 1 feature
@@ -22,7 +22,7 @@
 - #1 Critical security repair — blocked by #2
 
 ### Uncertain (not startable)
-- #6 Choose storage — ambiguous dependency wording: Blocked by design review
+- #6 Choose storage — 'Blocked by' declares a dependency but the blocker names no issue or spec task: Blocked by design review
 
 ### Warnings
 - unmapped worktree: /repo-issue-99 (issue-99-old-work)

--- a/tests/project_next/fixtures/golden/full.md
+++ b/tests/project_next/fixtures/golden/full.md
@@ -1,4 +1,4 @@
-## example/operations — Project Next 1.2
+## example/operations — Project Next 1.3
 
 **Top action:** continue_pr: Build active foundation (issue #2, PR #20) — PR #20 is active and should be completed before broad new work. Evidence: head:issue-2-active-foundation, checks:pending, review:unknown.
 **Next safe issue:** #3 Wave 1 feature
@@ -22,7 +22,7 @@
 - #1 Critical security repair — blocked by #2
 
 ### Uncertain (not startable)
-- #6 Choose storage — ambiguous dependency wording: Blocked by design review
+- #6 Choose storage — 'Blocked by' declares a dependency but the blocker names no issue or spec task: Blocked by design review
 
 ### Warnings
 - unmapped worktree: /repo-issue-99 (issue-99-old-work)
@@ -63,11 +63,11 @@
 - #20 Build active foundation — head issue-2-active-foundation; checks pending; review unknown; merge BLOCKED
 
 ### Worktree detail
-| Path | Branch | Issue | State | Dirty | Recent commits |
-|---|---|---:|---|---:|---|
-| /repo | main | — | default | no | aaa main commit |
-| /repo-issue-2 | issue-2-active-foundation | #2 | in-flight | yes | bbb active work<br>aaa main commit |
-| /repo-issue-99 | issue-99-old-work | #99 | no-open-issue | no | ccc old work |
+| Path | Branch | Issue | State | Working tree | Recent commits |
+|---|---|---:|---|---|---|
+| /repo | main | — | default | clean | aaa main commit |
+| /repo-issue-2 | issue-2-active-foundation | #2 | in-flight | modified | bbb active work<br>aaa main commit |
+| /repo-issue-99 | issue-99-old-work | #99 | no-open-issue | clean | ccc old work |
 
 ### Cleanup guidance
 - worktree `/repo-issue-99` (issue-99-old-work) — branch does not map to an open issue; it may be merged, closed, or abandoned. Review with $flow-cleanup.

--- a/tests/project_next/fixtures/golden/result.json
+++ b/tests/project_next/fixtures/golden/result.json
@@ -32,7 +32,7 @@
     "unmapped_worktrees": []
   },
   "cleanup_candidates": [],
-  "contract_version": "1.2",
+  "contract_version": "1.3",
   "inventory_complete": true,
   "next_startable_issue": null,
   "ranked_available": [],

--- a/tests/project_next/fixtures/scenarios.json
+++ b/tests/project_next/fixtures/scenarios.json
@@ -120,9 +120,13 @@
       "default_branch": "main",
       "collected_at": "2026-08-06T20:00:00Z",
       "issues": [
-        {"number": 158, "title": "Wave 7 Stage 1", "body": "Blocked by #157"},
-        {"number": 159, "title": "Wave 7 Stage 2", "body": "After #157"},
-        {"number": 160, "title": "Wave 7 Stage 3", "body": "Depends on #159"}
+        {
+          "number": 158,
+          "title": "Wave 7 Stage 1",
+          "body": "Re-evaluate the ten time-bounded Wave 7 skill exclusions after the v0.2.0 rollout has accumulated real usage evidence.\n\nRun after the v0.2.0 release has accumulated dogfood feedback and no later than 2026-09-30."
+        },
+        {"number": 159, "title": "Wave 7 Stage 2", "body": "**Depends on:** #157"},
+        {"number": 160, "title": "Wave 7 Stage 3", "body": "**Blocked by:** #158, #159"}
       ],
       "branches": [
         {"name": "issue-158-wave-7-stage-1", "remote": false}
@@ -144,9 +148,14 @@
       "default_branch": "main",
       "collected_at": "2026-08-06T20:00:00Z",
       "issues": [
-        {"number": 700, "title": "Phase 2 active", "labels": ["p1"]},
-        {"number": 701, "title": "Phase 1 documentation", "labels": ["documentation"]},
-        {"number": 702, "title": "Phase 3 dependent", "body": "Requires #700"}
+        {"number": 700, "title": "Phase 2 active", "labels": ["Priority: High"]},
+        {
+          "number": 701,
+          "title": "Phase 1 documentation",
+          "labels": ["documentation"],
+          "body": "Rewrite the setup guide.\n\n```python\n# this example depends on #700 but is code, not a declaration\nrender(after=700)\n```"
+        },
+        {"number": 702, "title": "Phase 3 dependent", "body": "Requires #700 before it can start."}
       ],
       "pull_requests": [
         {
@@ -280,6 +289,213 @@
       "blocked": [1],
       "available": [3, 4, 5],
       "uncertain": [6]
+    }
+  },
+  "markdown_dependency_forms": {
+    "state": {
+      "repository": "example/markdown",
+      "default_branch": "main",
+      "collected_at": "2026-08-07T13:00:00Z",
+      "issues": [
+        {
+          "number": 50,
+          "title": "T-CV14: release gate",
+          "body": "**Parent:** #40 · **Task:** T-CV14 · **Depends on:** #51, #52–#53"
+        },
+        {"number": 51, "title": "Base one", "labels": ["task"]},
+        {"number": 52, "title": "Base two", "labels": ["task"]},
+        {"number": 53, "title": "Base three", "labels": ["task"]}
+      ]
+    },
+    "expected": {
+      "top_action": "start_issue",
+      "top_issue": 51,
+      "next_startable": 51,
+      "in_flight": [],
+      "blocked": [50],
+      "available": [51, 52, 53],
+      "uncertain": []
+    }
+  },
+  "prose_is_not_a_dependency": {
+    "state": {
+      "repository": "example/prose",
+      "default_branch": "main",
+      "collected_at": "2026-08-07T13:00:00Z",
+      "issues": [
+        {
+          "number": 60,
+          "title": "Review exclusions",
+          "labels": ["task"],
+          "body": "Run this after the v0.2.0 release has accumulated feedback.\n\nThe `icm_aware` phase definition requires ante in play, and ranges with heavy blocker overlap still reconcile."
+        },
+        {
+          "number": 61,
+          "title": "Label gutter fix",
+          "labels": ["bug"],
+          "body": "From the layout audit:\n\n```python\nx=layout.left_gutter_px,  # <- starts after the label gutter\n```\n\nAfter sign-in the position is not much better."
+        }
+      ]
+    },
+    "expected": {
+      "top_action": "start_issue",
+      "top_issue": 60,
+      "next_startable": 60,
+      "in_flight": [],
+      "blocked": [],
+      "available": [60, 61],
+      "uncertain": []
+    }
+  },
+  "declared_blocker_without_a_reference": {
+    "state": {
+      "repository": "example/declared",
+      "default_branch": "main",
+      "collected_at": "2026-08-07T13:00:00Z",
+      "issues": [
+        {"number": 70, "title": "Needs a decision", "body": "**Blockers:** the design review has not happened"},
+        {"number": 71, "title": "Safe task", "labels": ["task"]}
+      ]
+    },
+    "expected": {
+      "top_action": "start_issue",
+      "top_issue": 71,
+      "next_startable": 71,
+      "in_flight": [],
+      "blocked": [],
+      "available": [71],
+      "uncertain": [70]
+    }
+  },
+  "spec_task_dependencies": {
+    "state": {
+      "repository": "cooneycw/poker-measure",
+      "default_branch": "main",
+      "collected_at": "2026-08-07T13:00:00Z",
+      "issues": [
+        {"number": 13, "title": "Canonical corpus schema (depends on T004)", "labels": ["task"]},
+        {
+          "number": 14,
+          "title": "Repository-owned parser (depends on T008)",
+          "labels": ["task"],
+          "body": "- [ ] **T009** Port card parsing (depends on T008)\n- [ ] **T010** Port header parsing (depends on T009)\n- [ ] **T011** Map results (depends on T010)\n\nAfter synchronization, update the Issue Sync ledger for `wave-3`."
+        },
+        {"number": 15, "title": "Unrelated cleanup", "labels": ["chore"]}
+      ],
+      "branches": [{"name": "issue-13-canonical-corpus-schema", "remote": false}],
+      "spec_tasks": [
+        {
+          "task_id": "T008",
+          "title": "PostgreSQL tests",
+          "feature": "ingestion",
+          "source": ".specify/specs/ingestion/tasks.md",
+          "issue_numbers": [13],
+          "synchronized": true,
+          "mapping_status": "mapped"
+        },
+        {
+          "task_id": "T009",
+          "title": "Port card parsing",
+          "feature": "ingestion",
+          "source": ".specify/specs/ingestion/tasks.md",
+          "issue_numbers": [14],
+          "synchronized": true,
+          "mapping_status": "mapped"
+        }
+      ]
+    },
+    "expected": {
+      "top_action": "continue_work",
+      "top_issue": 13,
+      "next_startable": 15,
+      "in_flight": [13],
+      "blocked": [14],
+      "available": [15],
+      "uncertain": []
+    }
+  },
+  "task_ids_resolved_from_issue_titles": {
+    "state": {
+      "repository": "cooneycw/agentic-poker",
+      "default_branch": "main",
+      "collected_at": "2026-08-07T13:00:00Z",
+      "issues": [
+        {"number": 368, "title": "T-CV03: store versioned absolute EV", "labels": ["enhancement"]},
+        {
+          "number": 371,
+          "title": "T-CV06: show realized and benchmark-best EV",
+          "labels": ["enhancement"],
+          "body": "**Parent:** #365 · **Depends on:** T-CV03 · **Coordinates with:** #314"
+        }
+      ]
+    },
+    "expected": {
+      "top_action": "start_issue",
+      "top_issue": 368,
+      "next_startable": 368,
+      "in_flight": [],
+      "blocked": [371],
+      "available": [368],
+      "uncertain": []
+    }
+  },
+  "unlabeled_backlog": {
+    "state": {
+      "repository": "cooneycw/agentic-poker",
+      "default_branch": "main",
+      "collected_at": "2026-08-07T13:00:00Z",
+      "issues": [
+        {"number": 264, "title": "Zero values take a direction", "labels": ["bug", "information-design"]},
+        {"number": 334, "title": "Diverging bars name no unit", "labels": ["enhancement", "postflop-solver"]}
+      ]
+    },
+    "expected": {
+      "top_action": "start_issue",
+      "top_issue": 264,
+      "next_startable": 264,
+      "in_flight": [],
+      "blocked": [],
+      "available": [264, 334],
+      "uncertain": []
+    }
+  },
+  "untracked_only_worktree": {
+    "state": {
+      "repository": "example/untracked",
+      "default_branch": "main",
+      "collected_at": "2026-08-07T13:00:00Z",
+      "issues": [{"number": 90, "title": "Ready work", "labels": ["task"]}],
+      "worktrees": [
+        {"path": "/repo", "branch": "main", "dirty": false, "untracked_only": true}
+      ]
+    },
+    "expected": {
+      "top_action": "start_issue",
+      "top_issue": 90,
+      "next_startable": 90,
+      "in_flight": [],
+      "blocked": [],
+      "available": [90],
+      "uncertain": []
+    }
+  },
+  "untracked_only_with_no_startable_work": {
+    "state": {
+      "repository": "example/untracked-idle",
+      "default_branch": "main",
+      "collected_at": "2026-08-07T13:00:00Z",
+      "worktrees": [
+        {"path": "/repo", "branch": "main", "dirty": false, "untracked_only": true}
+      ]
+    },
+    "expected": {
+      "top_action": "review_untracked",
+      "top_issue": null,
+      "next_startable": null,
+      "in_flight": [],
+      "blocked": [],
+      "available": [],
+      "uncertain": []
     }
   }
 }

--- a/tests/project_next/test_classification.py
+++ b/tests/project_next/test_classification.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 
 from lib.project_next.classify import classify_repository
-from lib.project_next.models import RepositoryState
+from lib.project_next.models import Issue, RepositoryState
 
 
 @pytest.mark.parametrize(
@@ -16,6 +16,12 @@ from lib.project_next.models import RepositoryState
         "dependency_cycle",
         "ambiguous_dependency",
         "incomplete_inventory",
+        "markdown_dependency_forms",
+        "prose_is_not_a_dependency",
+        "declared_blocker_without_a_reference",
+        "spec_task_dependencies",
+        "task_ids_resolved_from_issue_titles",
+        "unlabeled_backlog",
     ],
 )
 def test_fixture_classification_is_exact(project_next_scenarios: dict[str, Any], name: str) -> None:
@@ -46,3 +52,80 @@ def test_cycles_are_blocked_not_startable(project_next_scenarios: dict[str, Any]
 
     assert result.blocked_by == {20: (21,), 21: (20,)}
     assert result.available == ()
+
+
+def test_markdown_and_range_dependency_forms_are_parsed(project_next_scenarios: dict[str, Any]) -> None:
+    state = RepositoryState.from_dict(project_next_scenarios["markdown_dependency_forms"]["state"])
+    result = classify_repository(state)
+
+    assert result.dependency_map[50] == (51, 52, 53)
+
+
+def test_prose_sequencing_never_creates_uncertainty(project_next_scenarios: dict[str, Any]) -> None:
+    state = RepositoryState.from_dict(project_next_scenarios["prose_is_not_a_dependency"]["state"])
+    result = classify_repository(state)
+
+    assert result.uncertainty == {}
+    assert result.dependency_map == {60: (), 61: ()}
+
+
+def test_declared_blocker_without_a_reference_stays_uncertain(project_next_scenarios: dict[str, Any]) -> None:
+    state = RepositoryState.from_dict(project_next_scenarios["declared_blocker_without_a_reference"]["state"])
+    result = classify_repository(state)
+
+    assert "names no issue or spec task" in result.uncertainty[70][0]
+
+
+def test_spec_task_dependencies_resolve_through_the_issue_sync_ledger(
+    project_next_scenarios: dict[str, Any],
+) -> None:
+    state = RepositoryState.from_dict(project_next_scenarios["spec_task_dependencies"]["state"])
+    result = classify_repository(state)
+
+    assert result.dependency_map[14] == (13,)
+    assert result.uncertainty == {}
+
+
+def test_task_ids_resolve_from_issue_titles_when_no_ledger_exists(
+    project_next_scenarios: dict[str, Any],
+) -> None:
+    state = RepositoryState.from_dict(project_next_scenarios["task_ids_resolved_from_issue_titles"]["state"])
+    result = classify_repository(state)
+
+    assert result.dependency_map[371] == (368,)
+
+
+def test_unresolved_task_reference_is_satisfied_when_the_inventory_is_complete() -> None:
+    state = RepositoryState(
+        repository="example/repo",
+        default_branch="main",
+        collected_at="2026-08-07T13:00:00Z",
+        issues=(Issue(1, "Consumer", body="**Depends on:** T-CV01"),),
+    )
+
+    result = classify_repository(state)
+
+    assert result.available == (1,)
+    assert result.uncertainty == {}
+
+
+def test_unresolved_task_reference_is_uncertain_when_the_inventory_is_incomplete() -> None:
+    state = RepositoryState(
+        repository="example/repo",
+        default_branch="main",
+        collected_at="2026-08-07T13:00:00Z",
+        inventory_complete=False,
+        issues=(Issue(1, "Consumer", body="**Depends on:** T-CV01"),),
+    )
+
+    result = classify_repository(state)
+
+    assert result.uncertain == (1,)
+    assert "T-CV01" in result.uncertainty[1][0]
+
+
+def test_code_blocks_never_declare_dependencies(project_next_scenarios: dict[str, Any]) -> None:
+    state = RepositoryState.from_dict(project_next_scenarios["claude_power_pack_dogfood"]["state"])
+    result = classify_repository(state)
+
+    assert result.dependency_map[701] == ()

--- a/tests/project_next/test_dogfood.py
+++ b/tests/project_next/test_dogfood.py
@@ -30,3 +30,43 @@ def test_no_non_available_issue_leaks_into_startable_selection(project_next_scen
             assert result.next_startable_issue in result.classification.available
         if result.top_action is not None and result.top_action.kind == "start_issue":
             assert result.top_action.issue_number in result.classification.available
+
+
+def test_a_backlog_with_no_blockers_always_yields_a_ready_recommendation(
+    project_next_scenarios: dict[str, Any],
+) -> None:
+    """The enrichment work shipped reports that were shaped correctly but empty in practice."""
+    unblocked = ("prose_is_not_a_dependency", "unlabeled_backlog", "markdown_dependency_forms")
+    for name in unblocked:
+        state = RepositoryState.from_dict(project_next_scenarios[name]["state"])
+        result = recommend(state)
+
+        assert result.classification.available, f"{name} classified every open issue as unstartable"
+        assert result.next_startable_issue is not None, f"{name} produced no startable recommendation"
+        assert result.candidates, f"{name} rendered no ranked candidates"
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "markdown_dependency_forms",
+        "prose_is_not_a_dependency",
+        "declared_blocker_without_a_reference",
+        "spec_task_dependencies",
+        "task_ids_resolved_from_issue_titles",
+        "unlabeled_backlog",
+        "untracked_only_worktree",
+        "untracked_only_with_no_startable_work",
+    ],
+)
+def test_real_world_scenarios_select_expected_actions(project_next_scenarios: dict[str, Any], name: str) -> None:
+    scenario = project_next_scenarios[name]
+    result = recommend(RepositoryState.from_dict(scenario["state"]))
+    expected = scenario["expected"]
+
+    assert (result.top_action.kind if result.top_action else None) == expected["top_action"]
+    assert (result.top_action.issue_number if result.top_action else None) == expected["top_issue"]
+    assert result.next_startable_issue == expected["next_startable"]
+    assert list(result.classification.blocked) == expected["blocked"]
+    assert list(result.classification.available) == expected["available"]
+    assert list(result.classification.uncertain) == expected["uncertain"]

--- a/tests/project_next/test_output_contract.py
+++ b/tests/project_next/test_output_contract.py
@@ -18,7 +18,7 @@ def test_all_human_modes_are_versioned_and_separate_both_decisions(project_next_
 
     for mode in ("brief", "compact", "full"):
         rendered = render_result(result, state, mode)
-        assert "1.2" in rendered
+        assert "1.3" in rendered
         assert "Top action" in rendered
         assert "Next safe issue" in rendered
         assert "#1" in rendered
@@ -29,7 +29,7 @@ def test_structured_output_is_versioned_and_json_serializable(project_next_scena
     state = RepositoryState.from_dict(project_next_scenarios["active_pr_and_safe_issue"]["state"])
     payload = recommend(state).to_dict()
 
-    assert CONTRACT_VERSION == "1.2"
+    assert CONTRACT_VERSION == "1.3"
     assert payload["contract_version"] == CONTRACT_VERSION
     assert payload["top_action"]["issue_number"] == 1
     assert payload["next_startable_issue"] == 2

--- a/tests/project_next/test_ranking.py
+++ b/tests/project_next/test_ranking.py
@@ -146,3 +146,76 @@ def test_dirty_unmapped_worktree_cleanup_requires_inspection() -> None:
     candidate = recommend(state).cleanup_candidates[0]
 
     assert candidate.action == "Inspect uncommitted changes; do not remove automatically"
+
+
+def test_unmatched_label_vocabulary_is_reported_instead_of_passing_issue_order_as_rank(
+    project_next_scenarios: dict[str, Any],
+) -> None:
+    state = RepositoryState.from_dict(project_next_scenarios["unlabeled_backlog"]["state"])
+
+    result = recommend(state)
+
+    assert result.warnings[0].startswith("no issue label matches the configured")
+    assert ".project-next.json" in result.warnings[0]
+
+
+def test_recognised_label_vocabulary_raises_no_warning(project_next_scenarios: dict[str, Any]) -> None:
+    state = RepositoryState.from_dict(project_next_scenarios["operational_report"]["state"])
+
+    assert not any(warning.startswith("no issue label matches") for warning in recommend(state).warnings)
+
+
+def test_label_separators_are_normalized_before_matching() -> None:
+    state = RepositoryState(
+        repository="example/labels",
+        default_branch="main",
+        collected_at="2026-08-07T13:00:00Z",
+        issues=(
+            Issue(1, "Spelled with a colon", labels=("Priority: High",)),
+            Issue(2, "Spelled with a slash", labels=("priority/medium",)),
+        ),
+    )
+
+    result = recommend(state)
+
+    assert result.ranked_available == (1, 2)
+    assert result.candidates[0].priority == "high (priority-high)"
+
+
+def test_untracked_files_alone_never_outrank_a_startable_issue(
+    project_next_scenarios: dict[str, Any],
+) -> None:
+    state = RepositoryState.from_dict(project_next_scenarios["untracked_only_worktree"]["state"])
+
+    result = recommend(state)
+
+    assert result.top_action is not None
+    assert result.top_action.kind == "start_issue"
+    assert result.top_action.issue_number == 90
+
+
+def test_untracked_files_surface_once_nothing_else_is_actionable(
+    project_next_scenarios: dict[str, Any],
+) -> None:
+    state = RepositoryState.from_dict(project_next_scenarios["untracked_only_with_no_startable_work"]["state"])
+
+    result = recommend(state)
+
+    assert result.top_action is not None
+    assert result.top_action.kind == "review_untracked"
+    assert result.worktree_details[0].untracked_only is True
+
+
+def test_tracked_modifications_still_outrank_new_work() -> None:
+    state = RepositoryState(
+        repository="example/dirty",
+        default_branch="main",
+        collected_at="2026-08-07T13:00:00Z",
+        issues=(Issue(90, "Ready work", labels=("task",)),),
+        worktrees=(Worktree("/repo", "main", dirty=True),),
+    )
+
+    result = recommend(state)
+
+    assert result.top_action is not None
+    assert result.top_action.kind == "continue_work"

--- a/tests/test_project_next_skill.py
+++ b/tests/test_project_next_skill.py
@@ -23,7 +23,7 @@ def test_project_next_delegates_selection_to_the_deterministic_runtime() -> None
         "next_startable_issue",
         "Only `available` issues can be named as safe to start.",
         "In-flight, blocked, cyclic, and uncertain issues remain non-startable.",
-        "contract version `1.2`",
+        "contract version `1.3`",
         "scripts/project-next.py",
     )
 


### PR DESCRIPTION
## Problem

The #180 enrichment improved the renderer, but the engine underneath produced almost no signal on real repositories — so the reports got longer without getting more informative. Run against the live repos, the recommendation was either empty or issue-number order wearing rank-evidence clothing:

| repo | open | blocked | uncertain | ready to start |
|---|---|---|---|---|
| codex-power-pack | 1 | 0 | 1 | **None** |
| poker-measure | 8 | 0 | 7 | **None** |
| agentic-poker | 46 | 0 | 16 | 3, in issue-number order |

Three causes.

**1. Dependency parsing missed every convention actually in use.** The regex only matched the bare `depends on #12` form. Real bodies write `**Depends on:** #367`, `Blocked by: #12`, `(depends on T004)`. Those lines still tripped the looser word check — which also fired on the ordinary English word "after" — so declared dependencies never became blockers *and* the issues declaring them were dropped into `uncertain`. CxPP #173 was unstartable because its body says "after the v0.2.0 rollout"; agentic-poker #333 was flagged on a code comment reading `# <- starts after the label gutter`.

**2. The rank vocabulary matched none of these repos' labels.** Defaults expect `p0`/`p1`/`security`; agentic-poker uses `enhancement`, `postflop-solver`, `information-design`, `solver-s6`. With no overlap the rank tuple collapsed to (type, age, issue number) while the report presented three identical evidence strings as if they were rank evidence.

**3. `continue_work` fired on any `git status` output.** One untracked `lib/cicd/uv.lock` made "Continue main" the headline of every report.

## Changes

- **`classify.py`** — parse the lead-in phrase with its punctuation and Markdown intact; accept comma/`and`/range-separated reference runs; strip fenced and inline code first. Grade the phrases: strong verbs (`depends on`, `blocked by`, field-label `Blockers:`) without a resolvable target stay uncertain, weak sequencing (`after`, `requires`, `needs`) declares nothing on its own. Resolve spec task IDs through the `spec-sync:v1` ledger, then through issue titles; a task ID an issue defines itself is internal ordering, not a blocker. An unresolved task ID with a complete inventory reads as satisfied, exactly as a closed `#reference` already did.
- **`config.py` / `models.py`** — match labels after separator normalization (`priority:high` ≡ `priority/high` ≡ `priority-high`), broaden the defaults, and warn — naming the labels actually in use — when nothing matches, instead of silently presenting issue order as a ranking.
- **`collect.py` / `rank.py`** — `continue_work` requires tracked modifications; untracked-only worktrees are recorded as `untracked_only` and surface as `review_untracked` only after every real recommendation is exhausted.
- **`render.py` / `collect.py`** — cap rendered warnings (5) and per-issue uncertainty (2 reasons, truncated), group spec-sync warnings per file, and sort engine advice ahead of collector output. `--json` keeps the complete lists.
- **`__init__.py`** — `CONTRACT_VERSION` was duplicated and had drifted; it now derives from `rank.py`.

## Effect on the live repositories

| repo | before | after |
|---|---|---|
| poker-measure | 0 blocked, 7 uncertain, no recommendation | 7 blocked with correct chains behind in-flight #13 |
| agentic-poker | 0 blocked, 16 uncertain | 8 blocked, 0 uncertain |
| codex-power-pack | "Ready to start: None", 36 warning lines | #173 startable, 1 warning line |

## Why the acceptance checks passed the first time

The `codex_power_pack_dogfood` fixture — the one meant to prove real-world behavior — had been written to fit the parser: three-word bodies (`"Blocked by #157"`, `"After #157"`) in the single form the regex could match, with `p0`/`p1`/`security` labels no repo of ours uses, and `uncertain: []`. Every #180 acceptance criterion was about output *shape*, so all of them held while the tool returned nothing.

Fixtures now carry the real forms — markdown dependencies, task-ID dependencies, prose "after", fenced code, unlabeled backlogs, untracked-only worktrees — and a new test asserts that a backlog with no blockers always yields a non-empty ready list.

## Contract

Bumped to `1.3`, additive only: adds `untracked_only` to worktree state/details and the `review_untracked` action kind. Consumers that ignore unknown fields and action kinds read `1.3` unchanged. Docs, both SKILL.md copies, and `templates/project-next.json.example` updated; `lib/` and `plugins/project/lib/` re-synced.

`make verify` passes: 576 tests, mypy over 170 files, lint, harness lint, contract lint, skill evals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)